### PR TITLE
fix(extractor): include implicit instance deps in ChallengeDeps

### DIFF
--- a/EvalTools/ExtractTheorem.lean
+++ b/EvalTools/ExtractTheorem.lean
@@ -14,6 +14,11 @@ structure ExtractedTheorem where
   declarationName : String
   module : String
   sourceRange : SourceRange
+  /-- Names of declarations from the same module that appear (transitively) in the
+  type or value of this theorem. Computed from the elaborated terms, so this captures
+  uses introduced by typeclass synthesis (which the `.ilean` references metadata
+  records as textual matches only). -/
+  sameModuleDependencies : Array String
   deriving ToJson
 
 def parseName (text : String) : Name :=
@@ -50,6 +55,26 @@ def resolveDeclName (env : Environment) (moduleName declName : Name) : IO Name :
       return candidate
   findDeclByBasename env moduleName declName
 
+/-- Compute the set of names of declarations in `moduleName` that are reachable from
+the type or value of `start`, following the same-module subgraph of the constant
+dependency relation. The starting declaration itself is excluded from the result. -/
+def collectSameModuleDependencies (env : Environment) (moduleName start : Name) :
+    Array Name := Id.run do
+  let some moduleIdx := env.getModuleIdx? moduleName | return #[]
+  let mut closure : NameSet := {}
+  let mut stack : Array Name := #[start]
+  while !stack.isEmpty do
+    let current := stack.back!
+    stack := stack.pop
+    if closure.contains current then continue
+    closure := closure.insert current
+    let some info := env.find? current | continue
+    for c in info.getUsedConstantsAsSet do
+      if env.getModuleIdxFor? c == some moduleIdx
+          && c != current && !closure.contains c then
+        stack := stack.push c
+  return (closure.erase start).toArray
+
 def extractTheorem (moduleNameText declNameText : String) : IO ExtractedTheorem := do
   let moduleName := parseName moduleNameText
   let declName := parseName declNameText
@@ -69,10 +94,12 @@ def extractTheorem (moduleNameText declNameText : String) : IO ExtractedTheorem 
   }
   match constantInfo with
   | .thmInfo _ | .opaqueInfo _ =>
+      let deps := collectSameModuleDependencies env moduleName resolvedDeclName
       return {
         declarationName := toString resolvedDeclName
         module := moduleNameText
         sourceRange := sourceRange
+        sameModuleDependencies := deps.map toString
       }
   | _ =>
       throw <| IO.userError s!"Declaration '{resolvedDeclName}' is not a theorem or opaque theorem."

--- a/scripts/generate_projects.py
+++ b/scripts/generate_projects.py
@@ -66,6 +66,7 @@ class ExtractedTheorem:
     declaration_name: str
     module: str
     source_range: tuple[int, int, int, int]
+    same_module_dependencies: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -264,6 +265,9 @@ def extract_theorem(problem: ProblemSpec) -> ExtractedTheorem:
                 int(payload["sourceRange"]["endLine"]),
                 int(payload["sourceRange"]["endColumn"]),
             ),
+            same_module_dependencies=tuple(
+                str(name) for name in payload.get("sameModuleDependencies", [])
+            ),
         )
     except KeyError as exc:
         raise GenerationError(
@@ -440,44 +444,6 @@ def load_ilean_metadata(module_name: str) -> dict:
         raise GenerationError(f"Invalid JSON in compiled metadata for module '{module_name}': {exc}") from exc
 
 
-def same_module_dependency_closure(module_name: str, declaration_name: str) -> set[str]:
-    metadata = load_ilean_metadata(module_name)
-    graph: dict[str, set[str]] = {}
-    for raw_key, value in metadata.get("references", {}).items():
-        try:
-            parsed_key = json.loads(raw_key)
-            constant = parsed_key["c"]
-            referenced_module = str(constant["m"])
-            referenced_name = str(constant["n"])
-        except (json.JSONDecodeError, KeyError, TypeError) as exc:
-            raise GenerationError(
-                f"Unexpected reference metadata shape in {ilean_path(module_name)}"
-            ) from exc
-
-        if referenced_module != module_name:
-            continue
-        usages = value.get("usages")
-        if not isinstance(usages, list):
-            continue
-        for usage in usages:
-            if not isinstance(usage, list) or len(usage) < 5:
-                continue
-            user_name = str(usage[4])
-            if user_name == referenced_name:
-                continue
-            graph.setdefault(user_name, set()).add(referenced_name)
-
-    closure: set[str] = set()
-    stack = list(graph.get(declaration_name, set()))
-    while stack:
-        dependency = stack.pop()
-        if dependency in closure:
-            continue
-        closure.add(dependency)
-        stack.extend(graph.get(dependency, set()))
-    return closure
-
-
 def find_top_level_end_offset(source_text: str, start: int) -> int:
     match = re.search(r"(?m)^end(?:\s+\S+)?\s*$", source_text[start:])
     if match is None:
@@ -493,7 +459,7 @@ def render_challenge_deps(problem: ProblemSpec, extracted: ExtractedTheorem) -> 
     source_text = source_path.read_text(encoding="utf-8")
     body_start = import_prelude_length(source_text)
     metadata = load_ilean_metadata(problem.module)
-    keep_declarations = same_module_dependency_closure(problem.module, extracted.declaration_name)
+    keep_declarations = set(extracted.same_module_dependencies)
     if not keep_declarations:
         return None
     all_declarations = {

--- a/tests/test_generate_projects.py
+++ b/tests/test_generate_projects.py
@@ -107,6 +107,7 @@ submitter = "Kim"
             declaration_name="FormalMathEval.two_plus_two_eq_four",
             module=problem.module,
             source_range=(13, 0, 15, 7),
+            same_module_dependencies=(),
         )
         statement = gp.extract_statement_text(problem, extracted)
         self.assertEqual(statement, ": (2 : Nat) + 2 = 4")
@@ -124,6 +125,7 @@ submitter = "Kim"
             declaration_name="FormalMathEval.two_plus_two_eq_four",
             module=problem.module,
             source_range=(13, 0, 15, 7),
+            same_module_dependencies=(),
         )
         dependency = gp.DependencySpec(
             name="mathlib",

--- a/tests/test_run_eval.py
+++ b/tests/test_run_eval.py
@@ -36,6 +36,7 @@ class RunEvalTests(unittest.TestCase):
             declaration_name="Demo.demo_theorem",
             module=problem.module,
             source_range=(1, 0, 2, 9),
+            same_module_dependencies=(),
         )
         toolchain = "leanprover/lean4:v4.30.0-rc1\n"
 
@@ -254,6 +255,7 @@ rev = "{dependency.rev}"
             declaration_name="Demo.demo_theorem",
             module=problem.module,
             source_range=(1, 0, 2, 9),
+            same_module_dependencies=(),
         )
         toolchain = "leanprover/lean4:v4.30.0-rc1\n"
         dependency = gp.DependencySpec(


### PR DESCRIPTION
## Summary

The `ChallengeDeps.lean` file in each generated workspace was being computed by walking the `.ilean` `references` field, which records only **textual** uses of constants (with source line/column ranges). Helpers pulled in by typeclass synthesis from the elaborated theorem statement were silently omitted, producing a `Challenge.lean` that fails to elaborate with "failed to synthesize instance".

This change replaces the `.ilean`-based closure with a Lean-side closure computed via `ConstantInfo.getUsedConstantsAsSet` on the resolved theorem and its transitively reachable helpers. The `extract_theorem` binary emits the resulting list in a new `sameModuleDependencies` JSON field; the Python generator consumes it directly.

## Reproducer

When the eval source defines a helper `instance` and the theorem uses it implicitly (no textual mention):

```lean
noncomputable instance lieModuleToEnvelopingModule (R L M : Type*) [...] :
    Module (UniversalEnvelopingAlgebra R L) M := ...

theorem foo : ... := by  -- statement uses isotypicComponents which needs the above instance
  sorry
```

Pre-fix: generated `Challenge.lean` lacks the instance → `failed to synthesize instance Module ...`. Post-fix: instance is included in `ChallengeDeps.lean` and elaboration succeeds.

## Notes

- Lean autogenerates `_proof_*` declarations for `def`s; these end up in `sameModuleDependencies` too, but they have no source positions in `decls`, so the existing source-cutting logic in `render_challenge_deps` ignores them harmlessly.
- The old `same_module_dependency_closure` Python helper is removed.
- Tested against the implicit-instance case (now works) and against an already-merged eval with no helpers (`mulCayley_connected_iff_closure_eq_top` — generates a workspace with no `ChallengeDeps.lean`, as before).

## Test plan
- [x] `lake build extract_theorem` succeeds
- [x] Implicit-instance reproducer (the eval problem in #14): with `letI` removed and a standalone `instance`, the workspace generates and builds clean
- [x] Existing eval without helpers (`mulCayley_connected_iff_closure_eq_top`) still generates correctly with no `ChallengeDeps.lean`

🤖 Prepared with Claude Code