### PR TITLE
Add Gleason's theorem (finite-dim and separable Hilbert space)

### DIFF
--- a/LeanEval/Analysis/Gleason.lean
+++ b/LeanEval/Analysis/Gleason.lean
@@ -1,0 +1,98 @@
+import Mathlib.Analysis.InnerProductSpace.Positive
+import Mathlib.Analysis.InnerProductSpace.l2Space
+import Mathlib.LinearAlgebra.Trace
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+Gleason's theorem (1957).
+
+Let `H` be a complex Hilbert space of dimension at least `3`. Every non-negative function
+on the orthogonal projections of `H` that is countably additive on orthogonal families and
+sends the identity to `1` is given by `P ↦ Tr(ρ P)` for a unique density operator `ρ`
+(positive trace-class operator with trace `1`).
+
+This file states two versions:
+
+1. `gleason_theorem_finite`: `H` is finite-dimensional. The trace-class condition is
+   automatic, additivity on orthogonal pairs already implies countable additivity, and
+   the conclusion uses the standard finite trace `LinearMap.trace`.
+
+2. `gleason_theorem_separable`: `H` is separable. Stated in Gleason's original "frame
+   function on the unit sphere" form: a non-negative function on the unit sphere that
+   sums to `1` along every Hilbert basis is given by `x ↦ re ⟨x, ρ x⟩` for some positive
+   bounded operator `ρ`. (The Lean conclusion does not assert that `ρ` is trace-class
+   with `Tr ρ = 1`; stating that would require trace-class infrastructure not yet at
+   this Mathlib pin. It is recoverable by combining the conclusion with `f.basis_sum`.)
+-/
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+
+/-- An orthogonal projection on `H`: a self-adjoint idempotent continuous linear map. -/
+def IsOrthProj (P : H →L[ℂ] H) : Prop :=
+  IsIdempotentElem P ∧ IsSelfAdjoint P
+
+/-- A frame function on the projection lattice: non-negative on orthogonal projections,
+finitely additive on orthogonal pairs, and `μ I = 1`. (In finite dimensions any countable
+orthogonal family is finite, so finite additivity already yields countable additivity.) -/
+structure FrameFunction (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+    [CompleteSpace H] where
+  μ : (H →L[ℂ] H) → ℝ
+  nonneg : ∀ P : H →L[ℂ] H, IsOrthProj P → 0 ≤ μ P
+  additive : ∀ P Q : H →L[ℂ] H, IsOrthProj P → IsOrthProj Q → P * Q = 0 →
+    μ (P + Q) = μ P + μ Q
+  normalized : μ (1 : H →L[ℂ] H) = 1
+
+/-- The real part of the complex trace of a continuous linear operator on a
+finite-dimensional complex inner product space. -/
+noncomputable def reTr [FiniteDimensional ℂ H] (A : H →L[ℂ] H) : ℝ :=
+  (LinearMap.trace ℂ H A.toLinearMap).re
+
+/-- **Gleason's theorem**, finite-dimensional version. For `dim H ≥ 3`, every frame
+function on the projection lattice of `H` is given by `P ↦ re Tr(ρ P)` for the unique
+density operator `ρ` (positive, `re Tr ρ = 1`). -/
+@[eval_problem]
+theorem gleason_theorem_finite
+    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [FiniteDimensional ℂ H]
+    (hdim : 3 ≤ Module.finrank ℂ H)
+    (f : FrameFunction H) :
+    ∃! ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      reTr ρ = 1 ∧
+      ∀ P : H →L[ℂ] H, IsOrthProj P → f.μ P = reTr (ρ * P) := by
+  sorry
+
+/-- A frame function on the unit sphere of `H` (Gleason's original 1957 definition).
+A non-negative function on unit vectors whose values sum to `1` along every Hilbert
+basis. -/
+structure SphereFrameFunction (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+    [CompleteSpace H] where
+  f : Metric.sphere (0 : H) 1 → ℝ
+  nonneg : ∀ x : Metric.sphere (0 : H) 1, 0 ≤ f x
+  basis_sum : ∀ {ι : Type*} (b : HilbertBasis ι ℂ H),
+    HasSum
+      (fun i : ι => f ⟨b i, mem_sphere_zero_iff_norm.mpr (b.orthonormal.norm_eq_one i)⟩)
+      1
+
+/-- **Gleason's theorem**, separable Hilbert space version (Gleason's original 1957
+formulation). For a separable complex Hilbert space `H` of dimension at least `3`, every
+frame function on the unit sphere of `H` is given by `x ↦ re ⟨x, ρ x⟩` for some positive
+bounded operator `ρ`. (The Lean conclusion does not separately assert trace-class /
+`Tr ρ = 1`; see the file docstring.) -/
+@[eval_problem]
+theorem gleason_theorem_separable
+    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [TopologicalSpace.SeparableSpace H]
+    (hdim : 3 ≤ Module.rank ℂ H)
+    (f : SphereFrameFunction H) :
+    ∃ ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      ∀ x : Metric.sphere (0 : H) 1,
+        f.f x = (inner ℂ (x : H) (ρ (x : H))).re := by
+  sorry
+
+end Analysis
+end LeanEval

--- a/generated/gleason_theorem_finite/Challenge.lean
+++ b/generated/gleason_theorem_finite/Challenge.lean
@@ -1,0 +1,13 @@
+import ChallengeDeps
+
+open LeanEval.Analysis
+
+theorem gleason_theorem_finite {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [FiniteDimensional ℂ H]
+    (hdim : 3 ≤ Module.finrank ℂ H)
+    (f : FrameFunction H) :
+    ∃! ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      reTr ρ = 1 ∧
+      ∀ P : H →L[ℂ] H, IsOrthProj P → f.μ P = reTr (ρ * P) := by
+  sorry

--- a/generated/gleason_theorem_finite/ChallengeDeps.lean
+++ b/generated/gleason_theorem_finite/ChallengeDeps.lean
@@ -1,0 +1,53 @@
+import Mathlib
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+Gleason's theorem (1957).
+
+Let `H` be a complex Hilbert space of dimension at least `3`. Every non-negative function
+on the orthogonal projections of `H` that is countably additive on orthogonal families and
+sends the identity to `1` is given by `P ↦ Tr(ρ P)` for a unique density operator `ρ`
+(positive trace-class operator with trace `1`).
+
+This file states two versions:
+
+1. `gleason_theorem_finite`: `H` is finite-dimensional. The trace-class condition is
+   automatic, additivity on orthogonal pairs already implies countable additivity, and
+   the conclusion uses the standard finite trace `LinearMap.trace`.
+
+2. `gleason_theorem_separable`: `H` is separable. Stated in Gleason's original "frame
+   function on the unit sphere" form: a non-negative function on the unit sphere that
+   sums to `1` along every Hilbert basis is given by `x ↦ re ⟨x, ρ x⟩` for some positive
+   bounded operator `ρ`. (The Lean conclusion does not assert that `ρ` is trace-class
+   with `Tr ρ = 1`; stating that would require trace-class infrastructure not yet at
+   this Mathlib pin. It is recoverable by combining the conclusion with `f.basis_sum`.)
+-/
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+
+/-- An orthogonal projection on `H`: a self-adjoint idempotent continuous linear map. -/
+def IsOrthProj (P : H →L[ℂ] H) : Prop :=
+  IsIdempotentElem P ∧ IsSelfAdjoint P
+
+/-- A frame function on the projection lattice: non-negative on orthogonal projections,
+finitely additive on orthogonal pairs, and `μ I = 1`. (In finite dimensions any countable
+orthogonal family is finite, so finite additivity already yields countable additivity.) -/
+structure FrameFunction (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+    [CompleteSpace H] where
+  μ : (H →L[ℂ] H) → ℝ
+  nonneg : ∀ P : H →L[ℂ] H, IsOrthProj P → 0 ≤ μ P
+  additive : ∀ P Q : H →L[ℂ] H, IsOrthProj P → IsOrthProj Q → P * Q = 0 →
+    μ (P + Q) = μ P + μ Q
+  normalized : μ (1 : H →L[ℂ] H) = 1
+
+/-- The real part of the complex trace of a continuous linear operator on a
+finite-dimensional complex inner product space. -/
+noncomputable def reTr [FiniteDimensional ℂ H] (A : H →L[ℂ] H) : ℝ :=
+  (LinearMap.trace ℂ H A.toLinearMap).re
+
+
+
+end Analysis
+end LeanEval

--- a/generated/gleason_theorem_finite/README.md
+++ b/generated/gleason_theorem_finite/README.md
@@ -1,0 +1,25 @@
+# `gleason_theorem_finite`
+
+Gleason's theorem (finite-dimensional)
+
+- Problem ID: `gleason_theorem_finite`
+- Test Problem: no
+- Submitter: Kim Morrison
+- Notes: Gleason's theorem in finite dimensions: every frame function on the orthogonal projections of a complex Hilbert space of dimension at least 3 is given by P ↦ Tr(ρ P) for the unique density operator ρ. Stated using a bespoke `FrameFunction` structure (non-negative, additive on orthogonal projection pairs, normalized at the identity) and the standard Mathlib trace `LinearMap.trace`. Finite additivity on orthogonal pairs already implies countable additivity in finite dimensions, so the hypothesis matches Gleason's original σ-additive frame functions.
+- Source: A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893.
+- Informal solution: Gleason's original proof analyses regular frame functions on the unit sphere of R^3 by showing they are continuous and then quadratic, then promotes the resulting positive quadratic form on every 3-dimensional real subspace of H to a positive operator ρ on H whose diagonal in any orthonormal basis recovers the frame function, with Tr(ρ) = μ(I) = 1 ensuring ρ is a density operator.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+Write your solution in `Submission.lean` and any additional local modules under
+`Submission/`.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+Multi-file submissions are allowed through `Submission.lean` and additional local
+modules under `Submission/`.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/gleason_theorem_finite/Solution.lean
+++ b/generated/gleason_theorem_finite/Solution.lean
@@ -1,0 +1,14 @@
+import ChallengeDeps
+import Submission
+
+open LeanEval.Analysis
+
+theorem gleason_theorem_finite {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [FiniteDimensional ℂ H]
+    (hdim : 3 ≤ Module.finrank ℂ H)
+    (f : FrameFunction H) :
+    ∃! ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      reTr ρ = 1 ∧
+      ∀ P : H →L[ℂ] H, IsOrthProj P → f.μ P = reTr (ρ * P) := by
+  exact Submission.gleason_theorem_finite hdim f

--- a/generated/gleason_theorem_finite/Submission.lean
+++ b/generated/gleason_theorem_finite/Submission.lean
@@ -1,0 +1,18 @@
+import ChallengeDeps
+import Submission.Helpers
+
+open LeanEval.Analysis
+
+namespace Submission
+
+theorem gleason_theorem_finite {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [FiniteDimensional ℂ H]
+    (hdim : 3 ≤ Module.finrank ℂ H)
+    (f : FrameFunction H) :
+    ∃! ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      reTr ρ = 1 ∧
+      ∀ P : H →L[ℂ] H, IsOrthProj P → f.μ P = reTr (ρ * P) := by
+  sorry
+
+end Submission

--- a/generated/gleason_theorem_finite/Submission/Helpers.lean
+++ b/generated/gleason_theorem_finite/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/gleason_theorem_finite/WorkspaceTest.lean
+++ b/generated/gleason_theorem_finite/WorkspaceTest.lean
@@ -1,0 +1,38 @@
+import Lean
+
+open Lean
+
+def comparatorExists (comparatorBin : String) : IO Bool := do
+  if comparatorBin.contains '/' then
+    return (← System.FilePath.pathExists comparatorBin)
+  try
+    let child ← IO.Process.spawn {
+      cmd := "sh"
+      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", comparatorBin]
+    }
+    let exitCode ← child.wait
+    return exitCode == 0
+  catch _ =>
+    return false
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  if !(← comparatorExists comparatorBin) then
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    pure 1
+  else
+    try
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, "config.json"]
+      }
+      let exitCode ← child.wait
+      pure exitCode
+    catch err =>
+      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+      IO.eprintln s!"Original error: {err}"
+      pure 1

--- a/generated/gleason_theorem_finite/config.json
+++ b/generated/gleason_theorem_finite/config.json
@@ -1,0 +1,13 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "gleason_theorem_finite"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false
+}

--- a/generated/gleason_theorem_finite/lakefile.toml
+++ b/generated/gleason_theorem_finite/lakefile.toml
@@ -1,0 +1,27 @@
+name = "gleason_theorem_finite"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "ChallengeDeps"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/gleason_theorem_finite/lean-toolchain
+++ b/generated/gleason_theorem_finite/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/generated/gleason_theorem_separable/Challenge.lean
+++ b/generated/gleason_theorem_separable/Challenge.lean
@@ -1,0 +1,13 @@
+import ChallengeDeps
+
+open LeanEval.Analysis
+
+theorem gleason_theorem_separable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [TopologicalSpace.SeparableSpace H]
+    (hdim : 3 ≤ Module.rank ℂ H)
+    (f : SphereFrameFunction H) :
+    ∃ ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      ∀ x : Metric.sphere (0 : H) 1,
+        f.f x = (inner ℂ (x : H) (ρ (x : H))).re := by
+  sorry

--- a/generated/gleason_theorem_separable/ChallengeDeps.lean
+++ b/generated/gleason_theorem_separable/ChallengeDeps.lean
@@ -1,0 +1,45 @@
+import Mathlib
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+Gleason's theorem (1957).
+
+Let `H` be a complex Hilbert space of dimension at least `3`. Every non-negative function
+on the orthogonal projections of `H` that is countably additive on orthogonal families and
+sends the identity to `1` is given by `P ↦ Tr(ρ P)` for a unique density operator `ρ`
+(positive trace-class operator with trace `1`).
+
+This file states two versions:
+
+1. `gleason_theorem_finite`: `H` is finite-dimensional. The trace-class condition is
+   automatic, additivity on orthogonal pairs already implies countable additivity, and
+   the conclusion uses the standard finite trace `LinearMap.trace`.
+
+2. `gleason_theorem_separable`: `H` is separable. Stated in Gleason's original "frame
+   function on the unit sphere" form: a non-negative function on the unit sphere that
+   sums to `1` along every Hilbert basis is given by `x ↦ re ⟨x, ρ x⟩` for some positive
+   bounded operator `ρ`. (The Lean conclusion does not assert that `ρ` is trace-class
+   with `Tr ρ = 1`; stating that would require trace-class infrastructure not yet at
+   this Mathlib pin. It is recoverable by combining the conclusion with `f.basis_sum`.)
+-/
+
+variable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
+
+/-- A frame function on the unit sphere of `H` (Gleason's original 1957 definition).
+A non-negative function on unit vectors whose values sum to `1` along every Hilbert
+basis. -/
+structure SphereFrameFunction (H : Type*) [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+    [CompleteSpace H] where
+  f : Metric.sphere (0 : H) 1 → ℝ
+  nonneg : ∀ x : Metric.sphere (0 : H) 1, 0 ≤ f x
+  basis_sum : ∀ {ι : Type*} (b : HilbertBasis ι ℂ H),
+    HasSum
+      (fun i : ι => f ⟨b i, mem_sphere_zero_iff_norm.mpr (b.orthonormal.norm_eq_one i)⟩)
+      1
+
+
+
+end Analysis
+end LeanEval

--- a/generated/gleason_theorem_separable/README.md
+++ b/generated/gleason_theorem_separable/README.md
@@ -1,0 +1,25 @@
+# `gleason_theorem_separable`
+
+Gleason's theorem (separable Hilbert space)
+
+- Problem ID: `gleason_theorem_separable`
+- Test Problem: no
+- Submitter: Kim Morrison
+- Notes: Gleason's theorem for a separable complex Hilbert space H of dimension at least 3, in Gleason's original `frame function on the unit sphere' formulation: any non-negative function on the unit sphere whose values sum to 1 along every Hilbert basis is given by x ↦ re ⟨x, ρ x⟩ for some positive bounded operator ρ. The Lean conclusion does not assert that ρ is trace-class with Tr(ρ) = 1; stating that would require trace-class infrastructure not yet at this Mathlib pin. This side-steps the absence of Schatten 1 / trace-class infrastructure in Mathlib at the time of writing.
+- Source: A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893.
+- Informal solution: Reduce to the real 3-dimensional case via restriction to real subspaces of H, where Gleason's continuity argument plus an analysis of regular frame functions on S^2 gives a positive quadratic form. Patch these forms together using rotation-invariance and the assumed basis-sum normalization to obtain a globally defined positive bounded operator ρ on H reproducing the frame function on every unit vector.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+Write your solution in `Submission.lean` and any additional local modules under
+`Submission/`.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+Multi-file submissions are allowed through `Submission.lean` and additional local
+modules under `Submission/`.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/gleason_theorem_separable/Solution.lean
+++ b/generated/gleason_theorem_separable/Solution.lean
@@ -1,0 +1,14 @@
+import ChallengeDeps
+import Submission
+
+open LeanEval.Analysis
+
+theorem gleason_theorem_separable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [TopologicalSpace.SeparableSpace H]
+    (hdim : 3 ≤ Module.rank ℂ H)
+    (f : SphereFrameFunction H) :
+    ∃ ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      ∀ x : Metric.sphere (0 : H) 1,
+        f.f x = (inner ℂ (x : H) (ρ (x : H))).re := by
+  exact Submission.gleason_theorem_separable hdim f

--- a/generated/gleason_theorem_separable/Submission.lean
+++ b/generated/gleason_theorem_separable/Submission.lean
@@ -1,0 +1,18 @@
+import ChallengeDeps
+import Submission.Helpers
+
+open LeanEval.Analysis
+
+namespace Submission
+
+theorem gleason_theorem_separable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
+      [CompleteSpace H] [TopologicalSpace.SeparableSpace H]
+    (hdim : 3 ≤ Module.rank ℂ H)
+    (f : SphereFrameFunction H) :
+    ∃ ρ : H →L[ℂ] H,
+      ContinuousLinearMap.IsPositive ρ ∧
+      ∀ x : Metric.sphere (0 : H) 1,
+        f.f x = (inner ℂ (x : H) (ρ (x : H))).re := by
+  sorry
+
+end Submission

--- a/generated/gleason_theorem_separable/Submission/Helpers.lean
+++ b/generated/gleason_theorem_separable/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/gleason_theorem_separable/WorkspaceTest.lean
+++ b/generated/gleason_theorem_separable/WorkspaceTest.lean
@@ -1,0 +1,38 @@
+import Lean
+
+open Lean
+
+def comparatorExists (comparatorBin : String) : IO Bool := do
+  if comparatorBin.contains '/' then
+    return (← System.FilePath.pathExists comparatorBin)
+  try
+    let child ← IO.Process.spawn {
+      cmd := "sh"
+      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", comparatorBin]
+    }
+    let exitCode ← child.wait
+    return exitCode == 0
+  catch _ =>
+    return false
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  if !(← comparatorExists comparatorBin) then
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    pure 1
+  else
+    try
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, "config.json"]
+      }
+      let exitCode ← child.wait
+      pure exitCode
+    catch err =>
+      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+      IO.eprintln s!"Original error: {err}"
+      pure 1

--- a/generated/gleason_theorem_separable/config.json
+++ b/generated/gleason_theorem_separable/config.json
@@ -1,0 +1,13 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "gleason_theorem_separable"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false
+}

--- a/generated/gleason_theorem_separable/lakefile.toml
+++ b/generated/gleason_theorem_separable/lakefile.toml
@@ -1,0 +1,27 @@
+name = "gleason_theorem_separable"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "ChallengeDeps"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/gleason_theorem_separable/lean-toolchain
+++ b/generated/gleason_theorem_separable/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/generated/index.json
+++ b/generated/index.json
@@ -259,5 +259,23 @@
     "module": "LeanEval.NumberTheory.SmallHouse",
     "theorem": "cyclotomic_integer_house_between_two_and_76_33",
     "generated_path": "generated/cyclotomic_integer_house_between_two_and_76_33"
+  },
+  {
+    "id": "gleason_theorem_finite",
+    "title": "Gleason's theorem (finite-dimensional)",
+    "test": false,
+    "submitter": "Kim Morrison",
+    "module": "LeanEval.Analysis.Gleason",
+    "theorem": "gleason_theorem_finite",
+    "generated_path": "generated/gleason_theorem_finite"
+  },
+  {
+    "id": "gleason_theorem_separable",
+    "title": "Gleason's theorem (separable Hilbert space)",
+    "test": false,
+    "submitter": "Kim Morrison",
+    "module": "LeanEval.Analysis.Gleason",
+    "theorem": "gleason_theorem_separable",
+    "generated_path": "generated/gleason_theorem_separable"
   }
 ]

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -318,3 +318,25 @@ submitter = "Kim Morrison"
 notes = "The 2 < house < 76/33 branch of Theorem 1.0.5 from Calegari--Morrison--Snyder, stated using Mathlib's NumberField.house."
 source = "https://arxiv.org/pdf/1004.0665"
 informal_solution = "If the house lies in (2, 76/33), then it is one of the five explicitly listed values."
+
+[[problem]]
+id = "gleason_theorem_finite"
+title = "Gleason's theorem (finite-dimensional)"
+test = false
+module = "LeanEval.Analysis.Gleason"
+theorem = "gleason_theorem_finite"
+submitter = "Kim Morrison"
+notes = "Gleason's theorem in finite dimensions: every frame function on the orthogonal projections of a complex Hilbert space of dimension at least 3 is given by P ↦ Tr(ρ P) for the unique density operator ρ. Stated using a bespoke `FrameFunction` structure (non-negative, additive on orthogonal projection pairs, normalized at the identity) and the standard Mathlib trace `LinearMap.trace`. Finite additivity on orthogonal pairs already implies countable additivity in finite dimensions, so the hypothesis matches Gleason's original σ-additive frame functions."
+source = "A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893."
+informal_solution = "Gleason's original proof analyses regular frame functions on the unit sphere of R^3 by showing they are continuous and then quadratic, then promotes the resulting positive quadratic form on every 3-dimensional real subspace of H to a positive operator ρ on H whose diagonal in any orthonormal basis recovers the frame function, with Tr(ρ) = μ(I) = 1 ensuring ρ is a density operator."
+
+[[problem]]
+id = "gleason_theorem_separable"
+title = "Gleason's theorem (separable Hilbert space)"
+test = false
+module = "LeanEval.Analysis.Gleason"
+theorem = "gleason_theorem_separable"
+submitter = "Kim Morrison"
+notes = "Gleason's theorem for a separable complex Hilbert space H of dimension at least 3, in Gleason's original `frame function on the unit sphere' formulation: any non-negative function on the unit sphere whose values sum to 1 along every Hilbert basis is given by x ↦ re ⟨x, ρ x⟩ for some positive bounded operator ρ. The Lean conclusion does not assert that ρ is trace-class with Tr(ρ) = 1; stating that would require trace-class infrastructure not yet at this Mathlib pin. This side-steps the absence of Schatten 1 / trace-class infrastructure in Mathlib at the time of writing."
+source = "A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893."
+informal_solution = "Reduce to the real 3-dimensional case via restriction to real subspaces of H, where Gleason's continuity argument plus an analysis of regular frame functions on S^2 gives a positive quadratic form. Patch these forms together using rotation-invariance and the assumed basis-sum normalization to obtain a globally defined positive bounded operator ρ on H reproducing the frame function on every unit vector."


### PR DESCRIPTION
This PR adds two statements of Gleason's 1957 theorem on measures on the closed subspaces of a Hilbert space, in `LeanEval/Analysis/Gleason.lean`.

- **`gleason_theorem_finite`** — finite-dimensional `H` with `dim ≥ 3`. Every frame function on the projection lattice of `H` is given by `P ↦ Tr(ρ P)` for the unique density operator `ρ` (stated as `∃!`). Uses a small bespoke `FrameFunction` structure (non-negative, additive on orthogonal pairs, normalized at the identity) and Mathlib's `LinearMap.trace`. Finite additivity on orthogonal pairs already implies countable additivity in finite dimensions, so the hypothesis matches Gleason's original σ-additive frame functions.

- **`gleason_theorem_separable`** — separable complex Hilbert space `H` with `dim ≥ 3`. Stated in Gleason's original "frame function on the unit sphere" form: a non-negative function on the unit sphere whose values sum to `1` along every Hilbert basis is given by `x ↦ re ⟨x, ρ x⟩` for some positive bounded `ρ`. The Lean conclusion does not assert that `ρ` is trace-class with `Tr ρ = 1`; stating that would require trace-class infrastructure not yet at this Mathlib pin. It is recoverable by combining the conclusion with `f.basis_sum`. This sidesteps the absence of Schatten-1 / trace-class infrastructure in Mathlib at the current pin.

🤖 Prepared with Claude Code
