### PR TITLE
Make submission pipeline robust to fork-and-solve-a-few

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -167,13 +167,21 @@ jobs:
           tar -xzf /tmp/submission-artifact/source.tar.gz -C /tmp/submission-src --strip-components=1
 
       - name: Run evaluate_submission.py
+        # Sharing the host repo's .lake/packages tree across every
+        # per-submission workspace lets each `lake update` reuse Mathlib
+        # (~3GB unpacked) instead of cloning + decompressing it per
+        # workspace. Required to handle submissions that overlay several
+        # generated workspaces on a single runner without "no space left
+        # on device". Assumes generated workspaces stay in lock-step with
+        # the benchmark repo on dependency revs (they do, by construction).
         run: |
           python scripts/evaluate_submission.py \
             --source-dir /tmp/submission-src \
             --generated-root generated \
             --manifest manifests/problems.toml \
             --output-dir /tmp/evaluate-out \
-            --repo-root "$PWD"
+            --repo-root "$PWD" \
+            --shared-packages "$PWD/.lake/packages"
 
       - name: Copy frozen metadata through to record
         if: always()

--- a/EvalTools/Main.lean
+++ b/EvalTools/Main.lean
@@ -158,7 +158,7 @@ def checkGeneratedBuildsCmd : Cmd := `[Cli|
   "Build generated workspaces to catch breakage in emitted projects."
 
   FLAGS:
-    problem : Array String; "Restrict the build check to the given problem id. Can be passed multiple times."
+    problem : Array String; "Restrict the build check to the given problem id. Pass repeatedly or as `--problem id1,id2`."
 ]
 
 def startProblemCmd : Cmd := `[Cli|
@@ -181,7 +181,7 @@ def runEvalCmd : Cmd := `[Cli|
 
   FLAGS:
     manifest : String;               "Path to the problem manifest."
-    problem : Array String;          "Restrict scoring to the given problem id. Can be passed multiple times."
+    problem : Array String;          "Restrict scoring to the given problem id. Pass repeatedly or as `--problem id1,id2`."
     json;                            "Emit machine-readable JSON output."
     "workspaces-root" : String;      "Directory containing local problem workspaces. Defaults to `./workspaces`."
 ]
@@ -193,7 +193,7 @@ def validateSubmissionCmd : Cmd := `[Cli|
   FLAGS:
     base : String;        "Base git ref for changed-file validation."
     head : String;        "Head git ref for changed-file validation."
-    file : Array String;  "Explicit changed file path. Can be passed multiple times."
+    file : Array String;  "Explicit changed file path. Pass repeatedly or as `--file path1,path2`."
     json;                 "Emit machine-readable JSON output."
 ]
 
@@ -221,7 +221,31 @@ def leanEvalCmd : Cmd := `[Cli|
     author "OpenAI Codex"
 ]
 
-def runMain (args : List String) : IO UInt32 :=
+/--
+Coalesce repeated `--<name> v1 --<name> v2 ...` occurrences into a single
+`--<name> v1,v2,...` occurrence. lean4-cli's `Array String` flag instance
+parses one occurrence as a comma-separated list and rejects the second
+occurrence with `Duplicate flag`. Pre-processing here lets users also pass
+the flag the natural way (matching argparse, gh, etc.).
+-/
+def coalesceRepeatedFlag (args : List String) (name : String) : List String := Id.run do
+  let argsArr := args.toArray
+  let mut collected : Array String := #[]
+  let mut kept : Array String := #[]
+  let mut i := 0
+  while i < argsArr.size do
+    if argsArr[i]! == name && i + 1 < argsArr.size then
+      collected := collected.push argsArr[i + 1]!
+      i := i + 2
+    else
+      kept := kept.push argsArr[i]!
+      i := i + 1
+  if collected.size ≤ 1 then return args
+  return kept.toList ++ [name, ",".intercalate collected.toList]
+
+def runMain (args : List String) : IO UInt32 := do
+  let args := coalesceRepeatedFlag args "--problem"
+  let args := coalesceRepeatedFlag args "--file"
   leanEvalCmd.validate args
 
 end EvalTools

--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -101,15 +101,36 @@ def _read_lakefile_name(path: pathlib.Path) -> str | None:
     return name
 
 
+def _pristine_submission_bytes(
+    generated_root: pathlib.Path | None,
+    problem_id: str,
+) -> bytes | None:
+    if generated_root is None:
+        return None
+    pristine = generated_root / problem_id / "Submission.lean"
+    try:
+        return pristine.read_bytes()
+    except (FileNotFoundError, IsADirectoryError):
+        return None
+
+
 def detect_matches(
     source_dir: pathlib.Path,
     manifest_ids: set[str],
+    *,
+    generated_root: pathlib.Path | None = None,
 ) -> list[WorkspaceMatch]:
     """Walk source_dir for lakefile.toml files whose name matches a manifest problem id.
 
     A match is only valid if the containing directory also has a
     Submission.lean sibling. Duplicate problem ids across distinct
     directories are a hard failure.
+
+    If `generated_root` is provided, candidates whose Submission.lean is
+    byte-identical to `generated_root/<id>/Submission.lean` are marked with
+    a skip_reason. This avoids overlaying / priming / scoring problems that
+    the submitter never attempted (the common case for a fork that carries
+    every generated workspace but only solves a few).
     """
     candidates: list[WorkspaceMatch] = []
     for lakefile in _iter_lakefile_toml(source_dir):
@@ -129,6 +150,21 @@ def detect_matches(
                 )
             )
             continue
+        pristine_bytes = _pristine_submission_bytes(generated_root, name)
+        if pristine_bytes is not None and not submission_lean.is_symlink():
+            try:
+                submitted_bytes = submission_lean.read_bytes()
+            except OSError:
+                submitted_bytes = None
+            if submitted_bytes is not None and submitted_bytes == pristine_bytes:
+                candidates.append(
+                    WorkspaceMatch(
+                        problem_id=name,
+                        source_dir=containing,
+                        skip_reason="Submission.lean unchanged from pristine; nothing to score",
+                    )
+                )
+                continue
         candidates.append(WorkspaceMatch(problem_id=name, source_dir=containing))
 
     seen_by_id: dict[str, list[WorkspaceMatch]] = {}
@@ -309,6 +345,17 @@ def overlay_match(
       - overlaid_files: list[str]
       - shared_packages: bool | str (True if symlinked, else reason it was not)
     """
+    if match.skip_reason is not None:
+        # Bail before any tree copy or package-share work — this match is
+        # already known to be unactionable (e.g. submitter never modified
+        # Submission.lean from the pristine version).
+        return {
+            "problem_id": match.problem_id,
+            "overlaid": False,
+            "skip_reason": match.skip_reason,
+            "overlaid_files": [],
+            "shared_packages": False,
+        }
     target = workspaces_root / match.problem_id
     if target.exists():
         shutil.rmtree(target)
@@ -327,15 +374,6 @@ def overlay_match(
     if shared_packages is not None:
         reason = _share_packages(target, shared_packages)
         shared_state = True if reason is None else reason
-
-    if match.skip_reason is not None:
-        return {
-            "problem_id": match.problem_id,
-            "overlaid": False,
-            "skip_reason": match.skip_reason,
-            "overlaid_files": [],
-            "shared_packages": shared_state,
-        }
 
     # 1. Overlay Submission.lean
     source_submission_lean = match.source_dir / "Submission.lean"
@@ -411,8 +449,12 @@ def _run_run_eval(
         "--workspaces-root",
         str(workspaces_root),
     ]
-    for pid in problem_ids:
-        args.extend(["--problem", pid])
+    if problem_ids:
+        # lean4-cli's `Array String` flag wants one occurrence with
+        # comma-separated values; passing `--problem` repeatedly trips a
+        # `Duplicate flag` parse error. Problem ids are TOML identifiers,
+        # so commas never appear inside an id.
+        args.extend(["--problem", ",".join(problem_ids)])
     process = subprocess.Popen(
         args,
         cwd=repo_root,
@@ -506,7 +548,7 @@ def evaluate_submission(
     re-unpacking Mathlib for each.
     """
     manifest_ids = _load_manifest_ids(manifest_path)
-    matches = detect_matches(source_dir, manifest_ids)
+    matches = detect_matches(source_dir, manifest_ids, generated_root=generated_root)
 
     overlay_records: list[dict] = []
     # Create the tempdir as an immediate child of repo_root so that:
@@ -535,10 +577,22 @@ def evaluate_submission(
                 overlaid_ids.append(record["problem_id"])
 
         if not overlaid_ids:
+            pristine_skipped = sum(
+                1 for r in overlay_records
+                if r["skip_reason"] and "unchanged from pristine" in r["skip_reason"]
+            )
+            extra = ""
+            if pristine_skipped:
+                extra = (
+                    f" Found {pristine_skipped} workspace(s) whose Submission.lean "
+                    "was unchanged from the pristine version; edit Submission.lean "
+                    "(and any helpers under Submission/) with your proof."
+                )
             raise EvaluateError(
                 "No valid workspace matches found in the submission. "
                 "A candidate is a directory containing a `lakefile.toml` with a `name` "
                 "matching a benchmark problem id AND a non-empty `Submission.lean` sibling."
+                + extra
             )
 
         if run_eval_runner is None:

--- a/tests/test_evaluate_submission.py
+++ b/tests/test_evaluate_submission.py
@@ -172,6 +172,51 @@ class DetectMatchesTests(unittest.TestCase):
             with self.assertRaisesRegex(ev.EvaluateError, "escapes"):
                 list(ev._iter_lakefile_toml(src))
 
+    def test_pristine_equal_submission_lean_is_skipped(self) -> None:
+        # The fork-everything-solve-a-few case: submitter's Submission.lean is
+        # byte-identical to the pristine in generated/<id>/. detect_matches
+        # must mark these with a skip_reason so we don't waste prime/build
+        # cycles on workspaces the submitter never attempted.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            generated = tmp_path / "generated"
+            _write_pristine(generated, "two_plus_two")
+            src = tmp_path / "src"
+            _write_submitter_workspace(
+                src, ".", "two_plus_two",
+                submission_lean_contents="sorry\n",
+            )
+            matches = ev.detect_matches(
+                src, {"two_plus_two"}, generated_root=generated,
+            )
+        self.assertEqual(len(matches), 1)
+        self.assertIn("unchanged from pristine", matches[0].skip_reason or "")
+
+    def test_modified_submission_lean_is_not_skipped_as_pristine(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            generated = tmp_path / "generated"
+            _write_pristine(generated, "two_plus_two")
+            src = tmp_path / "src"
+            _write_submitter_workspace(src, ".", "two_plus_two")
+            matches = ev.detect_matches(
+                src, {"two_plus_two"}, generated_root=generated,
+            )
+        self.assertEqual(len(matches), 1)
+        self.assertIsNone(matches[0].skip_reason)
+
+    def test_pristine_check_off_when_no_generated_root(self) -> None:
+        # Backward compat: callers that don't pass generated_root must still
+        # see byte-identical Submission.lean as a real candidate, not a skip.
+        with tempfile.TemporaryDirectory() as tmp:
+            src = pathlib.Path(tmp) / "src"
+            _write_submitter_workspace(
+                src, ".", "two_plus_two", submission_lean_contents="sorry\n",
+            )
+            matches = ev.detect_matches(src, {"two_plus_two"})
+        self.assertEqual(len(matches), 1)
+        self.assertIsNone(matches[0].skip_reason)
+
 
 class OverlayMatchTests(unittest.TestCase):
     def test_overlay_copies_submission_lean_and_subdir(self) -> None:
@@ -352,6 +397,76 @@ class EvaluateSubmissionEndToEndTests(unittest.TestCase):
             )
         self.assertEqual(result["results"]["passed"], ["two_plus_two"])
 
+    def test_fork_everything_solve_a_few(self) -> None:
+        # Mirrors the real submission case from issue #20: a fork that
+        # carries every generated workspace but only solves a subset.
+        # Pristine workspaces must be detected and skipped; only the
+        # actually-attempted workspaces should reach the run-eval call.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            generated, manifest = self._setup_repo_like(tmp_path)
+            problem_ids = ["alpha", "beta", "gamma", "delta", "epsilon"]
+            for pid in problem_ids:
+                _write_pristine(generated, pid)
+            _write_manifest(manifest, problem_ids)
+            src = tmp_path / "src"
+            for pid in problem_ids:
+                # All five workspaces present in the fork.
+                _write_submitter_workspace(
+                    src, pid, pid,
+                    submission_lean_contents="sorry\n",
+                )
+            # Only beta and delta have real submissions.
+            (src / "beta" / "Submission.lean").write_text(
+                "by exact submitter.proof\n", encoding="utf-8"
+            )
+            (src / "delta" / "Submission.lean").write_text(
+                "by exact submitter.proof\n", encoding="utf-8"
+            )
+            output = tmp_path / "out"
+
+            seen_problem_ids: list[list[str]] = []
+
+            def runner(*, problem_ids: list[str], workspaces_root: pathlib.Path) -> dict:
+                seen_problem_ids.append(list(problem_ids))
+                return _fake_runner_factory(["beta"])(
+                    problem_ids=problem_ids, workspaces_root=workspaces_root
+                )
+
+            result = ev.evaluate_submission(
+                source_dir=src,
+                generated_root=generated,
+                manifest_path=manifest,
+                output_dir=output,
+                repo_root=tmp_path,
+                run_eval_runner=runner,
+            )
+        self.assertEqual(len(seen_problem_ids), 1)
+        self.assertEqual(sorted(seen_problem_ids[0]), ["beta", "delta"])
+        self.assertEqual(result["results"]["passed"], ["beta"])
+
+    def test_fork_with_no_real_submissions_explains_pristine_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            generated, manifest = self._setup_repo_like(tmp_path)
+            _write_pristine(generated, "two_plus_two")
+            _write_manifest(manifest, ["two_plus_two"])
+            src = tmp_path / "src"
+            _write_submitter_workspace(
+                src, ".", "two_plus_two",
+                submission_lean_contents="sorry\n",
+            )
+            output = tmp_path / "out"
+            with self.assertRaisesRegex(ev.EvaluateError, "unchanged from the pristine"):
+                ev.evaluate_submission(
+                    source_dir=src,
+                    generated_root=generated,
+                    manifest_path=manifest,
+                    output_dir=output,
+                    repo_root=tmp_path,
+                    run_eval_runner=_fake_runner_factory([]),
+                )
+
     def test_no_matches_is_hard_fail(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = pathlib.Path(tmp)
@@ -399,6 +514,51 @@ class RunEvalInvocationTests(unittest.TestCase):
         _, kwargs = popen.call_args
         self.assertIs(kwargs["stderr"], None)
         self.assertEqual(kwargs["stdout"], ev.subprocess.PIPE)
+
+    def test_run_eval_passes_problem_ids_as_single_comma_separated_flag(self) -> None:
+        # lean4-cli's `Array String` flag instance does NOT support
+        # `--problem foo --problem bar` (it raises `Duplicate flag`). It
+        # parses one occurrence as a comma-separated list. _run_run_eval
+        # must produce the comma-separated form so the Lean side accepts
+        # multi-problem evaluations.
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.returncode = 0
+
+            def communicate(self) -> tuple[str, None]:
+                return ('{"problems": []}', None)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = pathlib.Path(tmp)
+            with mock.patch.object(ev.subprocess, "Popen", return_value=FakeProcess()) as popen:
+                ev._run_run_eval(
+                    problem_ids=["foo", "bar", "baz"],
+                    workspaces_root=repo_root / "workspaces",
+                    repo_root=repo_root,
+                )
+        argv = popen.call_args[0][0]
+        problem_indices = [i for i, a in enumerate(argv) if a == "--problem"]
+        self.assertEqual(len(problem_indices), 1, f"--problem must appear exactly once, got argv={argv}")
+        self.assertEqual(argv[problem_indices[0] + 1], "foo,bar,baz")
+
+    def test_run_eval_omits_problem_flag_when_no_ids(self) -> None:
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.returncode = 0
+
+            def communicate(self) -> tuple[str, None]:
+                return ('{"problems": []}', None)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = pathlib.Path(tmp)
+            with mock.patch.object(ev.subprocess, "Popen", return_value=FakeProcess()) as popen:
+                ev._run_run_eval(
+                    problem_ids=[],
+                    workspaces_root=repo_root / "workspaces",
+                    repo_root=repo_root,
+                )
+        argv = popen.call_args[0][0]
+        self.assertNotIn("--problem", argv)
 
     def test_run_eval_nonzero_exit_includes_stdout(self) -> None:
         class FakeProcess:


### PR DESCRIPTION
## Summary
Fixes the failure mode hit in https://github.com/kim-em/lean-eval/issues/20: a submitter forks lean-eval, every generated workspace travels with the fork, and the evaluator tries to overlay + prime + score all of them. That blows up the runner disk and trips a \`Duplicate flag --problem\` error in lean4-cli.

Three orthogonal fixes:

- **Skip pristine submissions** — \`evaluate_submission.detect_matches\` now compares each submitter \`Submission.lean\` against \`generated/<id>/Submission.lean\` and marks byte-identical matches with a \`skip_reason\`. The existing skip-flow bypasses overlay + prime + run-eval for those workspaces, so we only do real work for the problems the submitter actually attempted.
- **Fix \`Duplicate flag --problem\`** — \`_run_run_eval\` now passes a single \`--problem id1,id2,...\`. lean4-cli's \`Array String\` instance parses one occurrence as a comma-separated list and rejects further occurrences as duplicates; passing the flag repeatedly tripped that. \`EvalTools.runMain\` additionally pre-coalesces repeated \`--problem\` / \`--file\` argv into the comma form so the documented \"pass repeatedly\" UX works for direct CLI users too.
- **Share Mathlib across workspaces** — \`submission.yml\` now passes \`--shared-packages \"\$PWD/.lake/packages\"\` so each per-workspace \`lake update\` symlinks to the host's already-populated Mathlib instead of cloning + decompressing it per workspace. The plumbing in \`_share_packages\` already existed; just unused.

If the whole submission turns out to be pristine workspaces, the error message now says so explicitly so submitters understand why nothing scored.

## Test plan
- [x] \`python3 -m unittest tests.test_evaluate_submission\` — 25 tests pass, including new \`test_pristine_equal_submission_lean_is_skipped\`, \`test_run_eval_passes_problem_ids_as_single_comma_separated_flag\`, and \`test_fork_everything_solve_a_few\`.
- [x] \`lake build «lean-eval»\` succeeds.
- [x] Manual: \`lake exe lean-eval run-eval --problem foo --problem bar\` no longer fails with \`Duplicate flag --problem\` (advances past argv parsing into the Python script).
- [ ] CI runs full suite on this branch.

🤖 Prepared with Claude Code