### PR TITLE
chore: retarget repo references to leanprover org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Benchmark source code and documentation
-    url: https://github.com/kim-em/lean-eval
+    url: https://github.com/leanprover/lean-eval
     about: Read the README for submission requirements before opening a submission issue.
   - name: Leaderboard (results store)
-    url: https://github.com/kim-em/lean-eval-leaderboard
+    url: https://github.com/leanprover/lean-eval-leaderboard
     about: Machine-written results per GitHub user. The schema lives in that repo's README.

--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -15,7 +15,7 @@ body:
         and tries every match it finds. That means all of these work:
 
         - a repo that is a single generated workspace
-        - a fork of `kim-em/lean-eval` with changes under `generated/`
+        - a fork of `leanprover/lean-eval` with changes under `generated/`
         - a repo that contains several workspaces side by side
         - a gist that contains a `lakefile.toml` and a `Submission.lean`
 

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -220,7 +220,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: kim-em/lean-eval-leaderboard
+          repository: leanprover/lean-eval-leaderboard
           token: ${{ secrets.LEADERBOARD_WRITE_TOKEN }}
           path: leaderboard
 

--- a/LANDRUN.md
+++ b/LANDRUN.md
@@ -77,8 +77,8 @@ on and closed, and the leaderboard receives (an empty) update.
 
 ### Relevant repositories
 
-- `kim-em/lean-eval` — the benchmark. This repo.
-- `kim-em/lean-eval-leaderboard` — the public results store. Write-only from CI.
+- `leanprover/lean-eval` — the benchmark. This repo.
+- `leanprover/lean-eval-leaderboard` — the public results store. Write-only from CI.
 - `kim-em/lean-eval-dogfood` — throwaway private test submission (just a
   `lakefile.toml` + `Submission.lean` proving `two_plus_two_eq_four`).
 - `leanprover/comparator` — upstream comparator, which drives the
@@ -387,7 +387,7 @@ a submission can take: `lakefile.toml` with
 (`theorem two_plus_two_eq_four : (2 : Nat) + 2 = 4 := by decide`). The
 `lean-eval-bot` GitHub App is installed on it. Re-triggering the
 submission workflow against it is the fastest feedback loop — toggle
-the `submission` label on issue #1 of `kim-em/lean-eval`.
+the `submission` label on issue #1 of `leanprover/lean-eval`.
 
 ### Running the minimal reproducer outside CI
 
@@ -395,7 +395,7 @@ On a Linux machine with landrun installed (`go install
 github.com/zouuup/landrun/cmd/landrun@latest`) and lean4 via elan:
 
 ```bash
-git clone https://github.com/kim-em/lean-eval
+git clone https://github.com/leanprover/lean-eval
 cd lean-eval
 lake exe cache get    # seed repo-root Mathlib
 # build comparator and lean4export locally; add them to PATH

--- a/scripts/update_leaderboard.py
+++ b/scripts/update_leaderboard.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Merge comparator results into a clone of kim-em/lean-eval-leaderboard.
+Merge comparator results into a clone of leanprover/lean-eval-leaderboard.
 
 Implements the sticky-no-op semantics documented at
-https://github.com/kim-em/lean-eval-leaderboard (README, schema v1).
+https://github.com/leanprover/lean-eval-leaderboard (README, schema v1).
 Does not run git; the caller is responsible for cloning the leaderboard
 repo, committing the modified file, and pushing.
 """
@@ -149,7 +149,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--leaderboard-dir",
         required=True,
         type=pathlib.Path,
-        help="Path to a local clone of kim-em/lean-eval-leaderboard.",
+        help="Path to a local clone of leanprover/lean-eval-leaderboard.",
     )
     parser.add_argument(
         "--results-json",


### PR DESCRIPTION
This PR updates hardcoded references to `kim-em/lean-eval` and `kim-em/lean-eval-leaderboard` so they point at the new `leanprover/...` locations in advance of the GitHub repo transfer to the `leanprover` organization.

Touches the submission workflow's leaderboard checkout (`.github/workflows/submission.yml` line 223), the issue templates' contact links, the `update_leaderboard.py` docstring/help text, and the `LANDRUN.md` repository overview. Historical `actions/runs/...` URLs in LANDRUN.md are left as-is — GitHub's redirects keep them working.

Companion PR on the leaderboard repo: https://github.com/kim-em/lean-eval-leaderboard/pull/3.

Note: after the transfer, the `LEADERBOARD_WRITE_TOKEN` secret on this repo will need to have its scope verified for the new `leanprover/lean-eval-leaderboard` location, and the `lean-eval-bot` GitHub App will need to be installed/granted on the `leanprover` org.

🤖 Prepared with Claude Code