### PR TITLE
[codex] clarify exceptional tensor-square problem wording

### DIFF
--- a/LeanEval/RepresentationTheory/ExceptionalLieTensorSquare.lean
+++ b/LeanEval/RepresentationTheory/ExceptionalLieTensorSquare.lean
@@ -13,22 +13,32 @@ namespace RepresentationTheory
 open scoped TensorProduct
 
 /-!
-Tensor square decomposition for irreducible representations of g₂ and e₈
+Existential tensor-square problems for irreducible representations of g₂ and e₈
 defined by the Serre construction.
 
-For each of the exceptional Lie algebras g₂ and e₈ over ℂ, the irreducible
-representation with highest weight `ω₁ + ω_n` (the sum of the first and last
-fundamental weights, in Bourbaki labelling) has a particular dimension `d`,
-and its tensor square decomposes into `k` isotypic components (counted as
+For each of the exceptional Lie algebras g₂ and e₈ over ℂ, we ask only for the
+existence of an irreducible representation `V` of a specified dimension whose
+tensor square has a specified number of isotypic components (counted as
 distinct isomorphism classes of irreducible Lie submodules):
 
-* g₂: dim V = 64,     k = 14   (highest weight ω₁ + ω₂)
-* e₈: dim V = 779247, k = 40   (highest weight ω₁ + ω₈)
+* g₂: dim V = 64,     `V ⊗ V` has 14 isotypic components
+* e₈: dim V = 779247, `V ⊗ V` has 40 isotypic components
 
-Mathlib's `isotypicComponents` is defined for modules over a ring. To use it
-on a Lie module `M`, we transport the action through the universal enveloping
-algebra: a `LieModule R L M` extends to a `Module (UniversalEnvelopingAlgebra R L) M`
-via the universal property.
+In the intended solution, one exhibits `V` as the highest-weight
+representation `ω₁ + ω_n` (the sum of the first and last fundamental weights,
+in Bourbaki labelling):
+
+* g₂: highest weight `ω₁ + ω₂`
+* e₈: highest weight `ω₁ + ω₈`
+
+Mathlib does not yet package the highest-weight classification needed to state
+those descriptions directly, so they serve here as mathematical guidance for
+constructing a witness rather than as part of the formal theorem statement.
+
+Mathlib's `isotypicComponents` is defined for modules over a ring. To use it on
+a Lie module `M`, we transport the action through the universal enveloping
+algebra: a `LieModule R L M` extends to a
+`Module (UniversalEnvelopingAlgebra R L) M` via the universal property.
 -/
 
 noncomputable instance lieModuleToEnvelopingModule

--- a/generated/e8_irrep_tensor_square_decomp/ChallengeDeps.lean
+++ b/generated/e8_irrep_tensor_square_decomp/ChallengeDeps.lean
@@ -6,22 +6,32 @@ namespace RepresentationTheory
 open scoped TensorProduct
 
 /-!
-Tensor square decomposition for irreducible representations of g₂ and e₈
+Existential tensor-square problems for irreducible representations of g₂ and e₈
 defined by the Serre construction.
 
-For each of the exceptional Lie algebras g₂ and e₈ over ℂ, the irreducible
-representation with highest weight `ω₁ + ω_n` (the sum of the first and last
-fundamental weights, in Bourbaki labelling) has a particular dimension `d`,
-and its tensor square decomposes into `k` isotypic components (counted as
+For each of the exceptional Lie algebras g₂ and e₈ over ℂ, we ask only for the
+existence of an irreducible representation `V` of a specified dimension whose
+tensor square has a specified number of isotypic components (counted as
 distinct isomorphism classes of irreducible Lie submodules):
 
-* g₂: dim V = 64,     k = 14   (highest weight ω₁ + ω₂)
-* e₈: dim V = 779247, k = 40   (highest weight ω₁ + ω₈)
+* g₂: dim V = 64,     `V ⊗ V` has 14 isotypic components
+* e₈: dim V = 779247, `V ⊗ V` has 40 isotypic components
 
-Mathlib's `isotypicComponents` is defined for modules over a ring. To use it
-on a Lie module `M`, we transport the action through the universal enveloping
-algebra: a `LieModule R L M` extends to a `Module (UniversalEnvelopingAlgebra R L) M`
-via the universal property.
+In the intended solution, one exhibits `V` as the highest-weight
+representation `ω₁ + ω_n` (the sum of the first and last fundamental weights,
+in Bourbaki labelling):
+
+* g₂: highest weight `ω₁ + ω₂`
+* e₈: highest weight `ω₁ + ω₈`
+
+Mathlib does not yet package the highest-weight classification needed to state
+those descriptions directly, so they serve here as mathematical guidance for
+constructing a witness rather than as part of the formal theorem statement.
+
+Mathlib's `isotypicComponents` is defined for modules over a ring. To use it on
+a Lie module `M`, we transport the action through the universal enveloping
+algebra: a `LieModule R L M` extends to a
+`Module (UniversalEnvelopingAlgebra R L) M` via the universal property.
 -/
 
 noncomputable instance lieModuleToEnvelopingModule

--- a/generated/e8_irrep_tensor_square_decomp/README.md
+++ b/generated/e8_irrep_tensor_square_decomp/README.md
@@ -1,13 +1,13 @@
 # `e8_irrep_tensor_square_decomp`
 
-Tensor square decomposition of a 779247-dim irreducible e₈-representation
+Existence of a 779247-dim irreducible e₈-representation with 40 tensor-square isotypic components
 
 - Problem ID: `e8_irrep_tensor_square_decomp`
 - Test Problem: no
 - Submitter: Kim Morrison
-- Notes: e₈ is the largest exceptional Lie algebra (dim 248), defined here by the Serre construction (Mathlib's `LieAlgebra.e₈`). The relevant irreducible representation has highest weight ω₁ + ω₈ (the sum of the first and last fundamental weights, in Bourbaki labelling), dimension 779247; its tensor square decomposes into 40 isomorphism classes of irreducible Lie submodules. The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra.
+- Notes: e₈ is the largest exceptional Lie algebra (dim 248), defined here by the Serre construction (Mathlib's `LieAlgebra.e₈`). The formal statement is existential: it asks for some 779247-dimensional irreducible representation whose tensor square has 40 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight ω₁ + ω₈ (the sum of the first and last fundamental weights, in Bourbaki labelling). The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra.
 - Source: Classical: representation theory of the exceptional Lie algebra e₈.
-- Informal solution: Construct V as V(ω₁+ω₈), the unique 779247-dim irrep of e₈. Tensor square (LiE-verified) has 40 distinct simple summand isomorphism classes (155 components with multiplicity), with the smallest being the trivial 1-dim, the 248-dim adjoint (mult 2), the 3875-dim V(ω₁), and so on up to the 85,424,220,000-dim summand.
+- Informal solution: Construct V as V(ω₁+ω₈), the unique 779247-dim irrep of e₈. Tensor square (LiE-verified) has 40 distinct simple summand isomorphism classes (155 components with multiplicity), with the smallest being the trivial 1-dim, the 248-dim adjoint (mult 2), the 3875-dim V(ω₁), and so on up to the 85,424,220,000-dim summand. This is used to produce the existential witness required by the formal statement.
 
 Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
 trusted benchmark and fixed by the repository.

--- a/generated/g2_irrep_tensor_square_decomp/ChallengeDeps.lean
+++ b/generated/g2_irrep_tensor_square_decomp/ChallengeDeps.lean
@@ -6,22 +6,32 @@ namespace RepresentationTheory
 open scoped TensorProduct
 
 /-!
-Tensor square decomposition for irreducible representations of g₂ and e₈
+Existential tensor-square problems for irreducible representations of g₂ and e₈
 defined by the Serre construction.
 
-For each of the exceptional Lie algebras g₂ and e₈ over ℂ, the irreducible
-representation with highest weight `ω₁ + ω_n` (the sum of the first and last
-fundamental weights, in Bourbaki labelling) has a particular dimension `d`,
-and its tensor square decomposes into `k` isotypic components (counted as
+For each of the exceptional Lie algebras g₂ and e₈ over ℂ, we ask only for the
+existence of an irreducible representation `V` of a specified dimension whose
+tensor square has a specified number of isotypic components (counted as
 distinct isomorphism classes of irreducible Lie submodules):
 
-* g₂: dim V = 64,     k = 14   (highest weight ω₁ + ω₂)
-* e₈: dim V = 779247, k = 40   (highest weight ω₁ + ω₈)
+* g₂: dim V = 64,     `V ⊗ V` has 14 isotypic components
+* e₈: dim V = 779247, `V ⊗ V` has 40 isotypic components
 
-Mathlib's `isotypicComponents` is defined for modules over a ring. To use it
-on a Lie module `M`, we transport the action through the universal enveloping
-algebra: a `LieModule R L M` extends to a `Module (UniversalEnvelopingAlgebra R L) M`
-via the universal property.
+In the intended solution, one exhibits `V` as the highest-weight
+representation `ω₁ + ω_n` (the sum of the first and last fundamental weights,
+in Bourbaki labelling):
+
+* g₂: highest weight `ω₁ + ω₂`
+* e₈: highest weight `ω₁ + ω₈`
+
+Mathlib does not yet package the highest-weight classification needed to state
+those descriptions directly, so they serve here as mathematical guidance for
+constructing a witness rather than as part of the formal theorem statement.
+
+Mathlib's `isotypicComponents` is defined for modules over a ring. To use it on
+a Lie module `M`, we transport the action through the universal enveloping
+algebra: a `LieModule R L M` extends to a
+`Module (UniversalEnvelopingAlgebra R L) M` via the universal property.
 -/
 
 noncomputable instance lieModuleToEnvelopingModule

--- a/generated/g2_irrep_tensor_square_decomp/README.md
+++ b/generated/g2_irrep_tensor_square_decomp/README.md
@@ -1,13 +1,13 @@
 # `g2_irrep_tensor_square_decomp`
 
-Tensor square decomposition of a 64-dim irreducible g₂-representation
+Existence of a 64-dim irreducible g₂-representation with 14 tensor-square isotypic components
 
 - Problem ID: `g2_irrep_tensor_square_decomp`
 - Test Problem: no
 - Submitter: Kim Morrison
-- Notes: g₂ is the smallest exceptional Lie algebra, defined here by the Serre construction (Mathlib's `LieAlgebra.g₂`). The relevant irreducible representation has highest weight ω₁ + ω₂ (the sum of the two fundamental weights), dimension 64; its tensor square decomposes into 14 isomorphism classes of irreducible Lie submodules. The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra.
+- Notes: g₂ is the smallest exceptional Lie algebra, defined here by the Serre construction (Mathlib's `LieAlgebra.g₂`). The formal statement is existential: it asks for some 64-dimensional irreducible representation whose tensor square has 14 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight ω₁ + ω₂ (the sum of the two fundamental weights). The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra.
 - Source: Classical: representation theory of the exceptional Lie algebra g₂.
-- Informal solution: Construct V as the irreducible 64-dim representation V(ω₁+ω₂). Decomposition (LiE-verified): V⊗V = V(0,0) + V(1,0) + 2V(0,1) + 2V(2,0) + 2V(1,1) + 2V(0,2) + 3V(3,0) + 3V(2,1) + V(1,2) + V(0,3) + 2V(4,0) + 2V(3,1) + V(2,2) + V(5,0). The 14 distinct highest weights give 14 isotypic components.
+- Informal solution: Construct V as the irreducible 64-dim representation V(ω₁+ω₂). Decomposition (LiE-verified): V⊗V = V(0,0) + V(1,0) + 2V(0,1) + 2V(2,0) + 2V(1,1) + 2V(0,2) + 3V(3,0) + 3V(2,1) + V(1,2) + V(0,3) + 2V(4,0) + 2V(3,1) + V(2,2) + V(5,0). This is used to produce the existential witness required by the formal statement.
 
 Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
 trusted benchmark and fixed by the repository.

--- a/generated/index.json
+++ b/generated/index.json
@@ -217,7 +217,7 @@
   },
   {
     "id": "g2_irrep_tensor_square_decomp",
-    "title": "Tensor square decomposition of a 64-dim irreducible g\u2082-representation",
+    "title": "Existence of a 64-dim irreducible g\u2082-representation with 14 tensor-square isotypic components",
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare",
@@ -226,7 +226,7 @@
   },
   {
     "id": "e8_irrep_tensor_square_decomp",
-    "title": "Tensor square decomposition of a 779247-dim irreducible e\u2088-representation",
+    "title": "Existence of a 779247-dim irreducible e\u2088-representation with 40 tensor-square isotypic components",
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare",

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -266,25 +266,25 @@ informal_solution = "By polarization over R with k! invertible, the subalgebra g
 
 [[problem]]
 id = "g2_irrep_tensor_square_decomp"
-title = "Tensor square decomposition of a 64-dim irreducible g₂-representation"
+title = "Existence of a 64-dim irreducible g₂-representation with 14 tensor-square isotypic components"
 test = false
 module = "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare"
 theorem = "g2_irrep_tensor_square_decomp"
 submitter = "Kim Morrison"
-notes = "g₂ is the smallest exceptional Lie algebra, defined here by the Serre construction (Mathlib's `LieAlgebra.g₂`). The relevant irreducible representation has highest weight ω₁ + ω₂ (the sum of the two fundamental weights), dimension 64; its tensor square decomposes into 14 isomorphism classes of irreducible Lie submodules. The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra."
+notes = "g₂ is the smallest exceptional Lie algebra, defined here by the Serre construction (Mathlib's `LieAlgebra.g₂`). The formal statement is existential: it asks for some 64-dimensional irreducible representation whose tensor square has 14 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight ω₁ + ω₂ (the sum of the two fundamental weights). The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra."
 source = "Classical: representation theory of the exceptional Lie algebra g₂."
-informal_solution = "Construct V as the irreducible 64-dim representation V(ω₁+ω₂). Decomposition (LiE-verified): V⊗V = V(0,0) + V(1,0) + 2V(0,1) + 2V(2,0) + 2V(1,1) + 2V(0,2) + 3V(3,0) + 3V(2,1) + V(1,2) + V(0,3) + 2V(4,0) + 2V(3,1) + V(2,2) + V(5,0). The 14 distinct highest weights give 14 isotypic components."
+informal_solution = "Construct V as the irreducible 64-dim representation V(ω₁+ω₂). Decomposition (LiE-verified): V⊗V = V(0,0) + V(1,0) + 2V(0,1) + 2V(2,0) + 2V(1,1) + 2V(0,2) + 3V(3,0) + 3V(2,1) + V(1,2) + V(0,3) + 2V(4,0) + 2V(3,1) + V(2,2) + V(5,0). This is used to produce the existential witness required by the formal statement."
 
 [[problem]]
 id = "e8_irrep_tensor_square_decomp"
-title = "Tensor square decomposition of a 779247-dim irreducible e₈-representation"
+title = "Existence of a 779247-dim irreducible e₈-representation with 40 tensor-square isotypic components"
 test = false
 module = "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare"
 theorem = "e8_irrep_tensor_square_decomp"
 submitter = "Kim Morrison"
-notes = "e₈ is the largest exceptional Lie algebra (dim 248), defined here by the Serre construction (Mathlib's `LieAlgebra.e₈`). The relevant irreducible representation has highest weight ω₁ + ω₈ (the sum of the first and last fundamental weights, in Bourbaki labelling), dimension 779247; its tensor square decomposes into 40 isomorphism classes of irreducible Lie submodules. The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra."
+notes = "e₈ is the largest exceptional Lie algebra (dim 248), defined here by the Serre construction (Mathlib's `LieAlgebra.e₈`). The formal statement is existential: it asks for some 779247-dimensional irreducible representation whose tensor square has 40 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight ω₁ + ω₈ (the sum of the first and last fundamental weights, in Bourbaki labelling). The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra."
 source = "Classical: representation theory of the exceptional Lie algebra e₈."
-informal_solution = "Construct V as V(ω₁+ω₈), the unique 779247-dim irrep of e₈. Tensor square (LiE-verified) has 40 distinct simple summand isomorphism classes (155 components with multiplicity), with the smallest being the trivial 1-dim, the 248-dim adjoint (mult 2), the 3875-dim V(ω₁), and so on up to the 85,424,220,000-dim summand."
+informal_solution = "Construct V as V(ω₁+ω₈), the unique 779247-dim irrep of e₈. Tensor square (LiE-verified) has 40 distinct simple summand isomorphism classes (155 components with multiplicity), with the smallest being the trivial 1-dim, the 248-dim adjoint (mult 2), the 3875-dim V(ω₁), and so on up to the 85,424,220,000-dim summand. This is used to produce the existential witness required by the formal statement."
 
 [[problem]]
 id = "cerf_gamma_four"


### PR DESCRIPTION
## What changed

This PR rewrites the public wording for the `g2_irrep_tensor_square_decomp` and `e8_irrep_tensor_square_decomp` benchmark problems so it matches the actual Lean statement.

The problems remain existential: they ask for some irreducible representation of the specified dimension whose tensor square has the specified number of isotypic components.

## Why

The previous title and notes read like the benchmark formalized a full tensor-square decomposition of a specific highest-weight representation. In Lean, the theorem only asserts existence plus the isotypic-component count.

The highest-weight descriptions are still useful, but as solver guidance rather than formal constraints. This PR makes that explicit in:

- the source module docstring
- the manifest titles, notes, and informal solutions
- the checked-in generated metadata

## Validation

- Updated the trusted source files and the committed generated metadata consistently.
- Attempted `lake`-based verification, but local concurrent Lean/Lake processes in this checkout were contending over `.lake` artifacts and produced spurious setup/olean cache errors unrelated to these wording changes.
