### PR TITLE
doc: link leaderboard prominently from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lean Eval
 
+**[View the leaderboard →](https://leanprover.github.io/lean-eval-leaderboard/)**
+
 This repository is a comparator-based Lean benchmark for formal mathematics.
 Benchmark authors write trusted problem statements once in shared Lean modules, and the
 tooling generates one comparator workspace per problem under `generated/`.


### PR DESCRIPTION
This PR adds a prominent link to the public leaderboard at https://leanprover.github.io/lean-eval-leaderboard/ at the top of the README, so visitors can find the live results without having to read past the project description.

🤖 Prepared with Claude Code