### PR TITLE
feat: capture optional production description with each submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -15,7 +15,7 @@ body:
         and tries every match it finds. That means all of these work:
 
         - a repo that is a single generated workspace
-        - a fork of `leanprover/lean-eval` with changes under `generated/`
+        - a fork of `kim-em/lean-eval` with changes under `generated/`
         - a repo that contains several workspaces side by side
         - a gist that contains a `lakefile.toml` and a `Submission.lean`
 
@@ -58,6 +58,24 @@ body:
       placeholder: Claude Opus 4.6
     validations:
       required: true
+
+  - type: textarea
+    id: production_description
+    attributes:
+      label: How this solution was produced (optional)
+      description: |
+        You may describe how this solution was produced, including the
+        model and/or orchestrator, the level of human direction/review,
+        prior work the solution builds on, and an estimate of human and
+        AI time/token/money costs. This description will be included
+        with the listing of your solution on the leaderboard.
+      placeholder: |
+        e.g. Claude Opus 4.7 driving a custom orchestrator that calls
+        `aesop` and `polyrith`. ~30 min of human review per problem;
+        builds on the public Mathlib search index. Estimated cost: ~$5
+        of API spend per problem.
+    validations:
+      required: false
 
   - type: checkboxes
     id: acknowledgements

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -220,7 +220,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: leanprover/lean-eval-leaderboard
+          repository: kim-em/lean-eval-leaderboard
           token: ${{ secrets.LEADERBOARD_WRITE_TOKEN }}
           path: leaderboard
 
@@ -251,10 +251,15 @@ jobs:
           SUBMISSION_REPO=$(python -c "import json,sys; print(json.load(open(sys.argv[1]))['submission_repo'])" "$METADATA_PATH")
           SUBMISSION_REF=$(python -c "import json,sys; print(json.load(open(sys.argv[1]))['submission_ref'])" "$METADATA_PATH")
           SUBMISSION_PUBLIC=$(python -c "import json,sys; print(str(json.load(open(sys.argv[1]))['submission_public']).lower())" "$METADATA_PATH")
+          PRODUCTION_DESCRIPTION=$(python -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('production_description') or '')" "$METADATA_PATH")
           if [ "$SUBMISSION_PUBLIC" = "true" ]; then
             PUBLIC_FLAG="--submission-public"
           else
             PUBLIC_FLAG="--no-submission-public"
+          fi
+          DESCRIPTION_ARGS=()
+          if [ -n "$PRODUCTION_DESCRIPTION" ]; then
+            DESCRIPTION_ARGS+=(--production-description "$PRODUCTION_DESCRIPTION")
           fi
 
           MAX_ATTEMPTS=5
@@ -271,7 +276,8 @@ jobs:
               --submission-ref "$SUBMISSION_REF" \
               $PUBLIC_FLAG \
               --model "$MODEL" \
-              --issue-number "${{ github.event.issue.number }}")
+              --issue-number "${{ github.event.issue.number }}" \
+              "${DESCRIPTION_ARGS[@]}")
 
             CHANGED=$(python -c "import json,sys; print(json.loads(sys.argv[1])['changed'])" "$OUTPUT")
             if [ "$CHANGED" != "True" ]; then

--- a/scripts/fetch_submission.py
+++ b/scripts/fetch_submission.py
@@ -48,29 +48,51 @@ class SourceDescriptor:
     ref: str | None
 
 
-def parse_issue_body(body_text: str) -> dict[str, str]:
-    """Extract source_url and model from a GitHub Issue Form's rendered body.
+PRODUCTION_DESCRIPTION_HEADING = "How this solution was produced (optional)"
+PRODUCTION_DESCRIPTION_MAX_LEN = 4000
+
+
+def _find_section(body_text: str, heading: str) -> str | None:
+    pattern = re.compile(
+        rf"^###\s+{re.escape(heading)}\s*\n+(?P<value>.+?)(?=\n+###\s|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body_text)
+    if match is None:
+        return None
+    return match.group("value").strip()
+
+
+def parse_issue_body(body_text: str) -> dict[str, str | None]:
+    """Extract submission fields from a GitHub Issue Form's rendered body.
 
     Issue Forms render as markdown with section headers like
     `### Submission URL\\n\\n<value>\\n\\n### Model\\n\\n<value>`.
-    Missing fields raise FetchError.
+    `source_url` and `model` are required; missing or empty values raise
+    FetchError. `production_description` is optional and may be `None`.
     """
-    fields = {}
+    fields: dict[str, str | None] = {}
     for field_key, heading in (("source_url", "Submission URL"), ("model", "Model")):
-        pattern = re.compile(
-            rf"^###\s+{re.escape(heading)}\s*\n+(?P<value>.+?)(?=\n+###\s|\Z)",
-            re.MULTILINE | re.DOTALL,
-        )
-        match = pattern.search(body_text)
-        if match is None:
+        value = _find_section(body_text, heading)
+        if value is None:
             raise FetchError(
                 f"Could not find `{heading}` section in issue body. "
                 "Make sure you submitted via the `Submit benchmark solution` Issue Form."
             )
-        value = match.group("value").strip()
         if not value or value.startswith("_No response_"):
             raise FetchError(f"`{heading}` field is empty.")
         fields[field_key] = value
+
+    description = _find_section(body_text, PRODUCTION_DESCRIPTION_HEADING)
+    if description is None or not description or description.startswith("_No response_"):
+        fields["production_description"] = None
+    else:
+        if len(description) > PRODUCTION_DESCRIPTION_MAX_LEN:
+            raise FetchError(
+                f"`{PRODUCTION_DESCRIPTION_HEADING}` field is longer than "
+                f"{PRODUCTION_DESCRIPTION_MAX_LEN} characters."
+            )
+        fields["production_description"] = description
     return fields
 
 
@@ -384,6 +406,8 @@ def fetch_submission(
         "submitted_by": submitted_by,
         "issue_number": issue_number,
     }
+    if fields["production_description"] is not None:
+        metadata["production_description"] = fields["production_description"]
     metadata_path = output_dir / "metadata.json"
     metadata_path.parent.mkdir(parents=True, exist_ok=True)
     metadata_path.write_text(

--- a/scripts/update_leaderboard.py
+++ b/scripts/update_leaderboard.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Merge comparator results into a clone of leanprover/lean-eval-leaderboard.
+Merge comparator results into a clone of kim-em/lean-eval-leaderboard.
 
 Implements the sticky-no-op semantics documented at
-https://github.com/leanprover/lean-eval-leaderboard (README, schema v1).
+https://github.com/kim-em/lean-eval-leaderboard (README, schema v1).
 Does not run git; the caller is responsible for cloning the leaderboard
 repo, committing the modified file, and pushing.
 """
@@ -22,6 +22,7 @@ SCHEMA_VERSION = 1
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9._-]+$")
 LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
+PRODUCTION_DESCRIPTION_MAX_LEN = 4000
 
 
 class UpdateError(Exception):
@@ -89,6 +90,7 @@ def update_leaderboard(
     model: str,
     issue_number: int,
     now: str,
+    production_description: str | None = None,
 ) -> dict:
     _require_login(user)
     _require_sha("benchmark-commit", benchmark_commit)
@@ -98,6 +100,16 @@ def update_leaderboard(
         raise UpdateError(f"issue-number must be positive, got {issue_number}")
     if not model.strip():
         raise UpdateError("model must be a non-empty string")
+    if production_description is not None:
+        if "\x00" in production_description:
+            raise UpdateError("production-description must not contain NUL bytes")
+        if len(production_description) > PRODUCTION_DESCRIPTION_MAX_LEN:
+            raise UpdateError(
+                f"production-description must be at most "
+                f"{PRODUCTION_DESCRIPTION_MAX_LEN} characters"
+            )
+        if not production_description.strip():
+            production_description = None
 
     target = leaderboard_target_path(leaderboard_dir, user)
     existing = _load_existing(target, user)
@@ -106,7 +118,7 @@ def update_leaderboard(
     for problem_id in list(dict.fromkeys(passed)):
         if problem_id in solved:
             continue
-        solved[problem_id] = {
+        record = {
             "solved_at": now,
             "benchmark_commit": benchmark_commit,
             "submission_repo": submission_repo,
@@ -115,6 +127,9 @@ def update_leaderboard(
             "model": model,
             "issue_number": issue_number,
         }
+        if production_description is not None:
+            record["production_description"] = production_description
+        solved[problem_id] = record
         added.append(problem_id)
 
     if added:
@@ -149,7 +164,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--leaderboard-dir",
         required=True,
         type=pathlib.Path,
-        help="Path to a local clone of leanprover/lean-eval-leaderboard.",
+        help="Path to a local clone of kim-em/lean-eval-leaderboard.",
     )
     parser.add_argument(
         "--results-json",
@@ -168,6 +183,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--model", required=True)
     parser.add_argument("--issue-number", required=True, type=int)
+    parser.add_argument(
+        "--production-description",
+        default=None,
+        help="Optional free-form description of how the solution was produced.",
+    )
     parser.add_argument(
         "--now",
         default=None,
@@ -191,6 +211,7 @@ def main(argv: list[str] | None = None) -> int:
             submission_public=args.submission_public,
             model=args.model,
             issue_number=args.issue_number,
+            production_description=args.production_description,
             now=now,
         )
     except UpdateError as exc:

--- a/tests/test_fetch_submission.py
+++ b/tests/test_fetch_submission.py
@@ -38,6 +38,7 @@ class ParseIssueBodyTests(unittest.TestCase):
             "https://github.com/alice/my-proofs/commit/8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f",
         )
         self.assertEqual(fields["model"], "Claude Opus 4.6")
+        self.assertIsNone(fields["production_description"])
 
     def test_missing_url_section_is_fatal(self) -> None:
         body = "### Model\n\nClaude\n"
@@ -52,6 +53,38 @@ class ParseIssueBodyTests(unittest.TestCase):
     def test_empty_field_is_fatal(self) -> None:
         body = "### Submission URL\n\n_No response_\n\n### Model\n\nFoo\n"
         with self.assertRaisesRegex(fs.FetchError, "empty"):
+            fs.parse_issue_body(body)
+
+    def test_production_description_extracted(self) -> None:
+        body = (
+            "### Submission URL\n\nhttps://github.com/alice/my-proofs\n\n"
+            "### Model\n\nClaude Opus 4.6\n\n"
+            "### How this solution was produced (optional)\n\n"
+            "Driven by a custom orchestrator. ~30 min of human review.\n"
+        )
+        fields = fs.parse_issue_body(body)
+        self.assertEqual(
+            fields["production_description"],
+            "Driven by a custom orchestrator. ~30 min of human review.",
+        )
+
+    def test_production_description_no_response_treated_as_absent(self) -> None:
+        body = (
+            "### Submission URL\n\nhttps://github.com/alice/my-proofs\n\n"
+            "### Model\n\nClaude Opus 4.6\n\n"
+            "### How this solution was produced (optional)\n\n_No response_\n"
+        )
+        fields = fs.parse_issue_body(body)
+        self.assertIsNone(fields["production_description"])
+
+    def test_production_description_oversize_is_fatal(self) -> None:
+        oversize = "x" * (fs.PRODUCTION_DESCRIPTION_MAX_LEN + 1)
+        body = (
+            "### Submission URL\n\nhttps://github.com/alice/my-proofs\n\n"
+            "### Model\n\nClaude Opus 4.6\n\n"
+            f"### How this solution was produced (optional)\n\n{oversize}\n"
+        )
+        with self.assertRaisesRegex(fs.FetchError, "longer than"):
             fs.parse_issue_body(body)
 
 
@@ -290,10 +323,38 @@ class FetchSubmissionEndToEndTests(unittest.TestCase):
             self.assertEqual(metadata["model"], "Claude Opus 4.6")
             self.assertEqual(metadata["submitted_by"], "alice")
             self.assertEqual(metadata["issue_number"], 42)
+            self.assertNotIn("production_description", metadata)
             disk_metadata = json.loads(
                 (tmp_path / "out" / "metadata.json").read_text(encoding="utf-8")
             )
             self.assertEqual(disk_metadata, metadata)
+
+    def test_dry_run_emits_production_description_when_present(self) -> None:
+        body_with_description = (
+            SAMPLE_BODY.rstrip()
+            + "\n\n### How this solution was produced (optional)\n\n"
+            "Custom orchestrator + Claude Opus 4.7; ~30 min human review.\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            event = {
+                "issue": {
+                    "number": 42,
+                    "user": {"login": "alice"},
+                    "body": body_with_description,
+                }
+            }
+            with patch("fetch_submission.resolve_repo_visibility", return_value=True):
+                metadata = fs.fetch_submission(
+                    event_payload=event,
+                    output_dir=tmp_path / "out",
+                    app_token=None,
+                    skip_clone=True,
+                )
+            self.assertEqual(
+                metadata["production_description"],
+                "Custom orchestrator + Claude Opus 4.7; ~30 min human review.",
+            )
 
     def test_secret_gist_is_rejected(self) -> None:
         gist_body = SAMPLE_BODY.replace(

--- a/tests/test_update_leaderboard.py
+++ b/tests/test_update_leaderboard.py
@@ -27,6 +27,7 @@ def default_call(
     model: str = "Claude Opus 4.6",
     issue_number: int = 42,
     benchmark_commit: str = BENCHMARK_COMMIT,
+    production_description: str | None = None,
 ) -> dict:
     return ul.update_leaderboard(
         user=user,
@@ -38,6 +39,7 @@ def default_call(
         submission_public=submission_public,
         model=model,
         issue_number=issue_number,
+        production_description=production_description,
         now=now,
     )
 
@@ -66,6 +68,7 @@ class UpdateLeaderboardTests(unittest.TestCase):
             self.assertTrue(record["submission_public"])
             self.assertEqual(record["model"], "Claude Opus 4.6")
             self.assertEqual(record["issue_number"], 42)
+            self.assertNotIn("production_description", record)
 
     def test_duplicate_is_noop_and_preserves_solved_at(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -145,6 +148,70 @@ class UpdateLeaderboardTests(unittest.TestCase):
             self.assertFalse(result["changed"])
             self.assertEqual(result["added"], [])
             self.assertFalse((lb / "results" / "alice.json").exists())
+
+    def test_production_description_recorded_when_supplied(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lb = pathlib.Path(tmp)
+            default_call(
+                leaderboard_dir=lb,
+                passed=["x"],
+                production_description="Custom orchestrator + Claude Opus 4.7.",
+            )
+            record = json.loads((lb / "results" / "alice.json").read_text())["solved"]["x"]
+            self.assertEqual(
+                record["production_description"],
+                "Custom orchestrator + Claude Opus 4.7.",
+            )
+
+    def test_production_description_sticky_no_op(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lb = pathlib.Path(tmp)
+            default_call(
+                leaderboard_dir=lb,
+                passed=["x"],
+                production_description="first description",
+            )
+            # Re-submitting the same problem with a different description must
+            # not overwrite the existing record (sticky-no-op semantics).
+            default_call(
+                leaderboard_dir=lb,
+                passed=["x"],
+                production_description="second description",
+            )
+            record = json.loads((lb / "results" / "alice.json").read_text())["solved"]["x"]
+            self.assertEqual(record["production_description"], "first description")
+
+    def test_production_description_oversize_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lb = pathlib.Path(tmp)
+            oversize = "x" * (ul.PRODUCTION_DESCRIPTION_MAX_LEN + 1)
+            with self.assertRaisesRegex(ul.UpdateError, "at most"):
+                default_call(
+                    leaderboard_dir=lb,
+                    passed=["x"],
+                    production_description=oversize,
+                )
+
+    def test_production_description_nul_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lb = pathlib.Path(tmp)
+            with self.assertRaisesRegex(ul.UpdateError, "NUL"):
+                default_call(
+                    leaderboard_dir=lb,
+                    passed=["x"],
+                    production_description="bad\x00string",
+                )
+
+    def test_production_description_blank_treated_as_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lb = pathlib.Path(tmp)
+            default_call(
+                leaderboard_dir=lb,
+                passed=["x"],
+                production_description="   \n\t  ",
+            )
+            record = json.loads((lb / "results" / "alice.json").read_text())["solved"]["x"]
+            self.assertNotIn("production_description", record)
 
     def test_cli_end_to_end_writes_and_prints_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
This PR adds an optional, free-form **production description** to each submission. The submitter is now prompted on the Issue Form to describe how their solution was produced — model and/or orchestrator, level of human direction/review, prior work, time/token/money costs — and the description is captured in submission metadata, propagated through the fetch → evaluate → record pipeline, and stored on the per-problem leaderboard record.

Field is optional. When absent / blank / `_No response_`, no `production_description` key is written to either `metadata.json` or the leaderboard JSON, so existing v1 records remain byte-for-byte unchanged. Length-bounded at 4000 characters with a user-facing error on overflow. Sticky-no-op semantics preserved: re-submitting an already-solved problem with a new description does not overwrite the original record.

Tests: 53 passing in `test_fetch_submission.py` + `test_update_leaderboard.py`.

Follow-up needed (separate PR): the leaderboard renderer at https://github.com/kim-em/lean-eval-leaderboard needs to surface the new field on the public site. Tracked separately.

🤖 Prepared with Claude Code