### PR TITLE
fix: retarget leaderboard checkout to leanprover org

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -220,7 +220,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: kim-em/lean-eval-leaderboard
+          repository: leanprover/lean-eval-leaderboard
           token: ${{ secrets.LEADERBOARD_WRITE_TOKEN }}
           path: leaderboard
 


### PR DESCRIPTION
This PR completes the retarget started in b184a90: the `record` job's leaderboard checkout still references `kim-em/lean-eval-leaderboard`. GitHub silently follows the redirect on fetch, but the push hits `Permission to leanprover/lean-eval-leaderboard.git denied to kim-em` because the `LEADERBOARD_WRITE_TOKEN` PAT is bound to the original repo path. Observed in [run 25149475078](https://github.com/leanprover/lean-eval/actions/runs/25149475078) on issue #21 (Rado's submission), where evaluate succeeded and produced a valid result commit but every push retry was denied.

After merging, the `LEADERBOARD_WRITE_TOKEN` secret may also need its scope updated to grant write on the `leanprover` org's repo (if it's a fine-grained PAT — the symptom is consistent with that). Re-trigger Rado's submission #21 once both are in place.

Stale references in `LANDRUN.md` historical run URLs are intentional history and left untouched. Comment-only references in `scripts/update_leaderboard.py` and `.github/ISSUE_TEMPLATE/submit.yml` are cosmetic and not fixed here to keep this PR minimal.

🤖 Prepared with Claude Code