### PR TITLE
ci: auto-regenerate generated/ on main, drop from contributor flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,29 +135,40 @@ jobs:
       - name: Run Eval Workflow Check
         run: python scripts/check_eval_workflow.py
 
-      - name: Verify Generated Output
-        run: python scripts/generate_projects.py --check
-
-      # Detect whether generated/ files changed to skip the expensive
-      # workspace build step on PRs that only touch problem sources or
-      # manifests.
-      - name: Detect generated workspace changes
+      # Decide whether to run workspace generation/build. Source-only PRs
+      # regenerate generated/ in the runner's working tree (the regenerate-main
+      # workflow is the only thing that commits generated/ to main); solver PRs
+      # build the committed tree as-is.
+      - name: Detect changes
         id: changes
         run: |
           BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
           if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            echo "generated_changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$BASE"..HEAD | grep -q '^generated/'; then
+            echo "source_changed=true" >> "$GITHUB_OUTPUT"
             echo "generated_changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "generated_changed=false" >> "$GITHUB_OUTPUT"
+            CHANGED=$(git diff --name-only "$BASE"..HEAD)
+            if echo "$CHANGED" | grep -Eq '^(LeanEval/|EvalTools/|manifests/problems\.toml$|scripts/generate_projects\.py$|lakefile\.toml$|lean-toolchain$)'; then
+              echo "source_changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "source_changed=false" >> "$GITHUB_OUTPUT"
+            fi
+            if echo "$CHANGED" | grep -q '^generated/'; then
+              echo "generated_changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "generated_changed=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
+
+      - name: Regenerate workspaces from source
+        if: steps.changes.outputs.source_changed == 'true'
+        run: python scripts/generate_projects.py
 
       # Download Mathlib cache once in the first workspace, then hard-link
       # its .lake/packages tree into every other workspace so that each
       # subsequent `lake build` skips the ~2 GB download + decompression.
       - name: Prepare shared Mathlib cache for workspaces
-        if: steps.changes.outputs.generated_changed == 'true'
+        if: steps.changes.outputs.source_changed == 'true' || steps.changes.outputs.generated_changed == 'true'
         run: |
           set -euo pipefail
           FIRST=$(find generated -maxdepth 1 -mindepth 1 -type d -exec test -f '{}/lakefile.toml' \; -print | sort | head -1)
@@ -178,5 +189,5 @@ jobs:
           done
 
       - name: Build Generated Workspaces
-        if: steps.changes.outputs.generated_changed == 'true'
+        if: steps.changes.outputs.source_changed == 'true' || steps.changes.outputs.generated_changed == 'true'
         run: python scripts/check_generated_builds.py

--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -1,0 +1,49 @@
+name: Regenerate generated/ on main
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'LeanEval/**'
+      - 'EvalTools/**'
+      - 'manifests/problems.toml'
+      - 'scripts/generate_projects.py'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: regenerate-main
+  cancel-in-progress: false
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: leanprover/lean-action@v1
+        with:
+          use-mathlib-cache: true
+
+      - name: Regenerate
+        run: python scripts/generate_projects.py
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet generated/ && [ -z "$(git ls-files --others --exclude-standard generated/)" ]; then
+            echo "No changes to generated/."
+            exit 0
+          fi
+          git config user.name  "lean-eval-bot"
+          git config user.email "lean-eval-bot@users.noreply.github.com"
+          git add generated/
+          git commit -m "chore: regenerate generated/ workspaces"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The required fields are:
 - `theorem`
 - `submitter`
 
-### 4. Validate the authored source of truth
+### 4. Validate the authored source of truth (optional)
 
 ```bash
 lake exe lean-eval validate-manifest
@@ -80,40 +80,22 @@ lake exe lean-eval check-problem-build
 
 `validate-manifest` checks that `@[eval_problem]` declarations and manifest entries
 match. `check-problem-build` builds the problem modules so warning-producing Lean changes
-do not slip through.
+do not slip through. Both are cheap and catch the most common mistakes before a CI
+roundtrip.
 
-### 5. Regenerate comparator workspaces
+### 5. Open a PR
 
-Generate everything:
+That's it — push your branch and open a PR. CI regenerates the comparator workspaces
+under `generated/` and verifies they build, so you do not need to commit anything
+under `generated/` yourself. Once the PR merges, a separate workflow regenerates
+`generated/` on `main` and pushes the result.
 
-```bash
-lake exe lean-eval generate
-```
-
-Generate one problem only:
+If CI fails with a generation or build error, you'll need to fix the source. The
+fastest local equivalent is:
 
 ```bash
 lake exe lean-eval generate --problem my_new_problem
-```
-
-Check whether committed generated output is stale:
-
-```bash
-lake exe lean-eval generate --check
-```
-
-### 6. Build the generated workspaces
-
-For one workspace:
-
-```bash
 lake exe lean-eval check-generated-builds --problem my_new_problem
-```
-
-For all generated workspaces:
-
-```bash
-lake exe lean-eval check-generated-builds
 ```
 
 ## Quick Start For Solvers


### PR DESCRIPTION
This PR moves `generated/` from being a contributor-maintained tree to a build artifact maintained by automation, so adding a benchmark problem is just editing `LeanEval/` + `manifests/problems.toml` and pushing a PR.

Two pieces:

- A new `regenerate-main.yml` workflow on `push: branches: [main]` regenerates `generated/` and pushes the result. Runs only when source paths changed (paths filter), serialised via `concurrency: regenerate-main`, uses the default `GITHUB_TOKEN` for the same-repo push.
- `ci.yml` no longer fails PRs when committed `generated/` is stale. Instead it splits the change-detection into `source_changed` and `generated_changed` outputs; on source-touching PRs it regenerates the workspaces in the runner's working tree before running `check_generated_builds.py`. Solver PRs still build the committed tree as today.

`README.md` collapses the contributor's "regenerate workspaces" and "build the generated workspaces" steps into a single "open a PR" step.

Trade-off: between PR merge and the post-merge regen commit landing, `generated/` on `main` is one source-revision behind. That's acceptable for solvers.

Codex flagged several fatal issues with an earlier auto-commit-back-to-PR-branch design (GITHUB_TOKEN can't push to forks, `[skip ci]` semantics, races with `ci.yml`); this design avoids all of them by only pushing to `main` from a `push` event on the base repo.

🤖 Prepared with Claude Code