### PR TITLE
fix: retarget leaderboard repo to leanprover org

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -15,7 +15,7 @@ body:
         and tries every match it finds. That means all of these work:
 
         - a repo that is a single generated workspace
-        - a fork of `kim-em/lean-eval` with changes under `generated/`
+        - a fork of `leanprover/lean-eval` with changes under `generated/`
         - a repo that contains several workspaces side by side
         - a gist that contains a `lakefile.toml` and a `Submission.lean`
 

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -220,7 +220,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: kim-em/lean-eval-leaderboard
+          repository: leanprover/lean-eval-leaderboard
           token: ${{ secrets.LEADERBOARD_WRITE_TOKEN }}
           path: leaderboard
 

--- a/scripts/update_leaderboard.py
+++ b/scripts/update_leaderboard.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Merge comparator results into a clone of kim-em/lean-eval-leaderboard.
+Merge comparator results into a clone of leanprover/lean-eval-leaderboard.
 
 Implements the sticky-no-op semantics documented at
-https://github.com/kim-em/lean-eval-leaderboard (README, schema v1).
+https://github.com/leanprover/lean-eval-leaderboard (README, schema v1).
 Does not run git; the caller is responsible for cloning the leaderboard
 repo, committing the modified file, and pushing.
 """
@@ -164,7 +164,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--leaderboard-dir",
         required=True,
         type=pathlib.Path,
-        help="Path to a local clone of kim-em/lean-eval-leaderboard.",
+        help="Path to a local clone of leanprover/lean-eval-leaderboard.",
     )
     parser.add_argument(
         "--results-json",


### PR DESCRIPTION
This PR points the submission workflow's record step at \`leanprover/lean-eval-leaderboard\` instead of the old \`kim-em/lean-eval-leaderboard\` URL, plus refreshes the matching docstring/help/Issue Form references.

After the org migration to \`leanprover\`, the workflow's clone-and-push via the old URL fell back on GitHub's repo redirect, which doesn't carry write permission — every push attempt got \`remote: Permission to kim-em/lean-eval-leaderboard.git denied to kim-em\` (HTTP 403). Concretely, this caused the record job in https://github.com/leanprover/lean-eval/issues/30 to fail after fetch + evaluate succeeded; that submission had to be recorded by hand against the leaderboard.

⚠️ One extra step needed outside this PR: if \`LEADERBOARD_WRITE_TOKEN\` is a fine-grained PAT or App installation token still scoped to \`kim-em/lean-eval-leaderboard\`, it needs to be reissued / re-scoped against \`leanprover/lean-eval-leaderboard\` for this fix to actually take effect at runtime.

🤖 Prepared with Claude Code