### PR TITLE
test: smoke-test CI auto-regeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,37 @@ jobs:
       - name: Build Problem Modules
         run: python scripts/check_problem_build.py
 
+      # Decide whether to run workspace generation/build. Source-only PRs
+      # regenerate generated/ in the runner's working tree (the regenerate-main
+      # workflow is the only thing that commits generated/ to main); solver PRs
+      # build the committed tree as-is. Done early so that downstream steps
+      # which read generated/ (e.g. check_eval_workflow.py) see a tree that
+      # matches the source.
+      - name: Detect changes
+        id: changes
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "source_changed=true" >> "$GITHUB_OUTPUT"
+            echo "generated_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            CHANGED=$(git diff --name-only "$BASE"..HEAD)
+            if echo "$CHANGED" | grep -Eq '^(LeanEval/|EvalTools/|manifests/problems\.toml$|scripts/generate_projects\.py$|lakefile\.toml$|lean-toolchain$)'; then
+              echo "source_changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "source_changed=false" >> "$GITHUB_OUTPUT"
+            fi
+            if echo "$CHANGED" | grep -q '^generated/'; then
+              echo "generated_changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "generated_changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Regenerate workspaces from source
+        if: steps.changes.outputs.source_changed == 'true'
+        run: python scripts/generate_projects.py
+
       - name: Submission Policy Check
         run: python scripts/validate_submission.py --file generated/two_plus_two/Solution.lean
 
@@ -134,35 +165,6 @@ jobs:
 
       - name: Run Eval Workflow Check
         run: python scripts/check_eval_workflow.py
-
-      # Decide whether to run workspace generation/build. Source-only PRs
-      # regenerate generated/ in the runner's working tree (the regenerate-main
-      # workflow is the only thing that commits generated/ to main); solver PRs
-      # build the committed tree as-is.
-      - name: Detect changes
-        id: changes
-        run: |
-          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
-          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            echo "source_changed=true" >> "$GITHUB_OUTPUT"
-            echo "generated_changed=true" >> "$GITHUB_OUTPUT"
-          else
-            CHANGED=$(git diff --name-only "$BASE"..HEAD)
-            if echo "$CHANGED" | grep -Eq '^(LeanEval/|EvalTools/|manifests/problems\.toml$|scripts/generate_projects\.py$|lakefile\.toml$|lean-toolchain$)'; then
-              echo "source_changed=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "source_changed=false" >> "$GITHUB_OUTPUT"
-            fi
-            if echo "$CHANGED" | grep -q '^generated/'; then
-              echo "generated_changed=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "generated_changed=false" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
-      - name: Regenerate workspaces from source
-        if: steps.changes.outputs.source_changed == 'true'
-        run: python scripts/generate_projects.py
 
       # Download Mathlib cache once in the first workspace, then hard-link
       # its .lake/packages tree into every other workspace so that each

--- a/LeanEval/EasyProblems.lean
+++ b/LeanEval/EasyProblems.lean
@@ -50,6 +50,9 @@ Add a corresponding problem entry to the manifest.
 theorem eval_problem_inferable_implicit_guard {n : Nat} (h : n = n) : n = n := by
   exact h
 
+@[eval_problem]
+theorem ci_smoke_2026_04_30 : True := True.intro
+
 def starterNumber : Nat := 4
 
 end LeanEval

--- a/LeanEval/EasyProblems.lean
+++ b/LeanEval/EasyProblems.lean
@@ -51,7 +51,7 @@ theorem eval_problem_inferable_implicit_guard {n : Nat} (h : n = n) : n = n := b
   exact h
 
 @[eval_problem]
-theorem ci_smoke_2026_04_30 : True := True.intro
+theorem ci_smoke_2026_04_30 : True := by trivial
 
 def starterNumber : Nat := 4
 

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -12,6 +12,17 @@ source = "Internal starter problem."
 informal_solution = "By computation."
 
 [[problem]]
+id = "ci_smoke_2026_04_30"
+title = "CI smoke test"
+test = true
+module = "LeanEval.EasyProblems"
+theorem = "ci_smoke_2026_04_30"
+submitter = "Kim Morrison"
+notes = "Internal smoke test for the auto-regenerate CI; remove after verification."
+source = "Internal smoke test."
+informal_solution = "True is true."
+
+[[problem]]
 id = "list_append_singleton_length"
 title = "Appending a singleton increases the list length"
 test = true


### PR DESCRIPTION
This PR is a smoke test for the auto-regeneration CI shipped in https://github.com/leanprover/lean-eval/pull/31. It adds a trivial \`@[eval_problem] theorem ci_smoke_2026_04_30 : True := True.intro\` plus a matching manifest entry, with **no** \`generated/\` files committed, so the contributor experience is exercised end-to-end.

What I'm checking:

- PR \`verify\` job is green (the new \`Detect changes\` / \`Regenerate workspaces from source\` / \`Build Generated Workspaces\` steps).
- After merge, \`regenerate-main.yml\` fires and pushes a \`lean-eval-bot\` commit adding \`generated/ci_smoke_2026_04_30/\` and updating \`generated/index.json\`.

A follow-up PR will revert this once the workflows are confirmed working, exercising the prune-on-removal path.

🤖 Prepared with Claude Code