### PR TITLE
fix: rename CI check problem; disable regenerate-main push

### DIFF
--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -1,15 +1,12 @@
 name: Regenerate generated/ on main
 
+# DISABLED: GITHUB_TOKEN cannot push to main because of branch protection
+# (PRs required, "verify" status check required). A follow-up PR will switch
+# this workflow to mint an installation token from a dedicated GitHub App
+# whose principal is in the branch-protection bypass list, and re-enable the
+# push trigger.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'LeanEval/**'
-      - 'EvalTools/**'
-      - 'manifests/problems.toml'
-      - 'scripts/generate_projects.py'
-      - 'lakefile.toml'
-      - 'lean-toolchain'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/LeanEval/EasyProblems.lean
+++ b/LeanEval/EasyProblems.lean
@@ -51,7 +51,7 @@ theorem eval_problem_inferable_implicit_guard {n : Nat} (h : n = n) : n = n := b
   exact h
 
 @[eval_problem]
-theorem ci_smoke_2026_04_30 : True := by trivial
+theorem ci_regenerate_main_check : True := by trivial
 
 def starterNumber : Nat := 4
 

--- a/generated/ci_regenerate_main_check/Challenge.lean
+++ b/generated/ci_regenerate_main_check/Challenge.lean
@@ -1,0 +1,4 @@
+import Mathlib
+
+theorem ci_regenerate_main_check : True := by
+  sorry

--- a/generated/ci_regenerate_main_check/README.md
+++ b/generated/ci_regenerate_main_check/README.md
@@ -1,0 +1,25 @@
+# `ci_regenerate_main_check`
+
+CI regenerate-main check
+
+- Problem ID: `ci_regenerate_main_check`
+- Test Problem: yes
+- Submitter: Kim Morrison
+- Notes: Internal trivial problem used to exercise the regenerate-main workflow end-to-end.
+- Source: Internal CI check.
+- Informal solution: True is true.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+Write your solution in `Submission.lean` and any additional local modules under
+`Submission/`.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+Multi-file submissions are allowed through `Submission.lean` and additional local
+modules under `Submission/`.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/ci_regenerate_main_check/Solution.lean
+++ b/generated/ci_regenerate_main_check/Solution.lean
@@ -1,0 +1,5 @@
+import Mathlib
+import Submission
+
+theorem ci_regenerate_main_check : True := by
+  exact Submission.ci_regenerate_main_check

--- a/generated/ci_regenerate_main_check/Submission.lean
+++ b/generated/ci_regenerate_main_check/Submission.lean
@@ -1,0 +1,9 @@
+import Mathlib
+import Submission.Helpers
+
+namespace Submission
+
+theorem ci_regenerate_main_check : True := by
+  sorry
+
+end Submission

--- a/generated/ci_regenerate_main_check/Submission/Helpers.lean
+++ b/generated/ci_regenerate_main_check/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/ci_regenerate_main_check/WorkspaceTest.lean
+++ b/generated/ci_regenerate_main_check/WorkspaceTest.lean
@@ -1,0 +1,38 @@
+import Lean
+
+open Lean
+
+def comparatorExists (comparatorBin : String) : IO Bool := do
+  if comparatorBin.contains '/' then
+    return (← System.FilePath.pathExists comparatorBin)
+  try
+    let child ← IO.Process.spawn {
+      cmd := "sh"
+      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", comparatorBin]
+    }
+    let exitCode ← child.wait
+    return exitCode == 0
+  catch _ =>
+    return false
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  if !(← comparatorExists comparatorBin) then
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    pure 1
+  else
+    try
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, "config.json"]
+      }
+      let exitCode ← child.wait
+      pure exitCode
+    catch err =>
+      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+      IO.eprintln s!"Original error: {err}"
+      pure 1

--- a/generated/ci_regenerate_main_check/config.json
+++ b/generated/ci_regenerate_main_check/config.json
@@ -1,0 +1,13 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "ci_regenerate_main_check"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false
+}

--- a/generated/ci_regenerate_main_check/lakefile.toml
+++ b/generated/ci_regenerate_main_check/lakefile.toml
@@ -1,0 +1,24 @@
+name = "ci_regenerate_main_check"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/ci_regenerate_main_check/lean-toolchain
+++ b/generated/ci_regenerate_main_check/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/generated/index.json
+++ b/generated/index.json
@@ -9,6 +9,15 @@
     "generated_path": "generated/two_plus_two"
   },
   {
+    "id": "ci_regenerate_main_check",
+    "title": "CI regenerate-main check",
+    "test": true,
+    "submitter": "Kim Morrison",
+    "module": "LeanEval.EasyProblems",
+    "theorem": "ci_regenerate_main_check",
+    "generated_path": "generated/ci_regenerate_main_check"
+  },
+  {
     "id": "list_append_singleton_length",
     "title": "Appending a singleton increases the list length",
     "test": true,

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -12,14 +12,14 @@ source = "Internal starter problem."
 informal_solution = "By computation."
 
 [[problem]]
-id = "ci_smoke_2026_04_30"
-title = "CI smoke test"
+id = "ci_regenerate_main_check"
+title = "CI regenerate-main check"
 test = true
 module = "LeanEval.EasyProblems"
-theorem = "ci_smoke_2026_04_30"
+theorem = "ci_regenerate_main_check"
 submitter = "Kim Morrison"
-notes = "Internal smoke test for the auto-regenerate CI; remove after verification."
-source = "Internal smoke test."
+notes = "Internal trivial problem used to exercise the regenerate-main workflow end-to-end."
+source = "Internal CI check."
 informal_solution = "True is true."
 
 [[problem]]


### PR DESCRIPTION
This PR restores main to internal consistency after https://github.com/leanprover/lean-eval/pull/33. That PR added a CI check problem to source but the post-merge \`regenerate-main.yml\` workflow could not push the generated workspace to main because branch protection requires PRs and a passing \`verify\` status check, which \`GITHUB_TOKEN\`-authored pushes cannot satisfy.

This PR:

- Renames the CI check problem from \`ci_smoke_2026_04_30\` to \`ci_regenerate_main_check\`.
- Adds the previously-missing \`generated/ci_regenerate_main_check/\` workspace and updates \`generated/index.json\`.
- Switches \`regenerate-main.yml\` to \`workflow_dispatch\` only, with a comment recording the auth limitation. A follow-up PR will introduce a dedicated GitHub App whose principal is in the branch-protection bypass list, document it alongside the existing \`lean-eval-bot\` app, and re-enable the push trigger.

🤖 Prepared with Claude Code