### PR TITLE
doc: refresh PLAN.md to remaining work only

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,117 +1,44 @@
 # PLAN
 
-This file tracks the pieces that should be designed carefully rather than improvised in the
-first scaffold pass.
+This file tracks the pieces that should be designed carefully rather than improvised.
 
-## High-Priority Next Decisions
+## 1. Pin external versions
 
-### 1. Private Submission Service
+CI currently pulls several moving targets:
 
-The user asked to start at the "private submissions from day one" model instead of a
-public-only workflow.
+- `go install github.com/zouuup/landrun/cmd/landrun@main`
+  (in both `ci.yml` and `submission.yml`)
+- `jlumbroso/free-disk-space@main` (in `submission.yml`; `ci.yml` is on `@v1.3.1`)
+- comparator and `lean4export` are not pinned to specific revisions
 
-We need to design:
+Pick concrete versions, pin them, and write down the upgrade procedure.
 
-- how users authenticate
-- whether submissions arrive as private GitHub repos, patch bundles, or uploaded tarballs
-- how the service pins the benchmark base commit
-- how private evaluation workers are isolated
-- what proof artifacts are retained
-- what public metadata appears on the leaderboard
+## 2. Native-Lean migration of lean-eval tooling
 
-Recommended direction:
+The leaderboard *site* is native Lean, but the lean-eval-side tooling that
+produces the JSON it consumes is still Python:
 
-- start with GitHub-based private submissions against a pinned public base commit
-- require a commit SHA and a repository URL or installation-based access
-- evaluate in an isolated worker that checks changed files before any Lean build occurs
-- publish only score, model name, submission timestamp, and an optional paper/repo link
+- `scripts/generate_projects.py` — workspace generator
+- `scripts/evaluate_submission.py` — evaluation driver
+- `scripts/update_leaderboard.py` — result writer
+- `scripts/validate_submission.py` — submission shape check
+- `scripts/check_problem_build.py`, `check_generated_builds.py`,
+  `fetch_submission.py`, `run_eval.py`, `start_problem.py`
 
-### 2. Generator Output
+Migrate the remaining scripts so the entire toolchain lives inside `lake`.
 
-The generator emits one independent problem workspace per problem under `generated/`, and
-those workspaces are checked into the repo. Each workspace contains:
+## 3. Problem curation
 
-- `Challenge.lean`
-- `ChallengeDeps.lean`
-- `Solution.lean`
-- `Submission.lean`
-- `Submission/Helpers.lean`
-- `config.json`
-- `lakefile.toml`
-- `lean-toolchain`
-- `WorkspaceTest.lean`
-- `README.md`
+The repo currently ships ~33 workspaces across number theory, combinatorics,
+topology, complex analysis, group theory, convex geometry, linear algebra,
+algebraic geometry, differential geometry, and a couple of starter / hole
+examples.
 
-`lake test` invokes comparator; that is the canonical score check.
+Open work:
 
-Open questions:
-
-- Should we also generate a one-command "single problem starter repo" tarball or template,
-  beyond the existing `lake exe lean-eval start-problem` copy?
-- Should we expose a faster local pre-check in addition to comparator?
-
-### 3. Leaderboard Site
-
-We need a static or mostly-static leaderboard that supports:
-
-- overall score
-- solved-count view
-- per-problem breakdown
-- links to source and informal solution
-- model metadata
-- submission history
-
-Open questions:
-
-- static site generated from JSON, or a thin dynamic frontend backed by a database?
-- should failed private submissions remain entirely invisible, or show aggregate stats?
-
-Recommended direction:
-
-- JSON results artifacts checked into a separate public results repo or branch
-- static site generated from those artifacts
-
-## Problem Curation
-
-We should curate an initial batch of roughly 15 to 25 problems with:
-
-- broad topic coverage
-- statements already expressible in Mathlib
-- clear references
-- optional informal proof links
-- difficulty high enough that current frontier models do not saturate the benchmark
-
-Candidate families to investigate:
-
-- concrete algebra and number theory statements
-- equivalence theorems where the statement is compact but the formalization is nontrivial
-- results with published formalization-adjacent proofs that help humans but do not make the
-  Lean proof trivial
-
-The repository currently contains ~17 problems across number theory, combinatorics,
-topology, complex analysis, group theory, convex geometry, and linear algebra, plus the
-trivial starter `two_plus_two`. Further curation should fill gaps in topic coverage and
-difficulty distribution.
-
-## Immediate Follow-Up Work
-
-### Repo Scaffolding
-
-- add result schemas for per-problem and per-submission outputs
-- extend CI beyond the current repository health checks as the submission pipeline lands
-- continue migrating operational tooling from Python scripts to native Lean so manifest
-  validation, generation, submission checks, and scoring live inside the Lean toolchain
-  rather than behind Python wrappers (the `@[eval_problem]` attribute and manifest parser
-  are already native; generator, builder, and scorer are still Python shell-outs)
-
-### UX
-
-- decide whether participants work directly in this repo or in generated per-problem repos
-  when submitting (local workflow via `lake exe lean-eval start-problem` already exists)
-
-### Trust / Security
-
-- specify exactly when untrusted files may be read or built
-- pin comparator, `lean4export`, and `landrun` versions
-- decide whether we want optional nanoda checking enabled by default
-- document the exact threat model for the hosted submission service
+- audit topic coverage and difficulty distribution (we are already past the
+  original 15–25 problem target, so the question is which problems are
+  carrying their weight)
+- decide whether any problems are too easy or saturated by current frontier
+  models and should be retired or replaced
+- continue adding problems where we identify gaps


### PR DESCRIPTION
This PR refreshes PLAN.md so it only describes work that is still open. The previous version still framed the private submission service, generator workspaces, leaderboard site, and local participant UX as design questions; those are all in production. The new file is just three items: pinning external versions (landrun, comparator, lean4export, the @main GitHub Actions), migrating the lean-eval-side Python helper scripts to native Lean to match what the leaderboard repo already does, and a curation review of the existing problem set.

🤖 Prepared with Claude Code