### PR TITLE
feat: add Buzzard's Jacobian challenges and def-/instance-hole problem support

### DIFF
--- a/EvalTools/ExtractTheorem.lean
+++ b/EvalTools/ExtractTheorem.lean
@@ -19,6 +19,10 @@ structure ExtractedTheorem where
   uses introduced by typeclass synthesis (which the `.ilean` references metadata
   records as textual matches only). -/
   sameModuleDependencies : Array String
+  /-- One of `"theorem"` (covers `.thmInfo` and `.opaqueInfo`), `"def"`, or
+  `"instance"`. Drives whether the generator emits this hole in `theorem_names`
+  or `definition_names` in the comparator config. -/
+  kind : String
   deriving ToJson
 
 def parseName (text : String) : Name :=
@@ -92,17 +96,24 @@ def extractTheorem (moduleNameText declNameText : String) : IO ExtractedTheorem 
     endLine := declRanges.range.endPos.line
     endColumn := declRanges.range.endPos.column
   }
-  match constantInfo with
-  | .thmInfo _ | .opaqueInfo _ =>
+  let kind? : Option String := match constantInfo with
+    | .thmInfo _ | .opaqueInfo _ => some "theorem"
+    | .defnInfo _ =>
+        if Lean.Meta.isInstanceCore env resolvedDeclName then some "instance" else some "def"
+    | _ => none
+  match kind? with
+  | some kind =>
       let deps := collectSameModuleDependencies env moduleName resolvedDeclName
       return {
         declarationName := toString resolvedDeclName
         module := moduleNameText
         sourceRange := sourceRange
         sameModuleDependencies := deps.map toString
+        kind := kind
       }
-  | _ =>
-      throw <| IO.userError s!"Declaration '{resolvedDeclName}' is not a theorem or opaque theorem."
+  | none =>
+      throw <| IO.userError
+        s!"Declaration '{resolvedDeclName}' has unsupported kind for an eval-problem hole."
 
 def main (args : List String) : IO UInt32 := do
   let [moduleName, declName] := args

--- a/EvalTools/Main.lean
+++ b/EvalTools/Main.lean
@@ -199,7 +199,7 @@ def validateSubmissionCmd : Cmd := `[Cli|
 
 def checkEvalWorkflowCmd : Cmd := `[Cli|
   "check-eval-workflow" VIA runCheckEvalWorkflowCmd;
-  "Run the end-to-end local workflow smoke test."
+  "Run the end-to-end local workflow self-check."
 ]
 
 def leanEvalCmd : Cmd := `[Cli|

--- a/EvalTools/Markers.lean
+++ b/EvalTools/Markers.lean
@@ -17,7 +17,11 @@ structure EvalProblemMetadata where
   title : String
   test : Bool
   moduleName : String
-  theoremName : String
+  /-- The names of the `@[eval_problem]`-tagged declarations in `moduleName` that
+  comprise this problem; comparator's `theorem_names` and `definition_names`
+  are derived from this list (split by declaration kind). At least one entry
+  is required. -/
+  holes : Array String
   submitter : String
   notes : Option String := none
   source : Option String := none
@@ -48,7 +52,14 @@ instance : DecodeToml EvalProblemMetadata where
     let id ← requireNonempty "id" (← t.decode `id)
     let title ← requireNonempty "title" (← t.decode `title)
     let moduleName ← requireNonempty "module" (← t.decode `module)
-    let theoremName ← requireNonempty "theorem" (← t.decode `theorem)
+    let holes : Array String ← t.decode `holes
+    if holes.isEmpty then
+      throwDecodeErrorAt Syntax.missing
+        s!"Manifest entry `{id}` has empty `holes` array; list at least one declaration."
+    for h in holes do
+      if h.isEmpty then
+        throwDecodeErrorAt Syntax.missing
+          s!"Manifest entry `{id}` has an empty string in `holes`."
     let submitter ← requireNonempty "submitter" (← t.decode `submitter)
     let notes? : Option String ← t.decode? `notes
     let source? : Option String ← t.decode? `source
@@ -58,7 +69,7 @@ instance : DecodeToml EvalProblemMetadata where
       title := title
       test := ← t.decode `test
       moduleName := moduleName
-      theoremName := theoremName
+      holes := holes
       submitter := submitter
       notes := notes?.bind fun s => if s.isEmpty then none else some s
       source := source?.bind fun s => if s.isEmpty then none else some s
@@ -94,11 +105,12 @@ def parseManifestMetadata (contents : String) (fileName : String := manifestRela
     if seenIds.contains metadata.id then
       return Except.error s!"Duplicate problem id `{metadata.id}` in `manifests/problems.toml`."
     seenIds := seenIds.insert metadata.id
-    let theoremKey := (metadata.moduleName, metadata.theoremName)
-    if seenRefs.contains theoremKey then
-      return Except.error
-        s!"Duplicate theorem reference `{metadata.moduleName}:{metadata.theoremName}` in `manifests/problems.toml`."
-    seenRefs := seenRefs.insert theoremKey
+    for hole in metadata.holes do
+      let key := (metadata.moduleName, hole)
+      if seenRefs.contains key then
+        return Except.error
+          s!"Duplicate hole reference `{metadata.moduleName}:{hole}` in `manifests/problems.toml`."
+      seenRefs := seenRefs.insert key
     entries := entries.push metadata
   return Except.ok entries
 
@@ -107,20 +119,20 @@ def moduleNameForDecl (env : Environment) (declName : Name) : String :=
   | some idx => toString <| env.header.moduleNames[idx.toNat]!
   | none => toString env.mainModule
 
-def theoremMatches (declName : Name) (theoremField : String) : Bool :=
-  theoremField == declName.toString || theoremField == declName.getString!
+def holeMatches (declName : Name) (holeField : String) : Bool :=
+  holeField == declName.toString || holeField == declName.getString!
 
 def validateMatchingManifestEntry
     (declName : Name) (entries : Array EvalProblemMetadata) (moduleName : String) :
     Except String EvalProblemMetadata := do
   let matchingEntries := entries.filter fun entry =>
-    entry.moduleName == moduleName && theoremMatches declName entry.theoremName
+    entry.moduleName == moduleName && entry.holes.any (holeMatches declName ·)
   if matchingEntries.isEmpty then
     throw
-      s!"The theorem `{declName}` is marked with @[eval_problem], but `manifests/problems.toml` has no matching `theorem = ...` entry.\nAdd a corresponding problem entry to the manifest."
+      s!"The declaration `{declName}` is marked with @[eval_problem], but no entry in `manifests/problems.toml` lists it in `holes`.\nAdd a corresponding problem entry to the manifest."
   if matchingEntries.size > 1 then
     throw
-      s!"The theorem `{declName}` is marked with @[eval_problem], but `manifests/problems.toml` has multiple matching entries in module `{moduleName}`."
+      s!"The declaration `{declName}` is marked with @[eval_problem], but `manifests/problems.toml` has multiple matching entries in module `{moduleName}`."
   match matchingEntries[0]? with
   | some metadata => return metadata
   | none => throw "internal error: missing manifest entry after nonempty match set"
@@ -134,7 +146,7 @@ def formatManifestHover (metadata : EvalProblemMetadata) : String :=
       s!"- title: {metadata.title}",
       s!"- test: `{metadata.test}`",
       s!"- module: `{metadata.moduleName}`",
-      s!"- theorem: `{metadata.theoremName}`",
+      s!"- holes: {", ".intercalate (metadata.holes.toList.map (s!"`{·}`"))}",
       s!"- submitter: {metadata.submitter}"
     ]
     if let some notes := metadata.notes then
@@ -253,9 +265,14 @@ def ensureEvalProblemManifestEntry (declName : Name) : AttrM EvalProblemMetadata
       validateEvalProblemBinders declName info.type
   | some (.opaqueInfo info) =>
       validateEvalProblemBinders declName info.type
+  | some (.defnInfo _) =>
+      -- Definition / instance holes: comparator only checks name, type, universe
+      -- levels, and safety of the hole, so the binder-shape restriction we
+      -- impose on theorems (so they can be applied positionally) does not apply.
+      pure ()
   | _ =>
       throwError
-        "The attribute @[eval_problem] may only be applied to theorem or opaque theorem declarations, but `{declName}` is not one."
+        "The attribute @[eval_problem] may only be applied to theorem, opaque, def, or instance declarations, but `{declName}` is not one."
   let cwd ← IO.currentDir
   let some manifestPath ← findManifestPath? cwd
     | throwError

--- a/EvalTools/ProblemInventory.lean
+++ b/EvalTools/ProblemInventory.lean
@@ -7,6 +7,10 @@ structure InventoryEntry where
   module : String
   declarationName : String
   basename : String
+  /-- One of `"theorem"` (covers `.thmInfo` and `.opaqueInfo`), `"def"`, or
+  `"instance"`. The Python generator uses this to split holes between
+  `theorem_names` and `definition_names` in the comparator config. -/
+  kind : String
   deriving ToJson
 
 def parseName (text : String) : Name :=
@@ -26,14 +30,20 @@ def inventoryForModule (env : Environment) (moduleName : Name) : Array Inventory
         let mut entries := #[]
         for (declName, constantInfo) in env.constants do
           if env.getModuleIdxFor? declName == some moduleIdx && EvalTools.hasEvalProblemTag env declName then
-            match constantInfo with
-            | .thmInfo _ | .opaqueInfo _ =>
+            let kind? : Option String := match constantInfo with
+              | .thmInfo _ | .opaqueInfo _ => some "theorem"
+              | .defnInfo _ =>
+                  if Lean.Meta.isInstanceCore env declName then some "instance" else some "def"
+              | _ => none
+            match kind? with
+            | some kind =>
                 entries := entries.push {
                   module := toString moduleName
                   declarationName := toString declName
                   basename := lastComponent declName
+                  kind := kind
                 }
-            | _ => panic! s!"@[eval_problem] used on non-theorem declaration '{declName}'"
+            | none => panic! s!"@[eval_problem] used on unsupported declaration kind for '{declName}'"
         entries
 
 def main (args : List String) : IO UInt32 := do

--- a/LeanEval/AlgebraicGeometry/JacobianChallenge.lean
+++ b/LeanEval/AlgebraicGeometry/JacobianChallenge.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib
+import EvalTools.Markers
+
+/-!
+# Jacobians in algebraic geometry
+
+Christian Merten's algebraic-geometry analogue of Kevin Buzzard's Jacobian
+challenge, posted to leanprover Zulip:
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685>.
+
+In the following, by a smooth curve we mean a geometrically irreducible, smooth scheme of relative
+dimension one over a field.
+
+## Main missing definitions
+
+* `AlgebraicGeometry.JacobianChallenge.genus` -- genus of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian` -- the Jacobian of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve` -- the Abel-Jacobi map from a proper smooth
+  curve to its Jacobian
+
+## Main missing theorems
+
+* `Jacobian.smoothOfRelativeDimension_genus` -- The Jacobian of a proper, smooth curve `C` is smooth
+  of relative dimension `g`, where `g` is the genus of `C`.
+* `Jacobian.exists_unique_ofCurve_comp` -- the universal property of the Jacobian of a proper,
+  smooth curve.
+-/
+
+set_option autoImplicit false
+
+universe u
+
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory MonObj
+
+namespace AlgebraicGeometry
+
+namespace JacobianChallenge
+
+-- We make `C` implicit at the variable level so that instance and `def` holes
+-- whose statement references the outer `C` (e.g. `instance instGrpObj :
+-- GrpObj (Jacobian C) := sorry`) elaborate to a Π-type with `{C}` implicit;
+-- otherwise the eval-pipeline's `Solution.lean` would have to thread a `C`
+-- argument through every delegation. Decls that genuinely need `C` explicit
+-- (e.g. `genus`, `Jacobian`, `comp_ofCurve`) supply their own `(C : ...)`
+-- binder.
+variable {k : Type u} [Field k] {C : Over (Spec (.of k))}
+  -- smooth curve
+  [SmoothOfRelativeDimension 1 C.hom]
+  -- proper
+  [IsProper C.hom]
+  -- geometrically irreducible
+  [GeometricallyIrreducible C.hom]
+
+-- data
+/-- The genus of a smooth proper curve. -/
+@[eval_problem]
+def genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : ℕ :=
+  sorry
+
+-- data
+/-- The Jacobian of a smooth, proper curve over a field `k`. -/
+@[eval_problem]
+def Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : Over (Spec (.of k)) :=
+  sorry
+
+namespace Jacobian
+
+/-! ## The Jacobian of `C` is an abelian variety. -/
+
+-- data
+/-- The group scheme structure on the Jacobian of the curve `C`. -/
+@[eval_problem]
+instance instGrpObj : GrpObj (Jacobian C) :=
+  sorry
+
+/-- The Jacobian of `C` is smooth of relative dimension `g` over `k`, where `g` is the
+genus of `C`. -/
+@[eval_problem]
+instance smoothOfRelativeDimension_genus :
+    SmoothOfRelativeDimension (genus C) (Jacobian C).hom :=
+  sorry
+
+/-- The Jacobian of `C` is proper over `k`. -/
+@[eval_problem]
+instance instIsProper : IsProper (Jacobian C).hom :=
+  sorry
+
+/-- The Jacobian of `C` is geometrically irreducible over `k`. -/
+@[eval_problem]
+instance instGeometricallyIrreducible : GeometricallyIrreducible (Jacobian C).hom :=
+  sorry
+
+-- data
+/-- The Abel-Jacobi map from a smooth, proper curve to its Jacobian associated
+to a `k`-rational point of `C`. -/
+@[eval_problem]
+def ofCurve (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) : C ⟶ Jacobian C :=
+  sorry
+
+/-- The Abel-Jacobi map sends the `k`-rational point `P` to `0`, where `0` (denoted by `η` below) is
+the neutral element of the group scheme `Jacobian C`. -/
+@[eval_problem]
+theorem comp_ofCurve (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) :
+    P ≫ ofCurve P = η[Jacobian C] :=
+  sorry
+
+/--
+The universal property of the Jacobian variety: For any abelian variety `A`,
+any morphism `f : C ⟶ A` such that `f(P) = 0` factors uniquely through the
+Jacobian of `C`.
+In other words, `Jacobian C` is the Albanese variety of `C`.
+-/
+@[eval_problem]
+theorem exists_unique_ofCurve_comp (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C)
+    {A : Over (Spec (.of k))} [Smooth A.hom] [IsProper A.hom] [GrpObj A]
+    [GeometricallyIrreducible A.hom] (f : C ⟶ A) (hf : P ≫ f = η[A]) :
+    ∃! (g : Jacobian C ⟶ A), f = ofCurve P ≫ g :=
+  sorry
+
+end Jacobian
+
+end JacobianChallenge
+
+end AlgebraicGeometry

--- a/LeanEval/EasyProblems.lean
+++ b/LeanEval/EasyProblems.lean
@@ -20,7 +20,7 @@ theorem list_append_singleton_length :
   sorry
 
 /--
-error: The theorem `LeanEval.eval_problem_manifest_guard` is marked with @[eval_problem], but `manifests/problems.toml` has no matching `theorem = ...` entry.
+error: The declaration `LeanEval.eval_problem_manifest_guard` is marked with @[eval_problem], but no entry in `manifests/problems.toml` lists it in `holes`.
 Add a corresponding problem entry to the manifest.
 -/
 #guard_msgs in
@@ -42,7 +42,7 @@ theorem eval_problem_implicit_binder_guard {n : Nat} [NeZero n] : True := by
   trivial
 
 /--
-error: The theorem `LeanEval.eval_problem_inferable_implicit_guard` is marked with @[eval_problem], but `manifests/problems.toml` has no matching `theorem = ...` entry.
+error: The declaration `LeanEval.eval_problem_inferable_implicit_guard` is marked with @[eval_problem], but no entry in `manifests/problems.toml` lists it in `holes`.
 Add a corresponding problem entry to the manifest.
 -/
 #guard_msgs in

--- a/LeanEval/Geometry/JacobianChallenge.lean
+++ b/LeanEval/Geometry/JacobianChallenge.lean
@@ -1,0 +1,179 @@
+import Mathlib
+import EvalTools.Markers
+
+/-!
+# Jacobians of compact Riemann surfaces
+
+Kevin Buzzard's "Jacobian Challenge" v0.3, posted to leanprover Zulip
+(`#Autoformalization > Jacobian challenge`):
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge>.
+The original source uses anonymous instances; here every `instance` is
+named explicitly so the eval-problem pipeline can address it.
+
+## Main missing definitions
+
+* `genus` -- genus of a compact Riemann surface
+* `Jacobian` -- the Jacobian of a compact Riemann surface
+* `Jacobian.ofCurve` -- the Abel-Jacobi map from a compact Riemann surface to its Jacobian
+* `ContMDiff.degree` -- the degree of a holomorphic map between compact Riemann surfaces.
+    Equal to 0 if the map is constant, otherwise equal to the usual degree.
+* `Jacobian.pushforward` -- the pushforward map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+* `Jacobian.pullback` -- the pullback map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+
+## Main missing theorems
+
+* `genus_eq_zero_iff_homeo` -- a compact Riemann surface has genus 0 iff it is homeomorphic to the sphere
+* `ofCurve_inj` -- the Abel-Jacobi map is injective iff the genus is positive
+* `Jacobian.ofCurve_contMDiff` -- the Abel-Jacobi map is holomorphic
+* `Jacobian.pushforward_contMDiff` -- the pushforward map is holomorphic
+* `Jacobian.pullback_contMDiff` -- the pullback map is holomorphic
+* `pushforward_pullback` -- pullback then pushforward is multiplication by degree
+-/
+
+open scoped ContDiff -- for ω notation
+
+namespace JacobianChallenge
+
+universe u v w
+
+-- let X be a compact Riemann surface
+variable {X : Type u} [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+  [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X]
+
+-- data
+@[eval_problem]
+def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : ℕ := sorry
+
+-- this proof avoids the hack answer `∀ X, genus X = 0`
+-- Prop
+@[eval_problem]
+theorem genus_eq_zero_iff_homeo :
+    genus X = 0 ↔ Nonempty (X ≃ₜ (Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1)) :=
+  sorry
+
+-- data
+@[eval_problem]
+def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : Type u := sorry
+
+namespace Jacobian
+
+-- data
+@[eval_problem]
+instance instAddCommGroup : AddCommGroup (Jacobian X) := sorry
+
+-- data
+@[eval_problem]
+instance instTopologicalSpace : TopologicalSpace (Jacobian X) := sorry
+
+-- Prop
+@[eval_problem]
+instance instT2Space : T2Space (Jacobian X) := sorry
+
+-- Prop
+@[eval_problem]
+instance instCompactSpace : CompactSpace (Jacobian X) := sorry
+
+@[eval_problem]
+instance instChartedSpace : ChartedSpace (Fin (genus X) → ℂ) (Jacobian X) := sorry
+
+-- Prop
+@[eval_problem]
+instance instIsManifold :
+    IsManifold (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+
+-- Prop
+@[eval_problem]
+instance instLieAddGroup :
+    LieAddGroup (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+
+@[eval_problem]
+def ofCurve (P : X) : X → Jacobian X := sorry
+
+@[eval_problem]
+theorem ofCurve_contMDiff (P : X) :
+    ContMDiff (modelWithCornersSelf ℂ ℂ)
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (ofCurve P) := sorry
+
+@[eval_problem]
+theorem ofCurve_self (P : X) : ofCurve P P = 0 := sorry
+
+-- this is the lemma which stops the hack answer "J(X)=0 for all X"
+@[eval_problem]
+theorem ofCurve_inj (P : X) (h : 0 < genus X) : Function.Injective (ofCurve P) := sorry
+
+variable {Y : Type v} [TopologicalSpace Y] [T2Space Y] [CompactSpace Y] [ConnectedSpace Y]
+  [Nonempty Y] [ChartedSpace ℂ Y] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Y]
+
+variable (f : X → Y) (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+
+@[eval_problem]
+def pushforward (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian X →ₜ+ Jacobian Y := sorry
+
+@[eval_problem]
+theorem pushforward_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus X) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ)) ω (pushforward f hf) := sorry
+
+-- functoriality
+@[eval_problem]
+theorem pushforward_id_apply (P : Jacobian X) :
+    pushforward id contMDiff_id P = P := sorry
+
+variable {Z : Type w} [TopologicalSpace Z] [T2Space Z] [CompactSpace Z] [ConnectedSpace Z]
+  [Nonempty Z] [ChartedSpace ℂ Z] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Z]
+
+variable (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+
+@[eval_problem]
+theorem pushforward_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian X) :
+    pushforward (g ∘ f) (hg.comp hf) P = pushforward g hg (pushforward f hf P) :=
+  sorry
+
+-- if f is constant then the pullback should be the zero map, otherwise it's
+-- the usual pullback
+@[eval_problem]
+def pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian Y →ₜ+ Jacobian X := sorry
+
+@[eval_problem]
+theorem pullback_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (pullback f hf) := sorry
+
+@[eval_problem]
+theorem pullback_id_apply (P : Jacobian X) :
+    pullback id contMDiff_id P = P := sorry
+
+@[eval_problem]
+theorem pullback_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian Z) :
+    pullback (g.comp f) (hg.comp hf) P = pullback f hf (pullback g hg P) := sorry
+
+@[eval_problem]
+def degree (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) : ℕ :=
+  sorry -- 0 for constant case
+
+@[eval_problem]
+theorem pushforward_pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (P : Jacobian Y) :
+    pushforward f hf (pullback f hf P) = (degree f hf) • P := sorry
+
+end Jacobian
+
+end JacobianChallenge

--- a/LeanEval/Sandbox/DefHoleExample.lean
+++ b/LeanEval/Sandbox/DefHoleExample.lean
@@ -1,0 +1,16 @@
+import Mathlib
+import EvalTools.Markers
+
+/-!
+Minimal example exercising the def-hole / multi-hole eval-problem pipeline.
+
+A `def` and a `theorem` referring to it, both `sorry`. A submission
+defines `Submission.foo := 37` and proves `Submission.foo_def`; comparator
+should accept it.
+-/
+
+@[eval_problem]
+def foo : Nat := sorry
+
+@[eval_problem]
+theorem foo_def : foo = 37 := sorry

--- a/LeanEval/Sandbox/InstanceHoleExample.lean
+++ b/LeanEval/Sandbox/InstanceHoleExample.lean
@@ -1,0 +1,15 @@
+import Mathlib
+import EvalTools.Markers
+
+/-!
+Minimal example exercising `instance` holes in the multi-hole
+eval-problem pipeline. The carrier type is itself a hole so the source
+has no non-hole declarations and the generator does not need a
+`ChallengeDeps` split.
+-/
+
+@[eval_problem]
+def WidgetCarrier : Type := sorry
+
+@[eval_problem]
+instance instInhabitedWidget : Inhabited WidgetCarrier := sorry

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,117 +1,44 @@
 # PLAN
 
-This file tracks the pieces that should be designed carefully rather than improvised in the
-first scaffold pass.
+This file tracks the pieces that should be designed carefully rather than improvised.
 
-## High-Priority Next Decisions
+## 1. Pin external versions
 
-### 1. Private Submission Service
+CI currently pulls several moving targets:
 
-The user asked to start at the "private submissions from day one" model instead of a
-public-only workflow.
+- `go install github.com/zouuup/landrun/cmd/landrun@main`
+  (in both `ci.yml` and `submission.yml`)
+- `jlumbroso/free-disk-space@main` (in `submission.yml`; `ci.yml` is on `@v1.3.1`)
+- comparator and `lean4export` are not pinned to specific revisions
 
-We need to design:
+Pick concrete versions, pin them, and write down the upgrade procedure.
 
-- how users authenticate
-- whether submissions arrive as private GitHub repos, patch bundles, or uploaded tarballs
-- how the service pins the benchmark base commit
-- how private evaluation workers are isolated
-- what proof artifacts are retained
-- what public metadata appears on the leaderboard
+## 2. Native-Lean migration of lean-eval tooling
 
-Recommended direction:
+The leaderboard *site* is native Lean, but the lean-eval-side tooling that
+produces the JSON it consumes is still Python:
 
-- start with GitHub-based private submissions against a pinned public base commit
-- require a commit SHA and a repository URL or installation-based access
-- evaluate in an isolated worker that checks changed files before any Lean build occurs
-- publish only score, model name, submission timestamp, and an optional paper/repo link
+- `scripts/generate_projects.py` — workspace generator
+- `scripts/evaluate_submission.py` — evaluation driver
+- `scripts/update_leaderboard.py` — result writer
+- `scripts/validate_submission.py` — submission shape check
+- `scripts/check_problem_build.py`, `check_generated_builds.py`,
+  `fetch_submission.py`, `run_eval.py`, `start_problem.py`
 
-### 2. Generator Output
+Migrate the remaining scripts so the entire toolchain lives inside `lake`.
 
-The generator emits one independent problem workspace per problem under `generated/`, and
-those workspaces are checked into the repo. Each workspace contains:
+## 3. Problem curation
 
-- `Challenge.lean`
-- `ChallengeDeps.lean`
-- `Solution.lean`
-- `Submission.lean`
-- `Submission/Helpers.lean`
-- `config.json`
-- `lakefile.toml`
-- `lean-toolchain`
-- `WorkspaceTest.lean`
-- `README.md`
+The repo currently ships ~33 workspaces across number theory, combinatorics,
+topology, complex analysis, group theory, convex geometry, linear algebra,
+algebraic geometry, differential geometry, and a couple of starter / hole
+examples.
 
-`lake test` invokes comparator; that is the canonical score check.
+Open work:
 
-Open questions:
-
-- Should we also generate a one-command "single problem starter repo" tarball or template,
-  beyond the existing `lake exe lean-eval start-problem` copy?
-- Should we expose a faster local pre-check in addition to comparator?
-
-### 3. Leaderboard Site
-
-We need a static or mostly-static leaderboard that supports:
-
-- overall score
-- solved-count view
-- per-problem breakdown
-- links to source and informal solution
-- model metadata
-- submission history
-
-Open questions:
-
-- static site generated from JSON, or a thin dynamic frontend backed by a database?
-- should failed private submissions remain entirely invisible, or show aggregate stats?
-
-Recommended direction:
-
-- JSON results artifacts checked into a separate public results repo or branch
-- static site generated from those artifacts
-
-## Problem Curation
-
-We should curate an initial batch of roughly 15 to 25 problems with:
-
-- broad topic coverage
-- statements already expressible in Mathlib
-- clear references
-- optional informal proof links
-- difficulty high enough that current frontier models do not saturate the benchmark
-
-Candidate families to investigate:
-
-- concrete algebra and number theory statements
-- equivalence theorems where the statement is compact but the formalization is nontrivial
-- results with published formalization-adjacent proofs that help humans but do not make the
-  Lean proof trivial
-
-The repository currently contains ~17 problems across number theory, combinatorics,
-topology, complex analysis, group theory, convex geometry, and linear algebra, plus the
-trivial starter `two_plus_two`. Further curation should fill gaps in topic coverage and
-difficulty distribution.
-
-## Immediate Follow-Up Work
-
-### Repo Scaffolding
-
-- add result schemas for per-problem and per-submission outputs
-- extend CI beyond the current repository health checks as the submission pipeline lands
-- continue migrating operational tooling from Python scripts to native Lean so manifest
-  validation, generation, submission checks, and scoring live inside the Lean toolchain
-  rather than behind Python wrappers (the `@[eval_problem]` attribute and manifest parser
-  are already native; generator, builder, and scorer are still Python shell-outs)
-
-### UX
-
-- decide whether participants work directly in this repo or in generated per-problem repos
-  when submitting (local workflow via `lake exe lean-eval start-problem` already exists)
-
-### Trust / Security
-
-- specify exactly when untrusted files may be read or built
-- pin comparator, `lean4export`, and `landrun` versions
-- decide whether we want optional nanoda checking enabled by default
-- document the exact threat model for the hosted submission service
+- audit topic coverage and difficulty distribution (we are already past the
+  original 15–25 problem target, so the question is which problems are
+  carrying their weight)
+- decide whether any problems are too easy or saturated by current frontier
+  models and should be retired or replaced
+- continue adding problems where we identify gaps

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Current source modules live in topic folders such as:
 
 ### 3. Add the manifest entry
 
-Each tagged theorem must have exactly one matching entry in
-[`manifests/problems.toml`](/home/kim/lean-evals/manifests/problems.toml).
+Each tagged declaration must be listed by exactly one entry in
+[`manifests/problems.toml`](manifests/problems.toml). The `holes` array
+names every `@[eval_problem]`-tagged declaration in the module that the
+problem owns; for the common single-theorem case it has one element.
 
 ```toml
 [[problem]]
@@ -55,7 +57,7 @@ id = "my_new_problem"
 title = "My new problem"
 test = false
 module = "LeanEval.SomeModule"
-theorem = "my_new_problem"
+holes = ["my_new_problem"]
 submitter = "Your Name"
 notes = "Optional notes."
 source = "Optional citation or URL."
@@ -68,8 +70,28 @@ The required fields are:
 - `title`
 - `test`
 - `module`
-- `theorem`
+- `holes`
 - `submitter`
+
+#### Multi-hole problems
+
+A problem may bundle several `def`s, `instance`s and `theorem`s — list
+them all in `holes`. Comparator then asks the participant to fill every
+listed declaration in their `Submission.lean`. Two conventions:
+
+- **Name every instance.** The generator addresses holes by their
+  declaration name, and Lean's auto-generated names for anonymous
+  `instance`s (e.g. `instTopologicalSpaceJacobian`) are not stable. Use
+  `instance instAddCommGroup : ... := sorry` rather than `instance : ...
+  := sorry`.
+- **Use `holes` even for one declaration.** There is no `theorem = "..."`
+  shorthand; a singleton hole is just `holes = ["my_thm"]`.
+
+See [`LeanEval/Sandbox/DefHoleExample.lean`](LeanEval/Sandbox/DefHoleExample.lean)
+and [`LeanEval/Sandbox/InstanceHoleExample.lean`](LeanEval/Sandbox/InstanceHoleExample.lean)
+for the smallest working examples, or
+[`LeanEval/Geometry/JacobianChallenge.lean`](LeanEval/Geometry/JacobianChallenge.lean)
+for a realistic multi-hole problem.
 
 ### 4. Validate the authored source of truth (optional)
 
@@ -239,7 +261,7 @@ lake exe lean-eval check-generated-builds
 lake exe lean-eval run-eval
 ```
 
-There is also an end-to-end workflow smoke test:
+There is also an end-to-end workflow self-check:
 
 ```bash
 lake exe lean-eval check-eval-workflow

--- a/generated/def_hole_example/Challenge.lean
+++ b/generated/def_hole_example/Challenge.lean
@@ -1,0 +1,10 @@
+import Mathlib
+/-!
+Minimal example exercising the def-hole / multi-hole eval-problem pipeline.
+
+A `def` and a `theorem` referring to it, both `sorry`. A submission
+defines `Submission.foo := 37` and proves `Submission.foo_def`; comparator
+should accept it.
+-/
+def foo : Nat := sorry
+theorem foo_def : foo = 37 := sorry

--- a/generated/def_hole_example/README.md
+++ b/generated/def_hole_example/README.md
@@ -1,0 +1,23 @@
+# `def_hole_example`
+
+def-hole minimal example
+
+- Problem ID: `def_hole_example`
+- Test Problem: yes
+- Submitter: Kim Morrison
+- Holes (2): `foo` (def), `foo_def` (theorem)
+- Notes: Minimal example exercising def + theorem holes through the comparator def-hole pipeline.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+This is a multi-hole problem: the challenge declares multiple `def`s,
+`instance`s, and/or `theorem`s as `sorry`. Fill all of them in
+`Submission.lean` (under `namespace Submission`) for comparator to accept
+your solution.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/def_hole_example/Solution.lean
+++ b/generated/def_hole_example/Solution.lean
@@ -1,0 +1,13 @@
+import Mathlib
+import Submission
+/-!
+Minimal example exercising the def-hole / multi-hole eval-problem pipeline.
+
+A `def` and a `theorem` referring to it, both `sorry`. A submission
+defines `Submission.foo := 37` and proves `Submission.foo_def`; comparator
+should accept it.
+-/
+
+@[reducible] def foo : Nat := Submission.foo
+
+theorem foo_def : foo = 37 := Submission.foo_def

--- a/generated/def_hole_example/Submission.lean
+++ b/generated/def_hole_example/Submission.lean
@@ -1,0 +1,16 @@
+import Mathlib
+import Submission.Helpers
+/-!
+Minimal example exercising the def-hole / multi-hole eval-problem pipeline.
+
+A `def` and a `theorem` referring to it, both `sorry`. A submission
+defines `Submission.foo := 37` and proves `Submission.foo_def`; comparator
+should accept it.
+-/
+
+namespace Submission
+
+def foo : Nat := sorry
+theorem foo_def : foo = 37 := sorry
+
+end Submission

--- a/generated/def_hole_example/Submission/Helpers.lean
+++ b/generated/def_hole_example/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/def_hole_example/WorkspaceTest.lean
+++ b/generated/def_hole_example/WorkspaceTest.lean
@@ -1,0 +1,38 @@
+import Lean
+
+open Lean
+
+def comparatorExists (comparatorBin : String) : IO Bool := do
+  if comparatorBin.contains '/' then
+    return (← System.FilePath.pathExists comparatorBin)
+  try
+    let child ← IO.Process.spawn {
+      cmd := "sh"
+      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", comparatorBin]
+    }
+    let exitCode ← child.wait
+    return exitCode == 0
+  catch _ =>
+    return false
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  if !(← comparatorExists comparatorBin) then
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    pure 1
+  else
+    try
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, "config.json"]
+      }
+      let exitCode ← child.wait
+      pure exitCode
+    catch err =>
+      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+      IO.eprintln s!"Original error: {err}"
+      pure 1

--- a/generated/def_hole_example/config.json
+++ b/generated/def_hole_example/config.json
@@ -1,0 +1,16 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "foo_def"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false,
+  "definition_names": [
+    "foo"
+  ]
+}

--- a/generated/def_hole_example/lakefile.toml
+++ b/generated/def_hole_example/lakefile.toml
@@ -1,0 +1,24 @@
+name = "def_hole_example"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/def_hole_example/lean-toolchain
+++ b/generated/def_hole_example/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/generated/index.json
+++ b/generated/index.json
@@ -5,7 +5,9 @@
     "test": true,
     "submitter": "Kim Morrison",
     "module": "LeanEval.EasyProblems",
-    "theorem": "two_plus_two_eq_four",
+    "holes": [
+      "two_plus_two_eq_four"
+    ],
     "generated_path": "generated/two_plus_two"
   },
   {
@@ -14,7 +16,9 @@
     "test": true,
     "submitter": "Kim Morrison",
     "module": "LeanEval.EasyProblems",
-    "theorem": "ci_regenerate_main_check",
+    "holes": [
+      "ci_regenerate_main_check"
+    ],
     "generated_path": "generated/ci_regenerate_main_check"
   },
   {
@@ -23,7 +27,9 @@
     "test": true,
     "submitter": "Kim Morrison",
     "module": "LeanEval.EasyProblems",
-    "theorem": "list_append_singleton_length",
+    "holes": [
+      "list_append_singleton_length"
+    ],
     "generated_path": "generated/list_append_singleton_length"
   },
   {
@@ -32,7 +38,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Analysis.Chudnovsky",
-    "theorem": "chudnovsky_formula_for_pi_inv",
+    "holes": [
+      "chudnovsky_formula_for_pi_inv"
+    ],
     "generated_path": "generated/chudnovsky_formula_for_pi_inv"
   },
   {
@@ -41,7 +49,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Topology.HomotopyGroups",
-    "theorem": "pi1_circle_mulEquiv_int",
+    "holes": [
+      "pi1_circle_mulEquiv_int"
+    ],
     "generated_path": "generated/pi1_circle_mulEquiv_int"
   },
   {
@@ -50,7 +60,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Combinatorics.Ramsey",
-    "theorem": "finite_graph_ramsey_theorem",
+    "holes": [
+      "finite_graph_ramsey_theorem"
+    ],
     "generated_path": "generated/finite_graph_ramsey_theorem"
   },
   {
@@ -59,7 +71,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Combinatorics.CatalanSubstInv",
-    "theorem": "substInv_X_sub_X_sq_eq_catalan",
+    "holes": [
+      "substInv_X_sub_X_sq_eq_catalan"
+    ],
     "generated_path": "generated/substInv_X_sub_X_sq_eq_catalan"
   },
   {
@@ -68,7 +82,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.NumberTheory.Lagarias",
-    "theorem": "riemann_hypothesis_iff_lagarias_elementary_criterion",
+    "holes": [
+      "riemann_hypothesis_iff_lagarias_elementary_criterion"
+    ],
     "generated_path": "generated/riemann_hypothesis_iff_lagarias_elementary_criterion"
   },
   {
@@ -77,7 +93,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Combinatorics.MarkoffGraph",
-    "theorem": "dvd_card_connectedComponent_markoffGraph",
+    "holes": [
+      "dvd_card_connectedComponent_markoffGraph"
+    ],
     "generated_path": "generated/dvd_card_connectedComponent_markoffGraph"
   },
   {
@@ -86,7 +104,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Combinatorics.CayleyConnected",
-    "theorem": "mulCayley_connected_iff_closure_eq_top",
+    "holes": [
+      "mulCayley_connected_iff_closure_eq_top"
+    ],
     "generated_path": "generated/mulCayley_connected_iff_closure_eq_top"
   },
   {
@@ -95,7 +115,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Topology.HomotopyGroups",
-    "theorem": "pi3_sphere_two_mulEquiv_int",
+    "holes": [
+      "pi3_sphere_two_mulEquiv_int"
+    ],
     "generated_path": "generated/pi3_sphere_two_mulEquiv_int"
   },
   {
@@ -104,7 +126,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Topology.HomotopyGroups",
-    "theorem": "pin_sphere_n_mulEquiv_int",
+    "holes": [
+      "pin_sphere_n_mulEquiv_int"
+    ],
     "generated_path": "generated/pin_sphere_n_mulEquiv_int"
   },
   {
@@ -113,7 +137,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Topology.HomotopyGroups",
-    "theorem": "pi_succ_sphere_n_mulEquiv_zmod_two",
+    "holes": [
+      "pi_succ_sphere_n_mulEquiv_zmod_two"
+    ],
     "generated_path": "generated/pi_succ_sphere_n_mulEquiv_zmod_two"
   },
   {
@@ -122,7 +148,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.GroupTheory.Burnside",
-    "theorem": "finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow",
+    "holes": [
+      "finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow"
+    ],
     "generated_path": "generated/finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow"
   },
   {
@@ -131,7 +159,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.ComplexAnalysis.Rouche",
-    "theorem": "rouche_logCounting_zero_eq",
+    "holes": [
+      "rouche_logCounting_zero_eq"
+    ],
     "generated_path": "generated/rouche_logCounting_zero_eq"
   },
   {
@@ -140,7 +170,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.ConvexGeometry.MinkowskiCaratheodory",
-    "theorem": "mem_convexHull_finset_extremePoints_of_mem_compact_convex",
+    "holes": [
+      "mem_convexHull_finset_extremePoints_of_mem_compact_convex"
+    ],
     "generated_path": "generated/mem_convexHull_finset_extremePoints_of_mem_compact_convex"
   },
   {
@@ -149,7 +181,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.LinearAlgebra.PerronFrobenius",
-    "theorem": "irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius",
+    "holes": [
+      "irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius"
+    ],
     "generated_path": "generated/irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius"
   },
   {
@@ -158,7 +192,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.ComplexAnalysis.ComplementaryPolynomials",
-    "theorem": "exists_complementary_polynomial_on_unit_circle",
+    "holes": [
+      "exists_complementary_polynomial_on_unit_circle"
+    ],
     "generated_path": "generated/exists_complementary_polynomial_on_unit_circle"
   },
   {
@@ -167,7 +203,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Algebra.NormalProduct",
-    "theorem": "isStarNormal_mul_of_commute",
+    "holes": [
+      "isStarNormal_mul_of_commute"
+    ],
     "generated_path": "generated/isStarNormal_mul_of_commute"
   },
   {
@@ -176,7 +214,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.LinearAlgebra.EntrywiseExpPSD",
-    "theorem": "posSemidef_map_exp",
+    "holes": [
+      "posSemidef_map_exp"
+    ],
     "generated_path": "generated/posSemidef_map_exp"
   },
   {
@@ -185,7 +225,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.LinearAlgebra.Oppenheim",
-    "theorem": "oppenheim_inequality",
+    "holes": [
+      "oppenheim_inequality"
+    ],
     "generated_path": "generated/oppenheim_inequality"
   },
   {
@@ -194,7 +236,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Analysis.VonNeumannDoubleCommutant",
-    "theorem": "vonNeumann_doubleCommutant_tfae",
+    "holes": [
+      "vonNeumann_doubleCommutant_tfae"
+    ],
     "generated_path": "generated/vonNeumann_doubleCommutant_tfae"
   },
   {
@@ -203,7 +247,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.RepresentationTheory.SchurWeyl",
-    "theorem": "symAction_range_eq_centralizer_glAction",
+    "holes": [
+      "symAction_range_eq_centralizer_glAction"
+    ],
     "generated_path": "generated/symAction_range_eq_centralizer_glAction"
   },
   {
@@ -212,7 +258,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.RepresentationTheory.SchurWeyl",
-    "theorem": "glAction_range_eq_centralizer_symAction",
+    "holes": [
+      "glAction_range_eq_centralizer_symAction"
+    ],
     "generated_path": "generated/glAction_range_eq_centralizer_symAction"
   },
   {
@@ -221,7 +269,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare",
-    "theorem": "g2_irrep_tensor_square_decomp",
+    "holes": [
+      "g2_irrep_tensor_square_decomp"
+    ],
     "generated_path": "generated/g2_irrep_tensor_square_decomp"
   },
   {
@@ -230,8 +280,63 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare",
-    "theorem": "e8_irrep_tensor_square_decomp",
+    "holes": [
+      "e8_irrep_tensor_square_decomp"
+    ],
     "generated_path": "generated/e8_irrep_tensor_square_decomp"
+  },
+  {
+    "id": "jacobian_challenge_diffgeo",
+    "title": "Jacobian of a compact Riemann surface (Buzzard challenge)",
+    "test": false,
+    "submitter": "Kevin Buzzard",
+    "module": "LeanEval.Geometry.JacobianChallenge",
+    "holes": [
+      "JacobianChallenge.genus",
+      "JacobianChallenge.genus_eq_zero_iff_homeo",
+      "JacobianChallenge.Jacobian",
+      "JacobianChallenge.Jacobian.instAddCommGroup",
+      "JacobianChallenge.Jacobian.instTopologicalSpace",
+      "JacobianChallenge.Jacobian.instT2Space",
+      "JacobianChallenge.Jacobian.instCompactSpace",
+      "JacobianChallenge.Jacobian.instChartedSpace",
+      "JacobianChallenge.Jacobian.instIsManifold",
+      "JacobianChallenge.Jacobian.instLieAddGroup",
+      "JacobianChallenge.Jacobian.ofCurve",
+      "JacobianChallenge.Jacobian.ofCurve_contMDiff",
+      "JacobianChallenge.Jacobian.ofCurve_self",
+      "JacobianChallenge.Jacobian.ofCurve_inj",
+      "JacobianChallenge.Jacobian.pushforward",
+      "JacobianChallenge.Jacobian.pushforward_contMDiff",
+      "JacobianChallenge.Jacobian.pushforward_id_apply",
+      "JacobianChallenge.Jacobian.pushforward_comp_apply",
+      "JacobianChallenge.Jacobian.pullback",
+      "JacobianChallenge.Jacobian.pullback_contMDiff",
+      "JacobianChallenge.Jacobian.pullback_id_apply",
+      "JacobianChallenge.Jacobian.pullback_comp_apply",
+      "JacobianChallenge.Jacobian.degree",
+      "JacobianChallenge.Jacobian.pushforward_pullback"
+    ],
+    "generated_path": "generated/jacobian_challenge_diffgeo"
+  },
+  {
+    "id": "jacobian_challenge_alggeo",
+    "title": "Jacobian of a smooth proper curve (Merten challenge)",
+    "test": false,
+    "submitter": "Christian Merten",
+    "module": "LeanEval.AlgebraicGeometry.JacobianChallenge",
+    "holes": [
+      "AlgebraicGeometry.JacobianChallenge.genus",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian.smoothOfRelativeDimension_genus",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian.instIsProper",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian.instGeometricallyIrreducible",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian.comp_ofCurve",
+      "AlgebraicGeometry.JacobianChallenge.Jacobian.exists_unique_ofCurve_comp"
+    ],
+    "generated_path": "generated/jacobian_challenge_alggeo"
   },
   {
     "id": "cerf_gamma_four",
@@ -239,7 +344,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Topology.CerfGammaFour",
-    "theorem": "cerf_gamma_four",
+    "holes": [
+      "cerf_gamma_four"
+    ],
     "generated_path": "generated/cerf_gamma_four"
   },
   {
@@ -248,7 +355,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.Topology.SmaleConjecture",
-    "theorem": "smale_conjecture",
+    "holes": [
+      "smale_conjecture"
+    ],
     "generated_path": "generated/smale_conjecture"
   },
   {
@@ -257,7 +366,9 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.NumberTheory.SmallHouse",
-    "theorem": "cyclotomic_integer_house_le_two",
+    "holes": [
+      "cyclotomic_integer_house_le_two"
+    ],
     "generated_path": "generated/cyclotomic_integer_house_le_two"
   },
   {
@@ -266,25 +377,33 @@
     "test": false,
     "submitter": "Kim Morrison",
     "module": "LeanEval.NumberTheory.SmallHouse",
-    "theorem": "cyclotomic_integer_house_between_two_and_76_33",
+    "holes": [
+      "cyclotomic_integer_house_between_two_and_76_33"
+    ],
     "generated_path": "generated/cyclotomic_integer_house_between_two_and_76_33"
   },
   {
-    "id": "gleason_theorem_finite",
-    "title": "Gleason's theorem (finite-dimensional)",
-    "test": false,
+    "id": "def_hole_example",
+    "title": "def-hole minimal example",
+    "test": true,
     "submitter": "Kim Morrison",
-    "module": "LeanEval.Analysis.Gleason",
-    "theorem": "gleason_theorem_finite",
-    "generated_path": "generated/gleason_theorem_finite"
+    "module": "LeanEval.Sandbox.DefHoleExample",
+    "holes": [
+      "foo",
+      "foo_def"
+    ],
+    "generated_path": "generated/def_hole_example"
   },
   {
-    "id": "gleason_theorem_separable",
-    "title": "Gleason's theorem (separable Hilbert space)",
-    "test": false,
+    "id": "instance_hole_example",
+    "title": "instance-hole minimal example",
+    "test": true,
     "submitter": "Kim Morrison",
-    "module": "LeanEval.Analysis.Gleason",
-    "theorem": "gleason_theorem_separable",
-    "generated_path": "generated/gleason_theorem_separable"
+    "module": "LeanEval.Sandbox.InstanceHoleExample",
+    "holes": [
+      "WidgetCarrier",
+      "instInhabitedWidget"
+    ],
+    "generated_path": "generated/instance_hole_example"
   }
 ]

--- a/generated/instance_hole_example/Challenge.lean
+++ b/generated/instance_hole_example/Challenge.lean
@@ -1,0 +1,9 @@
+import Mathlib
+/-!
+Minimal example exercising `instance` holes in the multi-hole
+eval-problem pipeline. The carrier type is itself a hole so the source
+has no non-hole declarations and the generator does not need a
+`ChallengeDeps` split.
+-/
+def WidgetCarrier : Type := sorry
+instance instInhabitedWidget : Inhabited WidgetCarrier := sorry

--- a/generated/instance_hole_example/README.md
+++ b/generated/instance_hole_example/README.md
@@ -1,0 +1,23 @@
+# `instance_hole_example`
+
+instance-hole minimal example
+
+- Problem ID: `instance_hole_example`
+- Test Problem: yes
+- Submitter: Kim Morrison
+- Holes (2): `WidgetCarrier` (def), `instInhabitedWidget` (def)
+- Notes: Minimal example exercising instance + theorem holes; instances must be named so the comparator can address them.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+This is a multi-hole problem: the challenge declares multiple `def`s,
+`instance`s, and/or `theorem`s as `sorry`. Fill all of them in
+`Submission.lean` (under `namespace Submission`) for comparator to accept
+your solution.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/instance_hole_example/Solution.lean
+++ b/generated/instance_hole_example/Solution.lean
@@ -1,0 +1,12 @@
+import Mathlib
+import Submission
+/-!
+Minimal example exercising `instance` holes in the multi-hole
+eval-problem pipeline. The carrier type is itself a hole so the source
+has no non-hole declarations and the generator does not need a
+`ChallengeDeps` split.
+-/
+
+@[reducible] def WidgetCarrier : Type := Submission.WidgetCarrier
+
+@[reducible] instance instInhabitedWidget : Inhabited WidgetCarrier := Submission.instInhabitedWidget

--- a/generated/instance_hole_example/Submission.lean
+++ b/generated/instance_hole_example/Submission.lean
@@ -1,0 +1,15 @@
+import Mathlib
+import Submission.Helpers
+/-!
+Minimal example exercising `instance` holes in the multi-hole
+eval-problem pipeline. The carrier type is itself a hole so the source
+has no non-hole declarations and the generator does not need a
+`ChallengeDeps` split.
+-/
+
+namespace Submission
+
+def WidgetCarrier : Type := sorry
+instance instInhabitedWidget : Inhabited WidgetCarrier := sorry
+
+end Submission

--- a/generated/instance_hole_example/Submission/Helpers.lean
+++ b/generated/instance_hole_example/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/instance_hole_example/WorkspaceTest.lean
+++ b/generated/instance_hole_example/WorkspaceTest.lean
@@ -1,0 +1,38 @@
+import Lean
+
+open Lean
+
+def comparatorExists (comparatorBin : String) : IO Bool := do
+  if comparatorBin.contains '/' then
+    return (← System.FilePath.pathExists comparatorBin)
+  try
+    let child ← IO.Process.spawn {
+      cmd := "sh"
+      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", comparatorBin]
+    }
+    let exitCode ← child.wait
+    return exitCode == 0
+  catch _ =>
+    return false
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  if !(← comparatorExists comparatorBin) then
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    pure 1
+  else
+    try
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, "config.json"]
+      }
+      let exitCode ← child.wait
+      pure exitCode
+    catch err =>
+      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+      IO.eprintln s!"Original error: {err}"
+      pure 1

--- a/generated/instance_hole_example/config.json
+++ b/generated/instance_hole_example/config.json
@@ -1,0 +1,15 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false,
+  "definition_names": [
+    "WidgetCarrier",
+    "instInhabitedWidget"
+  ]
+}

--- a/generated/instance_hole_example/lakefile.toml
+++ b/generated/instance_hole_example/lakefile.toml
@@ -1,0 +1,24 @@
+name = "instance_hole_example"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/instance_hole_example/lean-toolchain
+++ b/generated/instance_hole_example/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/generated/jacobian_challenge_alggeo/Challenge.lean
+++ b/generated/jacobian_challenge_alggeo/Challenge.lean
@@ -1,0 +1,126 @@
+import Mathlib
+
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib
+/-!
+# Jacobians in algebraic geometry
+
+Christian Merten's algebraic-geometry analogue of Kevin Buzzard's Jacobian
+challenge, posted to leanprover Zulip:
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685>.
+
+In the following, by a smooth curve we mean a geometrically irreducible, smooth scheme of relative
+dimension one over a field.
+
+## Main missing definitions
+
+* `AlgebraicGeometry.JacobianChallenge.genus` -- genus of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian` -- the Jacobian of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve` -- the Abel-Jacobi map from a proper smooth
+  curve to its Jacobian
+
+## Main missing theorems
+
+* `Jacobian.smoothOfRelativeDimension_genus` -- The Jacobian of a proper, smooth curve `C` is smooth
+  of relative dimension `g`, where `g` is the genus of `C`.
+* `Jacobian.exists_unique_ofCurve_comp` -- the universal property of the Jacobian of a proper,
+  smooth curve.
+-/
+
+set_option autoImplicit false
+
+universe u
+
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory MonObj
+
+namespace AlgebraicGeometry
+
+namespace JacobianChallenge
+
+-- We make `C` implicit at the variable level so that instance and `def` holes
+-- whose statement references the outer `C` (e.g. `instance instGrpObj :
+-- GrpObj (Jacobian C) := sorry`) elaborate to a Π-type with `{C}` implicit;
+-- otherwise the eval-pipeline's `Solution.lean` would have to thread a `C`
+-- argument through every delegation. Decls that genuinely need `C` explicit
+-- (e.g. `genus`, `Jacobian`, `comp_ofCurve`) supply their own `(C : ...)`
+-- binder.
+variable {k : Type u} [Field k] {C : Over (Spec (.of k))}
+  -- smooth curve
+  [SmoothOfRelativeDimension 1 C.hom]
+  -- proper
+  [IsProper C.hom]
+  -- geometrically irreducible
+  [GeometricallyIrreducible C.hom]
+
+-- data
+/-- The genus of a smooth proper curve. -/
+def genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : ℕ :=
+  sorry
+
+-- data
+/-- The Jacobian of a smooth, proper curve over a field `k`. -/
+def Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : Over (Spec (.of k)) :=
+  sorry
+
+namespace Jacobian
+
+/-! ## The Jacobian of `C` is an abelian variety. -/
+
+-- data
+/-- The group scheme structure on the Jacobian of the curve `C`. -/
+instance instGrpObj : GrpObj (Jacobian C) :=
+  sorry
+
+/-- The Jacobian of `C` is smooth of relative dimension `g` over `k`, where `g` is the
+genus of `C`. -/
+instance smoothOfRelativeDimension_genus :
+    SmoothOfRelativeDimension (genus C) (Jacobian C).hom :=
+  sorry
+
+/-- The Jacobian of `C` is proper over `k`. -/
+instance instIsProper : IsProper (Jacobian C).hom :=
+  sorry
+
+/-- The Jacobian of `C` is geometrically irreducible over `k`. -/
+instance instGeometricallyIrreducible : GeometricallyIrreducible (Jacobian C).hom :=
+  sorry
+
+-- data
+/-- The Abel-Jacobi map from a smooth, proper curve to its Jacobian associated
+to a `k`-rational point of `C`. -/
+def ofCurve (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) : C ⟶ Jacobian C :=
+  sorry
+
+/-- The Abel-Jacobi map sends the `k`-rational point `P` to `0`, where `0` (denoted by `η` below) is
+the neutral element of the group scheme `Jacobian C`. -/
+theorem comp_ofCurve (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) :
+    P ≫ ofCurve P = η[Jacobian C] :=
+  sorry
+
+/--
+The universal property of the Jacobian variety: For any abelian variety `A`,
+any morphism `f : C ⟶ A` such that `f(P) = 0` factors uniquely through the
+Jacobian of `C`.
+In other words, `Jacobian C` is the Albanese variety of `C`.
+-/
+theorem exists_unique_ofCurve_comp (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C)
+    {A : Over (Spec (.of k))} [Smooth A.hom] [IsProper A.hom] [GrpObj A]
+    [GeometricallyIrreducible A.hom] (f : C ⟶ A) (hf : P ≫ f = η[A]) :
+    ∃! (g : Jacobian C ⟶ A), f = ofCurve P ≫ g :=
+  sorry
+
+end Jacobian
+
+end JacobianChallenge
+
+end AlgebraicGeometry

--- a/generated/jacobian_challenge_alggeo/README.md
+++ b/generated/jacobian_challenge_alggeo/README.md
@@ -1,0 +1,24 @@
+# `jacobian_challenge_alggeo`
+
+Jacobian of a smooth proper curve (Merten challenge)
+
+- Problem ID: `jacobian_challenge_alggeo`
+- Test Problem: no
+- Submitter: Christian Merten
+- Holes (9): `AlgebraicGeometry.JacobianChallenge.genus` (def), `AlgebraicGeometry.JacobianChallenge.Jacobian` (def), `AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj` (def), `AlgebraicGeometry.JacobianChallenge.Jacobian.smoothOfRelativeDimension_genus` (theorem), `AlgebraicGeometry.JacobianChallenge.Jacobian.instIsProper` (theorem), `AlgebraicGeometry.JacobianChallenge.Jacobian.instGeometricallyIrreducible` (theorem), `AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve` (def), `AlgebraicGeometry.JacobianChallenge.Jacobian.comp_ofCurve` (theorem), `AlgebraicGeometry.JacobianChallenge.Jacobian.exists_unique_ofCurve_comp` (theorem)
+- Source: https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685
+- Informal solution: Build the Albanese variety of C as the universal abelian variety receiving a pointed map from C; Weil's construction of the Jacobian of a curve makes this concrete via Pic^0(C). The universal property is the no-cheating clamp.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+This is a multi-hole problem: the challenge declares multiple `def`s,
+`instance`s, and/or `theorem`s as `sorry`. Fill all of them in
+`Submission.lean` (under `namespace Submission`) for comparator to accept
+your solution.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/jacobian_challenge_alggeo/Solution.lean
+++ b/generated/jacobian_challenge_alggeo/Solution.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib
+import Submission
+/-!
+# Jacobians in algebraic geometry
+
+Christian Merten's algebraic-geometry analogue of Kevin Buzzard's Jacobian
+challenge, posted to leanprover Zulip:
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685>.
+
+In the following, by a smooth curve we mean a geometrically irreducible, smooth scheme of relative
+dimension one over a field.
+
+## Main missing definitions
+
+* `AlgebraicGeometry.JacobianChallenge.genus` -- genus of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian` -- the Jacobian of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve` -- the Abel-Jacobi map from a proper smooth
+  curve to its Jacobian
+
+## Main missing theorems
+
+* `Jacobian.smoothOfRelativeDimension_genus` -- The Jacobian of a proper, smooth curve `C` is smooth
+  of relative dimension `g`, where `g` is the genus of `C`.
+* `Jacobian.exists_unique_ofCurve_comp` -- the universal property of the Jacobian of a proper,
+  smooth curve.
+-/
+
+set_option autoImplicit false
+
+universe u
+
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory MonObj
+
+namespace AlgebraicGeometry
+
+namespace JacobianChallenge
+
+-- We make `C` implicit at the variable level so that instance and `def` holes
+-- whose statement references the outer `C` (e.g. `instance instGrpObj :
+-- GrpObj (Jacobian C) := sorry`) elaborate to a Π-type with `{C}` implicit;
+-- otherwise the eval-pipeline's `Solution.lean` would have to thread a `C`
+-- argument through every delegation. Decls that genuinely need `C` explicit
+-- (e.g. `genus`, `Jacobian`, `comp_ofCurve`) supply their own `(C : ...)`
+-- binder.
+variable {k : Type u} [Field k] {C : Over (Spec (.of k))}
+  -- smooth curve
+  [SmoothOfRelativeDimension 1 C.hom]
+  -- proper
+  [IsProper C.hom]
+  -- geometrically irreducible
+  [GeometricallyIrreducible C.hom]
+
+-- data
+/-- The genus of a smooth proper curve. -/
+@[reducible] def genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : ℕ := Submission.AlgebraicGeometry.JacobianChallenge.genus C
+
+-- data
+/-- The Jacobian of a smooth, proper curve over a field `k`. -/
+@[reducible] def Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : Over (Spec (.of k)) := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian C
+
+namespace Jacobian
+
+/-! ## The Jacobian of `C` is an abelian variety. -/
+
+-- data
+/-- The group scheme structure on the Jacobian of the curve `C`. -/
+@[reducible] instance instGrpObj : GrpObj (Jacobian C) := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj
+
+/-- The Jacobian of `C` is smooth of relative dimension `g` over `k`, where `g` is the
+genus of `C`. -/
+instance smoothOfRelativeDimension_genus :
+    SmoothOfRelativeDimension (genus C) (Jacobian C).hom := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.smoothOfRelativeDimension_genus
+
+/-- The Jacobian of `C` is proper over `k`. -/
+instance instIsProper : IsProper (Jacobian C).hom := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.instIsProper
+
+/-- The Jacobian of `C` is geometrically irreducible over `k`. -/
+instance instGeometricallyIrreducible : GeometricallyIrreducible (Jacobian C).hom := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.instGeometricallyIrreducible
+
+-- data
+/-- The Abel-Jacobi map from a smooth, proper curve to its Jacobian associated
+to a `k`-rational point of `C`. -/
+@[reducible] def ofCurve (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) : C ⟶ Jacobian C := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve P
+
+/-- The Abel-Jacobi map sends the `k`-rational point `P` to `0`, where `0` (denoted by `η` below) is
+the neutral element of the group scheme `Jacobian C`. -/
+theorem comp_ofCurve (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) :
+    P ≫ ofCurve P = η[Jacobian C] := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.comp_ofCurve C P
+
+/--
+The universal property of the Jacobian variety: For any abelian variety `A`,
+any morphism `f : C ⟶ A` such that `f(P) = 0` factors uniquely through the
+Jacobian of `C`.
+In other words, `Jacobian C` is the Albanese variety of `C`.
+-/
+theorem exists_unique_ofCurve_comp (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C)
+    {A : Over (Spec (.of k))} [Smooth A.hom] [IsProper A.hom] [GrpObj A]
+    [GeometricallyIrreducible A.hom] (f : C ⟶ A) (hf : P ≫ f = η[A]) :
+    ∃! (g : Jacobian C ⟶ A), f = ofCurve P ≫ g := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.exists_unique_ofCurve_comp C P f hf
+
+end Jacobian
+
+end JacobianChallenge
+
+end AlgebraicGeometry

--- a/generated/jacobian_challenge_alggeo/Submission.lean
+++ b/generated/jacobian_challenge_alggeo/Submission.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib
+import Submission.Helpers
+/-!
+# Jacobians in algebraic geometry
+
+Christian Merten's algebraic-geometry analogue of Kevin Buzzard's Jacobian
+challenge, posted to leanprover Zulip:
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685>.
+
+In the following, by a smooth curve we mean a geometrically irreducible, smooth scheme of relative
+dimension one over a field.
+
+## Main missing definitions
+
+* `AlgebraicGeometry.JacobianChallenge.genus` -- genus of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian` -- the Jacobian of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve` -- the Abel-Jacobi map from a proper smooth
+  curve to its Jacobian
+
+## Main missing theorems
+
+* `Jacobian.smoothOfRelativeDimension_genus` -- The Jacobian of a proper, smooth curve `C` is smooth
+  of relative dimension `g`, where `g` is the genus of `C`.
+* `Jacobian.exists_unique_ofCurve_comp` -- the universal property of the Jacobian of a proper,
+  smooth curve.
+-/
+
+
+namespace Submission
+
+open AlgebraicGeometry
+set_option autoImplicit false
+
+universe u
+
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory MonObj
+
+namespace AlgebraicGeometry
+
+namespace JacobianChallenge
+
+-- We make `C` implicit at the variable level so that instance and `def` holes
+-- whose statement references the outer `C` (e.g. `instance instGrpObj :
+-- GrpObj (Jacobian C) := sorry`) elaborate to a Π-type with `{C}` implicit;
+-- otherwise the eval-pipeline's `Solution.lean` would have to thread a `C`
+-- argument through every delegation. Decls that genuinely need `C` explicit
+-- (e.g. `genus`, `Jacobian`, `comp_ofCurve`) supply their own `(C : ...)`
+-- binder.
+variable {k : Type u} [Field k] {C : Over (Spec (.of k))}
+  -- smooth curve
+  [SmoothOfRelativeDimension 1 C.hom]
+  -- proper
+  [IsProper C.hom]
+  -- geometrically irreducible
+  [GeometricallyIrreducible C.hom]
+
+-- data
+/-- The genus of a smooth proper curve. -/
+def genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : ℕ :=
+  sorry
+
+-- data
+/-- The Jacobian of a smooth, proper curve over a field `k`. -/
+def Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : Over (Spec (.of k)) :=
+  sorry
+
+namespace Jacobian
+
+/-! ## The Jacobian of `C` is an abelian variety. -/
+
+-- data
+/-- The group scheme structure on the Jacobian of the curve `C`. -/
+instance instGrpObj : GrpObj (Jacobian C) :=
+  sorry
+
+/-- The Jacobian of `C` is smooth of relative dimension `g` over `k`, where `g` is the
+genus of `C`. -/
+instance smoothOfRelativeDimension_genus :
+    SmoothOfRelativeDimension (genus C) (Jacobian C).hom :=
+  sorry
+
+/-- The Jacobian of `C` is proper over `k`. -/
+instance instIsProper : IsProper (Jacobian C).hom :=
+  sorry
+
+/-- The Jacobian of `C` is geometrically irreducible over `k`. -/
+instance instGeometricallyIrreducible : GeometricallyIrreducible (Jacobian C).hom :=
+  sorry
+
+-- data
+/-- The Abel-Jacobi map from a smooth, proper curve to its Jacobian associated
+to a `k`-rational point of `C`. -/
+def ofCurve (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) : C ⟶ Jacobian C :=
+  sorry
+
+/-- The Abel-Jacobi map sends the `k`-rational point `P` to `0`, where `0` (denoted by `η` below) is
+the neutral element of the group scheme `Jacobian C`. -/
+theorem comp_ofCurve (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) :
+    P ≫ ofCurve P = η[Jacobian C] :=
+  sorry
+
+/--
+The universal property of the Jacobian variety: For any abelian variety `A`,
+any morphism `f : C ⟶ A` such that `f(P) = 0` factors uniquely through the
+Jacobian of `C`.
+In other words, `Jacobian C` is the Albanese variety of `C`.
+-/
+theorem exists_unique_ofCurve_comp (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C)
+    {A : Over (Spec (.of k))} [Smooth A.hom] [IsProper A.hom] [GrpObj A]
+    [GeometricallyIrreducible A.hom] (f : C ⟶ A) (hf : P ≫ f = η[A]) :
+    ∃! (g : Jacobian C ⟶ A), f = ofCurve P ≫ g :=
+  sorry
+
+end Jacobian
+
+end JacobianChallenge
+
+end AlgebraicGeometry
+
+end Submission

--- a/generated/jacobian_challenge_alggeo/Submission/Helpers.lean
+++ b/generated/jacobian_challenge_alggeo/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/jacobian_challenge_alggeo/WorkspaceTest.lean
+++ b/generated/jacobian_challenge_alggeo/WorkspaceTest.lean
@@ -1,0 +1,38 @@
+import Lean
+
+open Lean
+
+def comparatorExists (comparatorBin : String) : IO Bool := do
+  if comparatorBin.contains '/' then
+    return (← System.FilePath.pathExists comparatorBin)
+  try
+    let child ← IO.Process.spawn {
+      cmd := "sh"
+      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", comparatorBin]
+    }
+    let exitCode ← child.wait
+    return exitCode == 0
+  catch _ =>
+    return false
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  if !(← comparatorExists comparatorBin) then
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    pure 1
+  else
+    try
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, "config.json"]
+      }
+      let exitCode ← child.wait
+      pure exitCode
+    catch err =>
+      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+      IO.eprintln s!"Original error: {err}"
+      pure 1

--- a/generated/jacobian_challenge_alggeo/config.json
+++ b/generated/jacobian_challenge_alggeo/config.json
@@ -1,0 +1,23 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "AlgebraicGeometry.JacobianChallenge.Jacobian.smoothOfRelativeDimension_genus",
+    "AlgebraicGeometry.JacobianChallenge.Jacobian.instIsProper",
+    "AlgebraicGeometry.JacobianChallenge.Jacobian.instGeometricallyIrreducible",
+    "AlgebraicGeometry.JacobianChallenge.Jacobian.comp_ofCurve",
+    "AlgebraicGeometry.JacobianChallenge.Jacobian.exists_unique_ofCurve_comp"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false,
+  "definition_names": [
+    "AlgebraicGeometry.JacobianChallenge.genus",
+    "AlgebraicGeometry.JacobianChallenge.Jacobian",
+    "AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj",
+    "AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve"
+  ]
+}

--- a/generated/jacobian_challenge_alggeo/lakefile.toml
+++ b/generated/jacobian_challenge_alggeo/lakefile.toml
@@ -1,0 +1,24 @@
+name = "jacobian_challenge_alggeo"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/jacobian_challenge_alggeo/lean-toolchain
+++ b/generated/jacobian_challenge_alggeo/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/generated/jacobian_challenge_diffgeo/Challenge.lean
+++ b/generated/jacobian_challenge_diffgeo/Challenge.lean
@@ -1,0 +1,141 @@
+import Mathlib
+/-!
+# Jacobians of compact Riemann surfaces
+
+Kevin Buzzard's "Jacobian Challenge" v0.3, posted to leanprover Zulip
+(`#Autoformalization > Jacobian challenge`):
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge>.
+The original source uses anonymous instances; here every `instance` is
+named explicitly so the eval-problem pipeline can address it.
+
+## Main missing definitions
+
+* `genus` -- genus of a compact Riemann surface
+* `Jacobian` -- the Jacobian of a compact Riemann surface
+* `Jacobian.ofCurve` -- the Abel-Jacobi map from a compact Riemann surface to its Jacobian
+* `ContMDiff.degree` -- the degree of a holomorphic map between compact Riemann surfaces.
+    Equal to 0 if the map is constant, otherwise equal to the usual degree.
+* `Jacobian.pushforward` -- the pushforward map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+* `Jacobian.pullback` -- the pullback map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+
+## Main missing theorems
+
+* `genus_eq_zero_iff_homeo` -- a compact Riemann surface has genus 0 iff it is homeomorphic to the sphere
+* `ofCurve_inj` -- the Abel-Jacobi map is injective iff the genus is positive
+* `Jacobian.ofCurve_contMDiff` -- the Abel-Jacobi map is holomorphic
+* `Jacobian.pushforward_contMDiff` -- the pushforward map is holomorphic
+* `Jacobian.pullback_contMDiff` -- the pullback map is holomorphic
+* `pushforward_pullback` -- pullback then pushforward is multiplication by degree
+-/
+
+open scoped ContDiff -- for ω notation
+
+namespace JacobianChallenge
+
+universe u v w
+
+-- let X be a compact Riemann surface
+variable {X : Type u} [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+  [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X]
+
+-- data
+def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : ℕ := sorry
+
+-- this proof avoids the hack answer `∀ X, genus X = 0`
+-- Prop
+theorem genus_eq_zero_iff_homeo :
+    genus X = 0 ↔ Nonempty (X ≃ₜ (Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1)) :=
+  sorry
+
+-- data
+def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : Type u := sorry
+
+namespace Jacobian
+
+-- data
+instance instAddCommGroup : AddCommGroup (Jacobian X) := sorry
+
+-- data
+instance instTopologicalSpace : TopologicalSpace (Jacobian X) := sorry
+
+-- Prop
+instance instT2Space : T2Space (Jacobian X) := sorry
+
+-- Prop
+instance instCompactSpace : CompactSpace (Jacobian X) := sorry
+instance instChartedSpace : ChartedSpace (Fin (genus X) → ℂ) (Jacobian X) := sorry
+
+-- Prop
+instance instIsManifold :
+    IsManifold (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+
+-- Prop
+instance instLieAddGroup :
+    LieAddGroup (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+def ofCurve (P : X) : X → Jacobian X := sorry
+theorem ofCurve_contMDiff (P : X) :
+    ContMDiff (modelWithCornersSelf ℂ ℂ)
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (ofCurve P) := sorry
+theorem ofCurve_self (P : X) : ofCurve P P = 0 := sorry
+
+-- this is the lemma which stops the hack answer "J(X)=0 for all X"
+theorem ofCurve_inj (P : X) (h : 0 < genus X) : Function.Injective (ofCurve P) := sorry
+
+variable {Y : Type v} [TopologicalSpace Y] [T2Space Y] [CompactSpace Y] [ConnectedSpace Y]
+  [Nonempty Y] [ChartedSpace ℂ Y] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Y]
+
+variable (f : X → Y) (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+def pushforward (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian X →ₜ+ Jacobian Y := sorry
+theorem pushforward_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus X) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ)) ω (pushforward f hf) := sorry
+
+-- functoriality
+theorem pushforward_id_apply (P : Jacobian X) :
+    pushforward id contMDiff_id P = P := sorry
+
+variable {Z : Type w} [TopologicalSpace Z] [T2Space Z] [CompactSpace Z] [ConnectedSpace Z]
+  [Nonempty Z] [ChartedSpace ℂ Z] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Z]
+
+variable (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+theorem pushforward_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian X) :
+    pushforward (g ∘ f) (hg.comp hf) P = pushforward g hg (pushforward f hf P) :=
+  sorry
+
+-- if f is constant then the pullback should be the zero map, otherwise it's
+-- the usual pullback
+def pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian Y →ₜ+ Jacobian X := sorry
+theorem pullback_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (pullback f hf) := sorry
+theorem pullback_id_apply (P : Jacobian X) :
+    pullback id contMDiff_id P = P := sorry
+theorem pullback_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian Z) :
+    pullback (g.comp f) (hg.comp hf) P = pullback f hf (pullback g hg P) := sorry
+def degree (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) : ℕ :=
+  sorry -- 0 for constant case
+theorem pushforward_pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (P : Jacobian Y) :
+    pushforward f hf (pullback f hf P) = (degree f hf) • P := sorry
+
+end Jacobian
+
+end JacobianChallenge

--- a/generated/jacobian_challenge_diffgeo/README.md
+++ b/generated/jacobian_challenge_diffgeo/README.md
@@ -1,0 +1,24 @@
+# `jacobian_challenge_diffgeo`
+
+Jacobian of a compact Riemann surface (Buzzard challenge)
+
+- Problem ID: `jacobian_challenge_diffgeo`
+- Test Problem: no
+- Submitter: Kevin Buzzard
+- Holes (24): `JacobianChallenge.genus` (def), `JacobianChallenge.genus_eq_zero_iff_homeo` (theorem), `JacobianChallenge.Jacobian` (def), `JacobianChallenge.Jacobian.instAddCommGroup` (def), `JacobianChallenge.Jacobian.instTopologicalSpace` (def), `JacobianChallenge.Jacobian.instT2Space` (theorem), `JacobianChallenge.Jacobian.instCompactSpace` (theorem), `JacobianChallenge.Jacobian.instChartedSpace` (def), `JacobianChallenge.Jacobian.instIsManifold` (theorem), `JacobianChallenge.Jacobian.instLieAddGroup` (theorem), `JacobianChallenge.Jacobian.ofCurve` (def), `JacobianChallenge.Jacobian.ofCurve_contMDiff` (theorem), `JacobianChallenge.Jacobian.ofCurve_self` (theorem), `JacobianChallenge.Jacobian.ofCurve_inj` (theorem), `JacobianChallenge.Jacobian.pushforward` (def), `JacobianChallenge.Jacobian.pushforward_contMDiff` (theorem), `JacobianChallenge.Jacobian.pushforward_id_apply` (theorem), `JacobianChallenge.Jacobian.pushforward_comp_apply` (theorem), `JacobianChallenge.Jacobian.pullback` (def), `JacobianChallenge.Jacobian.pullback_contMDiff` (theorem), `JacobianChallenge.Jacobian.pullback_id_apply` (theorem), `JacobianChallenge.Jacobian.pullback_comp_apply` (theorem), `JacobianChallenge.Jacobian.degree` (def), `JacobianChallenge.Jacobian.pushforward_pullback` (theorem)
+- Source: https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge
+- Informal solution: Construct J(X) as H^0(X, Omega^1)* / H_1(X, Z), the period lattice quotient; the Abel-Jacobi map sends a point to the linear functional 'integrate from a fixed basepoint to here'. Functoriality and the projection formula come from pushforward and pullback of differential forms.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+This is a multi-hole problem: the challenge declares multiple `def`s,
+`instance`s, and/or `theorem`s as `sorry`. Fill all of them in
+`Submission.lean` (under `namespace Submission`) for comparator to accept
+your solution.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/jacobian_challenge_diffgeo/Solution.lean
+++ b/generated/jacobian_challenge_diffgeo/Solution.lean
@@ -1,0 +1,151 @@
+import Mathlib
+import Submission
+/-!
+# Jacobians of compact Riemann surfaces
+
+Kevin Buzzard's "Jacobian Challenge" v0.3, posted to leanprover Zulip
+(`#Autoformalization > Jacobian challenge`):
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge>.
+The original source uses anonymous instances; here every `instance` is
+named explicitly so the eval-problem pipeline can address it.
+
+## Main missing definitions
+
+* `genus` -- genus of a compact Riemann surface
+* `Jacobian` -- the Jacobian of a compact Riemann surface
+* `Jacobian.ofCurve` -- the Abel-Jacobi map from a compact Riemann surface to its Jacobian
+* `ContMDiff.degree` -- the degree of a holomorphic map between compact Riemann surfaces.
+    Equal to 0 if the map is constant, otherwise equal to the usual degree.
+* `Jacobian.pushforward` -- the pushforward map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+* `Jacobian.pullback` -- the pullback map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+
+## Main missing theorems
+
+* `genus_eq_zero_iff_homeo` -- a compact Riemann surface has genus 0 iff it is homeomorphic to the sphere
+* `ofCurve_inj` -- the Abel-Jacobi map is injective iff the genus is positive
+* `Jacobian.ofCurve_contMDiff` -- the Abel-Jacobi map is holomorphic
+* `Jacobian.pushforward_contMDiff` -- the pushforward map is holomorphic
+* `Jacobian.pullback_contMDiff` -- the pullback map is holomorphic
+* `pushforward_pullback` -- pullback then pushforward is multiplication by degree
+-/
+
+open scoped ContDiff -- for ω notation
+
+namespace JacobianChallenge
+
+universe u v w
+
+-- let X be a compact Riemann surface
+variable {X : Type u} [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+  [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X]
+
+-- data
+@[reducible] def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : ℕ := Submission.JacobianChallenge.genus X
+
+-- this proof avoids the hack answer `∀ X, genus X = 0`
+-- Prop
+theorem genus_eq_zero_iff_homeo :
+    genus X = 0 ↔ Nonempty (X ≃ₜ (Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1)) := Submission.JacobianChallenge.genus_eq_zero_iff_homeo
+
+-- data
+@[reducible] def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : Type u := Submission.JacobianChallenge.Jacobian X
+
+namespace Jacobian
+
+-- data
+@[reducible] instance instAddCommGroup : AddCommGroup (Jacobian X) := Submission.JacobianChallenge.Jacobian.instAddCommGroup
+
+-- data
+@[reducible] instance instTopologicalSpace : TopologicalSpace (Jacobian X) := Submission.JacobianChallenge.Jacobian.instTopologicalSpace
+
+-- Prop
+instance instT2Space : T2Space (Jacobian X) := Submission.JacobianChallenge.Jacobian.instT2Space
+
+-- Prop
+instance instCompactSpace : CompactSpace (Jacobian X) := Submission.JacobianChallenge.Jacobian.instCompactSpace
+
+@[reducible] instance instChartedSpace : ChartedSpace (Fin (genus X) → ℂ) (Jacobian X) := Submission.JacobianChallenge.Jacobian.instChartedSpace
+
+-- Prop
+instance instIsManifold :
+    IsManifold (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := Submission.JacobianChallenge.Jacobian.instIsManifold
+
+-- Prop
+instance instLieAddGroup :
+    LieAddGroup (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := Submission.JacobianChallenge.Jacobian.instLieAddGroup
+
+@[reducible] def ofCurve (P : X) : X → Jacobian X := Submission.JacobianChallenge.Jacobian.ofCurve P
+
+theorem ofCurve_contMDiff (P : X) :
+    ContMDiff (modelWithCornersSelf ℂ ℂ)
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (ofCurve P) := Submission.JacobianChallenge.Jacobian.ofCurve_contMDiff P
+
+theorem ofCurve_self (P : X) : ofCurve P P = 0 := Submission.JacobianChallenge.Jacobian.ofCurve_self P
+
+-- this is the lemma which stops the hack answer "J(X)=0 for all X"
+theorem ofCurve_inj (P : X) (h : 0 < genus X) : Function.Injective (ofCurve P) := Submission.JacobianChallenge.Jacobian.ofCurve_inj P h
+
+variable {Y : Type v} [TopologicalSpace Y] [T2Space Y] [CompactSpace Y] [ConnectedSpace Y]
+  [Nonempty Y] [ChartedSpace ℂ Y] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Y]
+
+variable (f : X → Y) (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+
+@[reducible] def pushforward (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian X →ₜ+ Jacobian Y := Submission.JacobianChallenge.Jacobian.pushforward f hf
+
+theorem pushforward_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus X) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ)) ω (pushforward f hf) := Submission.JacobianChallenge.Jacobian.pushforward_contMDiff f hf
+
+-- functoriality
+theorem pushforward_id_apply (P : Jacobian X) :
+    pushforward id contMDiff_id P = P := Submission.JacobianChallenge.Jacobian.pushforward_id_apply P
+
+variable {Z : Type w} [TopologicalSpace Z] [T2Space Z] [CompactSpace Z] [ConnectedSpace Z]
+  [Nonempty Z] [ChartedSpace ℂ Z] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Z]
+
+variable (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+
+theorem pushforward_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian X) :
+    pushforward (g ∘ f) (hg.comp hf) P = pushforward g hg (pushforward f hf P) := Submission.JacobianChallenge.Jacobian.pushforward_comp_apply f hf g hg P
+
+-- if f is constant then the pullback should be the zero map, otherwise it's
+-- the usual pullback
+@[reducible] def pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian Y →ₜ+ Jacobian X := Submission.JacobianChallenge.Jacobian.pullback f hf
+
+theorem pullback_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (pullback f hf) := Submission.JacobianChallenge.Jacobian.pullback_contMDiff f hf
+
+theorem pullback_id_apply (P : Jacobian X) :
+    pullback id contMDiff_id P = P := Submission.JacobianChallenge.Jacobian.pullback_id_apply P
+
+theorem pullback_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian Z) :
+    pullback (g.comp f) (hg.comp hf) P = pullback f hf (pullback g hg P) := Submission.JacobianChallenge.Jacobian.pullback_comp_apply f hf g hg P
+
+@[reducible] def degree (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) : ℕ := Submission.JacobianChallenge.Jacobian.degree f hf -- 0 for constant case
+
+theorem pushforward_pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (P : Jacobian Y) :
+    pushforward f hf (pullback f hf P) = (degree f hf) • P := Submission.JacobianChallenge.Jacobian.pushforward_pullback f hf P
+
+end Jacobian
+
+end JacobianChallenge

--- a/generated/jacobian_challenge_diffgeo/Submission.lean
+++ b/generated/jacobian_challenge_diffgeo/Submission.lean
@@ -1,0 +1,147 @@
+import Mathlib
+import Submission.Helpers
+/-!
+# Jacobians of compact Riemann surfaces
+
+Kevin Buzzard's "Jacobian Challenge" v0.3, posted to leanprover Zulip
+(`#Autoformalization > Jacobian challenge`):
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge>.
+The original source uses anonymous instances; here every `instance` is
+named explicitly so the eval-problem pipeline can address it.
+
+## Main missing definitions
+
+* `genus` -- genus of a compact Riemann surface
+* `Jacobian` -- the Jacobian of a compact Riemann surface
+* `Jacobian.ofCurve` -- the Abel-Jacobi map from a compact Riemann surface to its Jacobian
+* `ContMDiff.degree` -- the degree of a holomorphic map between compact Riemann surfaces.
+    Equal to 0 if the map is constant, otherwise equal to the usual degree.
+* `Jacobian.pushforward` -- the pushforward map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+* `Jacobian.pullback` -- the pullback map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+
+## Main missing theorems
+
+* `genus_eq_zero_iff_homeo` -- a compact Riemann surface has genus 0 iff it is homeomorphic to the sphere
+* `ofCurve_inj` -- the Abel-Jacobi map is injective iff the genus is positive
+* `Jacobian.ofCurve_contMDiff` -- the Abel-Jacobi map is holomorphic
+* `Jacobian.pushforward_contMDiff` -- the pushforward map is holomorphic
+* `Jacobian.pullback_contMDiff` -- the pullback map is holomorphic
+* `pushforward_pullback` -- pullback then pushforward is multiplication by degree
+-/
+
+
+namespace Submission
+
+open scoped ContDiff -- for ω notation
+
+namespace JacobianChallenge
+
+universe u v w
+
+-- let X be a compact Riemann surface
+variable {X : Type u} [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+  [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X]
+
+-- data
+def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : ℕ := sorry
+
+-- this proof avoids the hack answer `∀ X, genus X = 0`
+-- Prop
+theorem genus_eq_zero_iff_homeo :
+    genus X = 0 ↔ Nonempty (X ≃ₜ (Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1)) :=
+  sorry
+
+-- data
+def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : Type u := sorry
+
+namespace Jacobian
+
+-- data
+instance instAddCommGroup : AddCommGroup (Jacobian X) := sorry
+
+-- data
+instance instTopologicalSpace : TopologicalSpace (Jacobian X) := sorry
+
+-- Prop
+instance instT2Space : T2Space (Jacobian X) := sorry
+
+-- Prop
+instance instCompactSpace : CompactSpace (Jacobian X) := sorry
+instance instChartedSpace : ChartedSpace (Fin (genus X) → ℂ) (Jacobian X) := sorry
+
+-- Prop
+instance instIsManifold :
+    IsManifold (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+
+-- Prop
+instance instLieAddGroup :
+    LieAddGroup (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+def ofCurve (P : X) : X → Jacobian X := sorry
+theorem ofCurve_contMDiff (P : X) :
+    ContMDiff (modelWithCornersSelf ℂ ℂ)
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (ofCurve P) := sorry
+theorem ofCurve_self (P : X) : ofCurve P P = 0 := sorry
+
+-- this is the lemma which stops the hack answer "J(X)=0 for all X"
+theorem ofCurve_inj (P : X) (h : 0 < genus X) : Function.Injective (ofCurve P) := sorry
+
+variable {Y : Type v} [TopologicalSpace Y] [T2Space Y] [CompactSpace Y] [ConnectedSpace Y]
+  [Nonempty Y] [ChartedSpace ℂ Y] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Y]
+
+variable (f : X → Y) (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+def pushforward (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian X →ₜ+ Jacobian Y := sorry
+theorem pushforward_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus X) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ)) ω (pushforward f hf) := sorry
+
+-- functoriality
+theorem pushforward_id_apply (P : Jacobian X) :
+    pushforward id contMDiff_id P = P := sorry
+
+variable {Z : Type w} [TopologicalSpace Z] [T2Space Z] [CompactSpace Z] [ConnectedSpace Z]
+  [Nonempty Z] [ChartedSpace ℂ Z] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Z]
+
+variable (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+theorem pushforward_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian X) :
+    pushforward (g ∘ f) (hg.comp hf) P = pushforward g hg (pushforward f hf P) :=
+  sorry
+
+-- if f is constant then the pullback should be the zero map, otherwise it's
+-- the usual pullback
+def pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian Y →ₜ+ Jacobian X := sorry
+theorem pullback_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (pullback f hf) := sorry
+theorem pullback_id_apply (P : Jacobian X) :
+    pullback id contMDiff_id P = P := sorry
+theorem pullback_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian Z) :
+    pullback (g.comp f) (hg.comp hf) P = pullback f hf (pullback g hg P) := sorry
+def degree (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) : ℕ :=
+  sorry -- 0 for constant case
+theorem pushforward_pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (P : Jacobian Y) :
+    pushforward f hf (pullback f hf P) = (degree f hf) • P := sorry
+
+end Jacobian
+
+end JacobianChallenge
+
+end Submission

--- a/generated/jacobian_challenge_diffgeo/Submission/Helpers.lean
+++ b/generated/jacobian_challenge_diffgeo/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/jacobian_challenge_diffgeo/WorkspaceTest.lean
+++ b/generated/jacobian_challenge_diffgeo/WorkspaceTest.lean
@@ -1,0 +1,38 @@
+import Lean
+
+open Lean
+
+def comparatorExists (comparatorBin : String) : IO Bool := do
+  if comparatorBin.contains '/' then
+    return (← System.FilePath.pathExists comparatorBin)
+  try
+    let child ← IO.Process.spawn {
+      cmd := "sh"
+      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", comparatorBin]
+    }
+    let exitCode ← child.wait
+    return exitCode == 0
+  catch _ =>
+    return false
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  if !(← comparatorExists comparatorBin) then
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    pure 1
+  else
+    try
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, "config.json"]
+      }
+      let exitCode ← child.wait
+      pure exitCode
+    catch err =>
+      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+      IO.eprintln s!"Original error: {err}"
+      pure 1

--- a/generated/jacobian_challenge_diffgeo/config.json
+++ b/generated/jacobian_challenge_diffgeo/config.json
@@ -1,0 +1,38 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "JacobianChallenge.genus_eq_zero_iff_homeo",
+    "JacobianChallenge.Jacobian.instT2Space",
+    "JacobianChallenge.Jacobian.instCompactSpace",
+    "JacobianChallenge.Jacobian.instIsManifold",
+    "JacobianChallenge.Jacobian.instLieAddGroup",
+    "JacobianChallenge.Jacobian.ofCurve_contMDiff",
+    "JacobianChallenge.Jacobian.ofCurve_self",
+    "JacobianChallenge.Jacobian.ofCurve_inj",
+    "JacobianChallenge.Jacobian.pushforward_contMDiff",
+    "JacobianChallenge.Jacobian.pushforward_id_apply",
+    "JacobianChallenge.Jacobian.pushforward_comp_apply",
+    "JacobianChallenge.Jacobian.pullback_contMDiff",
+    "JacobianChallenge.Jacobian.pullback_id_apply",
+    "JacobianChallenge.Jacobian.pullback_comp_apply",
+    "JacobianChallenge.Jacobian.pushforward_pullback"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false,
+  "definition_names": [
+    "JacobianChallenge.genus",
+    "JacobianChallenge.Jacobian",
+    "JacobianChallenge.Jacobian.instAddCommGroup",
+    "JacobianChallenge.Jacobian.instTopologicalSpace",
+    "JacobianChallenge.Jacobian.instChartedSpace",
+    "JacobianChallenge.Jacobian.ofCurve",
+    "JacobianChallenge.Jacobian.pushforward",
+    "JacobianChallenge.Jacobian.pullback",
+    "JacobianChallenge.Jacobian.degree"
+  ]
+}

--- a/generated/jacobian_challenge_diffgeo/lakefile.toml
+++ b/generated/jacobian_challenge_diffgeo/lakefile.toml
@@ -1,0 +1,24 @@
+name = "jacobian_challenge_diffgeo"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/jacobian_challenge_diffgeo/lean-toolchain
+++ b/generated/jacobian_challenge_diffgeo/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -5,7 +5,7 @@ id = "two_plus_two"
 title = "2 + 2 = 4"
 test = true
 module = "LeanEval.EasyProblems"
-theorem = "two_plus_two_eq_four"
+holes = ["two_plus_two_eq_four"]
 submitter = "Kim Morrison"
 notes = "An easy problem to get you on the leaderboard."
 source = "Internal starter problem."
@@ -16,7 +16,7 @@ id = "ci_regenerate_main_check"
 title = "CI regenerate-main check"
 test = true
 module = "LeanEval.EasyProblems"
-theorem = "ci_regenerate_main_check"
+holes = ["ci_regenerate_main_check"]
 submitter = "Kim Morrison"
 notes = "Internal trivial problem used to exercise the regenerate-main workflow end-to-end."
 source = "Internal CI check."
@@ -27,7 +27,7 @@ id = "list_append_singleton_length"
 title = "Appending a singleton increases the list length"
 test = true
 module = "LeanEval.EasyProblems"
-theorem = "list_append_singleton_length"
+holes = ["list_append_singleton_length"]
 submitter = "Kim Morrison"
 notes = "A simple list problem that exercises notation in generated files."
 source = "Internal starter problem."
@@ -38,7 +38,7 @@ id = "chudnovsky_formula_for_pi_inv"
 title = "Chudnovsky formula for pi inverse"
 test = false
 module = "LeanEval.Analysis.Chudnovsky"
-theorem = "chudnovsky_formula_for_pi_inv"
+holes = ["chudnovsky_formula_for_pi_inv"]
 submitter = "Kim Morrison"
 notes = "Uses the existing Mathlib definition of the Chudnovsky series and asks for the missing identity with pi inverse."
 source = "https://link.springer.com/article/10.1007/s40316-018-0102-6"
@@ -49,7 +49,7 @@ id = "pi1_circle_mulEquiv_int"
 title = "pi_1 of the circle is Z"
 test = false
 module = "LeanEval.Topology.HomotopyGroups"
-theorem = "pi1_circle_mulEquiv_int"
+holes = ["pi1_circle_mulEquiv_int"]
 submitter = "Kim Morrison"
 notes = "Computes the fundamental group of the complex unit circle."
 source = "Classical theorem in algebraic topology."
@@ -60,7 +60,7 @@ id = "finite_graph_ramsey_theorem"
 title = "Finite Ramsey theorem for graphs"
 test = false
 module = "LeanEval.Combinatorics.Ramsey"
-theorem = "finite_graph_ramsey_theorem"
+holes = ["finite_graph_ramsey_theorem"]
 submitter = "Kim Morrison"
 notes = "States finite Ramsey existence for red/blue edge colourings of complete graphs, encoded by a graph and its complement."
 source = "Classical theorem in Ramsey theory."
@@ -71,7 +71,7 @@ id = "substInv_X_sub_X_sq_eq_catalan"
 title = "Catalan generating function via compositional inversion"
 test = false
 module = "LeanEval.Combinatorics.CatalanSubstInv"
-theorem = "substInv_X_sub_X_sq_eq_catalan"
+holes = ["substInv_X_sub_X_sq_eq_catalan"]
 submitter = "Kim Morrison"
 notes = "The compositional inverse of X - X² is the generating function for Catalan numbers. This is a classical application of Lagrange inversion in enumerative combinatorics, connecting formal power series inversion to Dyck paths, binary trees, and triangulations."
 source = "E. Catalan, Note sur une équation aux différences finies, 1838; J.-L. Lagrange, Nouvelle méthode pour résoudre les équations littérales, 1770."
@@ -82,7 +82,7 @@ id = "riemann_hypothesis_iff_lagarias_elementary_criterion"
 title = "Lagarias criterion is equivalent to RH"
 test = false
 module = "LeanEval.NumberTheory.Lagarias"
-theorem = "riemann_hypothesis_iff_lagarias_elementary_criterion"
+holes = ["riemann_hypothesis_iff_lagarias_elementary_criterion"]
 submitter = "Kim Morrison"
 notes = "Lagarias' elementary divisor-sum criterion stated using Mathlib's RiemannHypothesis, harmonic numbers, and sigma notation."
 source = "https://arxiv.org/abs/math/0008177"
@@ -93,7 +93,7 @@ id = "dvd_card_connectedComponent_markoffGraph"
 title = "Chen theorem for Markoff graphs"
 test = false
 module = "LeanEval.Combinatorics.MarkoffGraph"
-theorem = "dvd_card_connectedComponent_markoffGraph"
+holes = ["dvd_card_connectedComponent_markoffGraph"]
 submitter = "Kim Morrison"
 notes = "For prime p > 3, every connected component of the nonzero Markoff graph over ZMod p has cardinality divisible by p."
 source = "https://link.springer.com/article/10.1007/s00222-025-01346-9"
@@ -104,7 +104,7 @@ id = "mulCayley_connected_iff_closure_eq_top"
 title = "Cayley graph connected iff generators generate the group"
 test = false
 module = "LeanEval.Combinatorics.CayleyConnected"
-theorem = "mulCayley_connected_iff_closure_eq_top"
+holes = ["mulCayley_connected_iff_closure_eq_top"]
 submitter = "Kim Morrison"
 notes = "A foundational result in geometric group theory using the newly defined Cayley graph. Connectivity of the Cayley graph is equivalent to the generating set S generating G as a group."
 source = "A. Cayley, On the theory of groups, as depending on the symbolic equation θ^n = 1, 1878."
@@ -115,7 +115,7 @@ id = "pi3_sphere_two_mulEquiv_int"
 title = "pi_3 of the 2-sphere is Z"
 test = false
 module = "LeanEval.Topology.HomotopyGroups"
-theorem = "pi3_sphere_two_mulEquiv_int"
+holes = ["pi3_sphere_two_mulEquiv_int"]
 submitter = "Kim Morrison"
 notes = "The classical computation pi_3(S^2) = Z, with an explicit basepoint."
 source = "Classical theorem in algebraic topology."
@@ -126,7 +126,7 @@ id = "pin_sphere_n_mulEquiv_int"
 title = "pi_n of the n-sphere is Z"
 test = false
 module = "LeanEval.Topology.HomotopyGroups"
-theorem = "pin_sphere_n_mulEquiv_int"
+holes = ["pin_sphere_n_mulEquiv_int"]
 submitter = "Kim Morrison"
 notes = "The diagonal sphere homotopy-group computation pi_n(S^n) = Z for n at least 1."
 source = "Classical theorem in algebraic topology."
@@ -137,7 +137,7 @@ id = "pi_succ_sphere_n_mulEquiv_zmod_two"
 title = "pi_(n+1) of S^n is Z/2 for n at least 3"
 test = false
 module = "LeanEval.Topology.HomotopyGroups"
-theorem = "pi_succ_sphere_n_mulEquiv_zmod_two"
+holes = ["pi_succ_sphere_n_mulEquiv_zmod_two"]
 submitter = "Kim Morrison"
 notes = "A concrete stable-family homotopy-group computation."
 source = "Classical theorem in unstable homotopy theory."
@@ -148,7 +148,7 @@ id = "finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow"
 title = "Burnside p^a q^b theorem"
 test = false
 module = "LeanEval.GroupTheory.Burnside"
-theorem = "finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow"
+holes = ["finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow"]
 submitter = "Kim Morrison"
 notes = "Burnside's theorem that a finite group of order p^a q^b is solvable."
 source = "Classical theorem in finite group theory."
@@ -159,7 +159,7 @@ id = "rouche_logCounting_zero_eq"
 title = "Rouche theorem via zero counting"
 test = false
 module = "LeanEval.ComplexAnalysis.Rouche"
-theorem = "rouche_logCounting_zero_eq"
+holes = ["rouche_logCounting_zero_eq"]
 submitter = "Kim Morrison"
 notes = "Phrases Rouché's theorem as equality of zero-counting functions for f and f + g."
 source = "Classical theorem in complex analysis."
@@ -170,7 +170,7 @@ id = "mem_convexHull_finset_extremePoints_of_mem_compact_convex"
 title = "Minkowski-Caratheodory theorem"
 test = false
 module = "LeanEval.ConvexGeometry.MinkowskiCaratheodory"
-theorem = "mem_convexHull_finset_extremePoints_of_mem_compact_convex"
+holes = ["mem_convexHull_finset_extremePoints_of_mem_compact_convex"]
 submitter = "Kim Morrison"
 notes = "Finite-dimensional compact convex sets are generated by their extreme points, with a finrank + 1 bound."
 source = "Classical theorem in convex geometry."
@@ -181,7 +181,7 @@ id = "irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius"
 title = "Perron-Frobenius for irreducible nonnegative matrices"
 test = false
 module = "LeanEval.LinearAlgebra.PerronFrobenius"
-theorem = "irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius"
+holes = ["irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius"]
 submitter = "Kim Morrison"
 notes = "A Perron-Frobenius style eigenvector existence statement at the spectral radius."
 source = "Classical theorem in linear algebra."
@@ -192,7 +192,7 @@ id = "exists_complementary_polynomial_on_unit_circle"
 title = "Complementary polynomial on the unit circle"
 test = false
 module = "LeanEval.ComplexAnalysis.ComplementaryPolynomials"
-theorem = "exists_complementary_polynomial_on_unit_circle"
+holes = ["exists_complementary_polynomial_on_unit_circle"]
 submitter = "Kim Morrison"
 notes = "If a complex polynomial has modulus at most 1 on the unit circle, then there is a same-degree complementary polynomial whose squared moduli add to 1 on the circle."
 source = "https://link.springer.com/article/10.1007/s00220-025-05302-9"
@@ -203,7 +203,7 @@ id = "isStarNormal_mul_of_commute"
 title = "Product of commuting normal elements is normal"
 test = false
 module = "LeanEval.Algebra.NormalProduct"
-theorem = "isStarNormal_mul_of_commute"
+holes = ["isStarNormal_mul_of_commute"]
 submitter = "Kim Morrison"
 notes = "Uses the Fuglede-Putnam-Rosenblum theorem to show all four of a, star a, b, star b pairwise commute, then verifies the normality condition by direct computation."
 source = "B. Fuglede, A commutativity theorem for normal operators, 1950."
@@ -214,7 +214,7 @@ id = "posSemidef_map_exp"
 title = "Entrywise exponential of a PSD matrix is PSD"
 test = false
 module = "LeanEval.LinearAlgebra.EntrywiseExpPSD"
-theorem = "posSemidef_map_exp"
+holes = ["posSemidef_map_exp"]
 submitter = "Kim Morrison"
 notes = "Part of the Schur-Polya-Loewner theory of entrywise functions preserving PSD. The proof uses the Schur product theorem iteratively: exp_⊙(A) = ∑ A^{⊙k}/k!, each Hadamard power is PSD, and the convergent series of PSD matrices is PSD."
 source = "I.J. Schoenberg, Positive definite functions on spheres, 1942."
@@ -225,7 +225,7 @@ id = "oppenheim_inequality"
 title = "Oppenheim's inequality for Hadamard products"
 test = false
 module = "LeanEval.LinearAlgebra.Oppenheim"
-theorem = "oppenheim_inequality"
+holes = ["oppenheim_inequality"]
 submitter = "Kim Morrison"
 notes = "Oppenheim's 1930 inequality: for PSD matrices A, B, det(A ⊙ B) ≥ det(A) · ∏ᵢ Bᵢᵢ. Uses the Schur product theorem (newly formalized) as a key ingredient."
 source = "I. Schur, Bemerkungen zur Theorie der beschränkten Bilinearformen, 1911; A. Oppenheim, Inequalities connected with definite Hermitian forms, 1930."
@@ -236,7 +236,7 @@ id = "vonNeumann_doubleCommutant_tfae"
 title = "von Neumann double commutant theorem"
 test = false
 module = "LeanEval.Analysis.VonNeumannDoubleCommutant"
-theorem = "vonNeumann_doubleCommutant_tfae"
+holes = ["vonNeumann_doubleCommutant_tfae"]
 submitter = "Kim Morrison"
 notes = "The classical double commutant theorem: for a unital *-subalgebra of bounded operators on a complex Hilbert space, equality with the double commutant is equivalent to closedness in the weak operator topology and to closedness in the strong operator topology. WOT and SOT live on Mathlib's irreducible type copies of H →L[ℂ] H (`ContinuousLinearMapWOT` and `PointwiseConvergenceCLM`), so each closure condition is phrased on the image of the carrier under the canonical inclusion."
 source = "J. von Neumann, Zur Algebra der Funktionaloperationen und Theorie der normalen Operatoren, Math. Ann. 102 (1930), 370-427."
@@ -247,7 +247,7 @@ id = "symAction_range_eq_centralizer_glAction"
 title = "Schur-Weyl duality: S_k image equals centralizer of GL(V) image"
 test = false
 module = "LeanEval.RepresentationTheory.SchurWeyl"
-theorem = "symAction_range_eq_centralizer_glAction"
+holes = ["symAction_range_eq_centralizer_glAction"]
 submitter = "Kim Morrison"
 notes = "One direction of Schur-Weyl duality: the subalgebra of End(V^⊗k) generated by the S_k action (permuting factors) equals the centralizer of the subalgebra generated by the diagonal GL(V) action. Hypothesis `Invertible (k! : R)` over a field is exactly the Maschke condition for R[S_k]."
 source = "H. Weyl, The Classical Groups, 1939; I. Schur, Über die rationalen Darstellungen der allgemeinen linearen Gruppe, 1927."
@@ -258,7 +258,7 @@ id = "glAction_range_eq_centralizer_symAction"
 title = "Schur-Weyl duality: GL(V) image equals centralizer of S_k image"
 test = false
 module = "LeanEval.RepresentationTheory.SchurWeyl"
-theorem = "glAction_range_eq_centralizer_symAction"
+holes = ["glAction_range_eq_centralizer_symAction"]
 submitter = "Kim Morrison"
 notes = "The other direction of Schur-Weyl duality: the subalgebra of End(V^⊗k) generated by the diagonal GL(V) action equals the centralizer of the subalgebra generated by the S_k action."
 source = "H. Weyl, The Classical Groups, 1939; I. Schur, Über die rationalen Darstellungen der allgemeinen linearen Gruppe, 1927."
@@ -269,7 +269,7 @@ id = "g2_irrep_tensor_square_decomp"
 title = "Existence of a 64-dim irreducible g₂-representation with 14 tensor-square isotypic components"
 test = false
 module = "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare"
-theorem = "g2_irrep_tensor_square_decomp"
+holes = ["g2_irrep_tensor_square_decomp"]
 submitter = "Kim Morrison"
 notes = "g₂ is the smallest exceptional Lie algebra, defined here by the Serre construction (Mathlib's `LieAlgebra.g₂`). The formal statement is existential: it asks for some 64-dimensional irreducible representation whose tensor square has 14 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight ω₁ + ω₂ (the sum of the two fundamental weights). The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra."
 source = "Classical: representation theory of the exceptional Lie algebra g₂."
@@ -280,7 +280,7 @@ id = "e8_irrep_tensor_square_decomp"
 title = "Existence of a 779247-dim irreducible e₈-representation with 40 tensor-square isotypic components"
 test = false
 module = "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare"
-theorem = "e8_irrep_tensor_square_decomp"
+holes = ["e8_irrep_tensor_square_decomp"]
 submitter = "Kim Morrison"
 notes = "e₈ is the largest exceptional Lie algebra (dim 248), defined here by the Serre construction (Mathlib's `LieAlgebra.e₈`). The formal statement is existential: it asks for some 779247-dimensional irreducible representation whose tensor square has 40 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight ω₁ + ω₈ (the sum of the first and last fundamental weights, in Bourbaki labelling). The U(g)-module structure on V ⊗ V used in the statement comes from lifting the Lie action via the universal enveloping algebra."
 source = "Classical: representation theory of the exceptional Lie algebra e₈."
@@ -291,7 +291,7 @@ id = "cerf_gamma_four"
 title = "Cerf's theorem: every self-diffeomorphism of S3 is smoothly isotopic to a linear isometry"
 test = false
 module = "LeanEval.Topology.CerfGammaFour"
-theorem = "cerf_gamma_four"
+holes = ["cerf_gamma_four"]
 submitter = "Kim Morrison"
 notes = "Cerf's 1968 theorem, the X = point (unparameterized) case of the Smale conjecture. Stated as the existence of a smooth isotopy [0,1] x S3 -> S3 from f to a linear isometry, witnessed by a smooth slice-inverse to encode the diffeomorphism property of each slice without needing a topology on Diffeomorph."
 source = "J. Cerf, Sur les diffeomorphismes de la sphere de dimension trois, Lecture Notes in Mathematics 53, Springer (1968)."
@@ -302,7 +302,7 @@ id = "smale_conjecture"
 title = "Smale conjecture (Hatcher) in relative parameterized form"
 test = false
 module = "LeanEval.Topology.SmaleConjecture"
-theorem = "smale_conjecture"
+holes = ["smale_conjecture"]
 submitter = "Kim Morrison"
 notes = "Hatcher's 1983 theorem that Diff(S3) is homotopy equivalent to O(4), stated in the relative-parameterized-family form (families on a compact manifold-with-boundary X whose boundary already factors through O(4) deform rel boundary to a family fully factoring through O(4)). Mathlib does not yet carry the C-infinity topology on Diffeomorph, which would be needed for the direct homotopy-equivalence formulation."
 source = "A. Hatcher, A proof of the Smale conjecture, Diff(S3) = O(4), Ann. of Math. 117 (1983)."
@@ -313,7 +313,7 @@ id = "cyclotomic_integer_house_le_two"
 title = "Real cyclotomic integer with house at most 2"
 test = false
 module = "LeanEval.NumberTheory.SmallHouse"
-theorem = "cyclotomic_integer_house_le_two"
+holes = ["cyclotomic_integer_house_le_two"]
 submitter = "Kim Morrison"
 notes = "The <= 2 branch of Theorem 1.0.5 from Calegari--Morrison--Snyder, stated using Mathlib's NumberField.house."
 source = "https://arxiv.org/pdf/1004.0665"
@@ -324,7 +324,7 @@ id = "cyclotomic_integer_house_between_two_and_76_33"
 title = "Real cyclotomic integer with house in (2, 76/33)"
 test = false
 module = "LeanEval.NumberTheory.SmallHouse"
-theorem = "cyclotomic_integer_house_between_two_and_76_33"
+holes = ["cyclotomic_integer_house_between_two_and_76_33"]
 submitter = "Kim Morrison"
 notes = "The 2 < house < 76/33 branch of Theorem 1.0.5 from Calegari--Morrison--Snyder, stated using Mathlib's NumberField.house."
 source = "https://arxiv.org/pdf/1004.0665"
@@ -335,7 +335,7 @@ id = "gleason_theorem_finite"
 title = "Gleason's theorem (finite-dimensional)"
 test = false
 module = "LeanEval.Analysis.Gleason"
-theorem = "gleason_theorem_finite"
+holes = ["gleason_theorem_finite"]
 submitter = "Kim Morrison"
 notes = "Gleason's theorem in finite dimensions: every frame function on the orthogonal projections of a complex Hilbert space of dimension at least 3 is given by P ↦ Tr(ρ P) for the unique density operator ρ. Stated using a bespoke `FrameFunction` structure (non-negative, additive on orthogonal projection pairs, normalized at the identity) and the standard Mathlib trace `LinearMap.trace`. Finite additivity on orthogonal pairs already implies countable additivity in finite dimensions, so the hypothesis matches Gleason's original σ-additive frame functions."
 source = "A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893."
@@ -346,8 +346,81 @@ id = "gleason_theorem_separable"
 title = "Gleason's theorem (separable Hilbert space)"
 test = false
 module = "LeanEval.Analysis.Gleason"
-theorem = "gleason_theorem_separable"
+holes = ["gleason_theorem_separable"]
 submitter = "Kim Morrison"
 notes = "Gleason's theorem for a separable complex Hilbert space H of dimension at least 3, in Gleason's original `frame function on the unit sphere' formulation: any non-negative function on the unit sphere whose values sum to 1 along every Hilbert basis is given by x ↦ re ⟨x, ρ x⟩ for some positive bounded operator ρ. The Lean conclusion does not assert that ρ is trace-class with Tr(ρ) = 1; stating that would require trace-class infrastructure not yet at this Mathlib pin. This side-steps the absence of Schatten 1 / trace-class infrastructure in Mathlib at the time of writing."
 source = "A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893."
 informal_solution = "Reduce to the real 3-dimensional case via restriction to real subspaces of H, where Gleason's continuity argument plus an analysis of regular frame functions on S^2 gives a positive quadratic form. Patch these forms together using rotation-invariance and the assumed basis-sum normalization to obtain a globally defined positive bounded operator ρ on H reproducing the frame function on every unit vector."
+[[problem]]
+id = "jacobian_challenge_diffgeo"
+title = "Jacobian of a compact Riemann surface (Buzzard challenge)"
+test = false
+module = "LeanEval.Geometry.JacobianChallenge"
+holes = [
+  "JacobianChallenge.genus",
+  "JacobianChallenge.genus_eq_zero_iff_homeo",
+  "JacobianChallenge.Jacobian",
+  "JacobianChallenge.Jacobian.instAddCommGroup",
+  "JacobianChallenge.Jacobian.instTopologicalSpace",
+  "JacobianChallenge.Jacobian.instT2Space",
+  "JacobianChallenge.Jacobian.instCompactSpace",
+  "JacobianChallenge.Jacobian.instChartedSpace",
+  "JacobianChallenge.Jacobian.instIsManifold",
+  "JacobianChallenge.Jacobian.instLieAddGroup",
+  "JacobianChallenge.Jacobian.ofCurve",
+  "JacobianChallenge.Jacobian.ofCurve_contMDiff",
+  "JacobianChallenge.Jacobian.ofCurve_self",
+  "JacobianChallenge.Jacobian.ofCurve_inj",
+  "JacobianChallenge.Jacobian.pushforward",
+  "JacobianChallenge.Jacobian.pushforward_contMDiff",
+  "JacobianChallenge.Jacobian.pushforward_id_apply",
+  "JacobianChallenge.Jacobian.pushforward_comp_apply",
+  "JacobianChallenge.Jacobian.pullback",
+  "JacobianChallenge.Jacobian.pullback_contMDiff",
+  "JacobianChallenge.Jacobian.pullback_id_apply",
+  "JacobianChallenge.Jacobian.pullback_comp_apply",
+  "JacobianChallenge.Jacobian.degree",
+  "JacobianChallenge.Jacobian.pushforward_pullback",
+]
+submitter = "Kevin Buzzard"
+source = "https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge"
+informal_solution = "Construct J(X) as H^0(X, Omega^1)* / H_1(X, Z), the period lattice quotient; the Abel-Jacobi map sends a point to the linear functional 'integrate from a fixed basepoint to here'. Functoriality and the projection formula come from pushforward and pullback of differential forms."
+
+[[problem]]
+id = "jacobian_challenge_alggeo"
+title = "Jacobian of a smooth proper curve (Merten challenge)"
+test = false
+module = "LeanEval.AlgebraicGeometry.JacobianChallenge"
+holes = [
+  "AlgebraicGeometry.JacobianChallenge.genus",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian.smoothOfRelativeDimension_genus",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian.instIsProper",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian.instGeometricallyIrreducible",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian.comp_ofCurve",
+  "AlgebraicGeometry.JacobianChallenge.Jacobian.exists_unique_ofCurve_comp",
+]
+submitter = "Christian Merten"
+source = "https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685"
+informal_solution = "Build the Albanese variety of C as the universal abelian variety receiving a pointed map from C; Weil's construction of the Jacobian of a curve makes this concrete via Pic^0(C). The universal property is the no-cheating clamp."
+
+[[problem]]
+id = "def_hole_example"
+title = "def-hole minimal example"
+test = true
+module = "LeanEval.Sandbox.DefHoleExample"
+holes = ["foo", "foo_def"]
+submitter = "Kim Morrison"
+notes = "Minimal example exercising def + theorem holes through the comparator def-hole pipeline."
+
+[[problem]]
+id = "instance_hole_example"
+title = "instance-hole minimal example"
+test = true
+module = "LeanEval.Sandbox.InstanceHoleExample"
+holes = ["WidgetCarrier", "instInhabitedWidget"]
+submitter = "Kim Morrison"
+notes = "Minimal example exercising instance + theorem holes; instances must be named so the comparator can address them."
+

--- a/scripts/generate_projects.py
+++ b/scripts/generate_projects.py
@@ -37,6 +37,45 @@ EXPECTED_FILES = {
 IGNORED_PATH_NAMES = {".lake", "build", ".cache", "lake-manifest.json"}
 
 
+_WORKSPACE_TEST_LEAN = (
+    "import Lean\n\n"
+    "open Lean\n\n"
+    "def comparatorExists (comparatorBin : String) : IO Bool := do\n"
+    "  if comparatorBin.contains '/' then\n"
+    "    return (← System.FilePath.pathExists comparatorBin)\n"
+    "  try\n"
+    "    let child ← IO.Process.spawn {\n"
+    '      cmd := "sh"\n'
+    '      args := #["-c", "command -v \\\"$1\\\" >/dev/null 2>&1", "sh", comparatorBin]\n'
+    "    }\n"
+    "    let exitCode ← child.wait\n"
+    "    return exitCode == 0\n"
+    "  catch _ =>\n"
+    "    return false\n\n"
+    "def main : IO UInt32 := do\n"
+    '  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"\n'
+    "  if !(← comparatorExists comparatorBin) then\n"
+    '    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."\n'
+    '    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."\n'
+    '    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."\n'
+    "    pure 1\n"
+    "  else\n"
+    "    try\n"
+    "      let child ← IO.Process.spawn {\n"
+    '        cmd := "lake"\n'
+    '        args := #["env", comparatorBin, "config.json"]\n'
+    "      }\n"
+    "      let exitCode ← child.wait\n"
+    "      pure exitCode\n"
+    "    catch err =>\n"
+    '      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."\n'
+    '      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."\n'
+    '      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."\n'
+    '      IO.eprintln s!"Original error: {err}"\n'
+    "      pure 1\n"
+)
+
+
 def _theorem_by_pattern(theorem_name: str) -> re.Pattern[str]:
     return re.compile(
         rf"(?:^|\s)theorem\s+{re.escape(theorem_name)}\b(?P<body>.*?)(?:\s*:=\s*by\b)",
@@ -54,11 +93,15 @@ class ProblemSpec:
     title: str
     test: bool
     module: str
-    theorem: str
+    holes: tuple[str, ...]
     submitter: str
     notes: str | None = None
     source: str | None = None
     informal_solution: str | None = None
+
+    @property
+    def is_multi_hole(self) -> bool:
+        return len(self.holes) != 1
 
 
 @dataclass(frozen=True)
@@ -67,6 +110,7 @@ class ExtractedTheorem:
     module: str
     source_range: tuple[int, int, int, int]
     same_module_dependencies: tuple[str, ...]
+    kind: str  # "theorem", "def", or "instance"
 
 
 @dataclass(frozen=True)
@@ -76,11 +120,19 @@ class DependencySpec:
     rev: str
 
 
+def _theorem_pattern(theorem_name: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"(?:^|\s)(?:theorem|opaque|def|instance)\s+{re.escape(theorem_name)}\b",
+        re.DOTALL,
+    )
+
+
 @dataclass(frozen=True)
 class InventoryEntry:
     module: str
     declaration_name: str
     basename: str
+    kind: str  # "theorem", "def", or "instance"
 
 
 def load_root_mathlib_dependency(path: pathlib.Path | None = None) -> DependencySpec:
@@ -126,7 +178,7 @@ def load_manifest(path: pathlib.Path) -> list[ProblemSpec]:
 
 
 def parse_problem(raw_problem: dict, index: int) -> ProblemSpec:
-    required_fields = ["id", "title", "module", "theorem", "submitter"]
+    required_fields = ["id", "title", "module", "submitter"]
     optional_fields = ["notes", "source", "informal_solution"]
 
     values: dict[str, str | None] = {}
@@ -161,12 +213,30 @@ def parse_problem(raw_problem: dict, index: int) -> ProblemSpec:
             f"Problem '{problem_id}' has non-boolean field 'test'"
         )
 
+    holes_value = raw_problem.get("holes")
+    if not isinstance(holes_value, list) or not holes_value:
+        raise GenerationError(
+            f"Problem '{problem_id}' must give 'holes' as a non-empty array of strings."
+        )
+    holes_list: list[str] = []
+    for entry in holes_value:
+        if not isinstance(entry, str) or not entry.strip():
+            raise GenerationError(
+                f"Problem '{problem_id}' has an empty or non-string entry in 'holes'."
+            )
+        holes_list.append(entry.strip())
+    if len(set(holes_list)) != len(holes_list):
+        raise GenerationError(
+            f"Problem '{problem_id}' has duplicate entries in 'holes'."
+        )
+    holes = tuple(holes_list)
+
     return ProblemSpec(
         id=values["id"],
         title=values["title"],
         test=test_value,
         module=values["module"],
-        theorem=values["theorem"],
+        holes=holes,
         submitter=values["submitter"],
         notes=values["notes"],
         source=values["source"],
@@ -176,18 +246,19 @@ def parse_problem(raw_problem: dict, index: int) -> ProblemSpec:
 
 def validate_problems(problems: list[ProblemSpec]) -> None:
     seen_ids: set[str] = set()
-    seen_theorems: set[tuple[str, str]] = set()
+    seen_holes: set[tuple[str, str]] = set()
     for problem in problems:
         if problem.id in seen_ids:
             raise GenerationError(f"Duplicate problem id '{problem.id}'")
         seen_ids.add(problem.id)
 
-        theorem_key = (problem.module, problem.theorem)
-        if theorem_key in seen_theorems:
-            raise GenerationError(
-                f"Duplicate theorem reference '{problem.module}:{problem.theorem}'"
-            )
-        seen_theorems.add(theorem_key)
+        for hole in problem.holes:
+            hole_key = (problem.module, hole)
+            if hole_key in seen_holes:
+                raise GenerationError(
+                    f"Duplicate hole reference '{problem.module}:{hole}'"
+                )
+            seen_holes.add(hole_key)
 
 
 def run(
@@ -240,19 +311,19 @@ def build_extractor(problems: list[ProblemSpec]) -> None:
     )
 
 
-def extract_theorem(problem: ProblemSpec) -> ExtractedTheorem:
+def extract_one(problem: ProblemSpec, hole: str) -> ExtractedTheorem:
     binary_path = REPO_ROOT / ".lake" / "build" / "bin" / "extract_theorem"
     completed = run(
-        ["lake", "env", str(binary_path), problem.module, problem.theorem],
+        ["lake", "env", str(binary_path), problem.module, hole],
         cwd=REPO_ROOT,
         capture_output=True,
-        error_prefix=f"Lean extraction failed for '{problem.id}'",
+        error_prefix=f"Lean extraction failed for '{problem.id}' hole '{hole}'",
     )
     try:
         payload = json.loads(completed.stdout)
     except json.JSONDecodeError as exc:
         raise GenerationError(
-            f"Lean extractor returned invalid JSON for '{problem.id}': {exc}"
+            f"Lean extractor returned invalid JSON for '{problem.id}' hole '{hole}': {exc}"
         ) from exc
 
     try:
@@ -268,10 +339,11 @@ def extract_theorem(problem: ProblemSpec) -> ExtractedTheorem:
             same_module_dependencies=tuple(
                 str(name) for name in payload.get("sameModuleDependencies", [])
             ),
+            kind=str(payload["kind"]),
         )
     except KeyError as exc:
         raise GenerationError(
-            f"Lean extractor response for '{problem.id}' is missing field {exc}"
+            f"Lean extractor response for '{problem.id}' hole '{hole}' is missing field {exc}"
         ) from exc
 
 
@@ -295,6 +367,7 @@ def inventory_entries(problems: list[ProblemSpec]) -> list[InventoryEntry]:
                 module=str(raw_entry["module"]),
                 declaration_name=str(raw_entry["declarationName"]),
                 basename=str(raw_entry["basename"]),
+                kind=str(raw_entry["kind"]),
             )
         )
     return entries
@@ -309,22 +382,23 @@ def validate_manifest_against_inventory(problems: list[ProblemSpec]) -> None:
 
     matched_declarations: set[str] = set()
     for problem in problems:
-        candidates = [
-            entry
-            for entry in by_module.get(problem.module, [])
-            if problem.theorem in {entry.basename, entry.declaration_name}
-        ]
-        if not candidates:
-            raise GenerationError(
-                f"Manifest entry '{problem.id}' does not match any @[eval_problem] theorem in "
-                f"module '{problem.module}'."
-            )
-        if len(candidates) > 1:
-            raise GenerationError(
-                f"Manifest entry '{problem.id}' is ambiguous in module '{problem.module}'. "
-                f"Use a fully qualified theorem name."
-            )
-        matched_declarations.add(candidates[0].declaration_name)
+        for hole in problem.holes:
+            candidates = [
+                entry
+                for entry in by_module.get(problem.module, [])
+                if hole in {entry.basename, entry.declaration_name}
+            ]
+            if not candidates:
+                raise GenerationError(
+                    f"Manifest entry '{problem.id}' references hole '{hole}' which has no "
+                    f"@[eval_problem] declaration in module '{problem.module}'."
+                )
+            if len(candidates) > 1:
+                raise GenerationError(
+                    f"Manifest entry '{problem.id}' hole '{hole}' is ambiguous in module "
+                    f"'{problem.module}'. Use a fully qualified name."
+                )
+            matched_declarations.add(candidates[0].declaration_name)
 
     untracked = sorted(
         entry.declaration_name
@@ -334,12 +408,17 @@ def validate_manifest_against_inventory(problems: list[ProblemSpec]) -> None:
     if untracked:
         joined = ", ".join(untracked)
         raise GenerationError(
-            "Tagged @[eval_problem] theorem(s) are missing from manifests/problems.toml: "
+            "Tagged @[eval_problem] declaration(s) are missing from manifests/problems.toml: "
             f"{joined}"
         )
 
 
-def validate_theorem_proof_shape(problems: list[ProblemSpec]) -> None:
+def validate_hole_shape(problems: list[ProblemSpec]) -> None:
+    """Sanity-check that each manifest hole is declared as a top-level
+    theorem/def/instance in its source module. Type-correctness is enforced
+    by `validate_manifest_against_inventory` (which builds the source);
+    this check is just for early failure with a clear message when a
+    manifest entry has a typo'd name."""
     for problem in problems:
         source_path = module_source_path(problem.module)
         if not source_path.is_file():
@@ -347,14 +426,13 @@ def validate_theorem_proof_shape(problems: list[ProblemSpec]) -> None:
                 f"Source file for module '{problem.module}' not found: {source_path}"
             )
         source_text = source_path.read_text(encoding="utf-8")
-        theorem_name = problem.theorem.rsplit(".", maxsplit=1)[-1]
-        if not _theorem_by_pattern(theorem_name).search(source_text):
-            raise GenerationError(
-                f"Problem '{problem.id}' points at `theorem {theorem_name}` in "
-                f"{source_path.relative_to(REPO_ROOT)}, but the declaration does not match "
-                "the required `theorem <name> ... := by` shape used by the source slicer. "
-                "Rewrite the proof as `:= by <tactics-or-sorry>`."
-            )
+        for hole in problem.holes:
+            basename = hole.rsplit(".", maxsplit=1)[-1]
+            if not _theorem_pattern(basename).search(source_text):
+                raise GenerationError(
+                    f"Problem '{problem.id}' lists hole '{basename}' which is not declared "
+                    f"as a top-level theorem/def/instance in {source_path.relative_to(REPO_ROOT)}."
+                )
 
 
 def local_theorem_name(extracted: ExtractedTheorem) -> str:
@@ -619,10 +697,29 @@ def explicit_binder_application_args(theorem_statement: str) -> list[str]:
 
 def render_workspace(
     problem: ProblemSpec,
-    extracted: ExtractedTheorem,
+    extracteds: list[ExtractedTheorem],
     toolchain: str,
     mathlib_dependency: DependencySpec,
 ) -> dict[str, str]:
+    """Generate the comparator workspace files for one problem.
+
+    Two code paths:
+    - Legacy single-theorem path (one hole, kind="theorem"): preserves the
+      historical layout with `ChallengeDeps.lean` (for same-module dependencies)
+      and a sliced `theorem ...` statement in `Challenge.lean`. All existing
+      single-theorem problems take this path, so byte-identical regeneration
+      is preserved.
+    - Multi-hole path (defs / instances / multiple holes): copies the entire
+      source module verbatim into `Challenge.lean` with `@[eval_problem]`
+      attributes stripped, and emits a thin `Solution.lean` whose holes
+      delegate to `Submission`. No `ChallengeDeps.lean`.
+    """
+    use_multi_hole = problem.is_multi_hole or extracteds[0].kind != "theorem"
+    if use_multi_hole:
+        return _render_workspace_multi_hole(
+            problem, extracteds, toolchain, mathlib_dependency
+        )
+    [extracted] = extracteds
     theorem_name = local_theorem_name(extracted)
     theorem_statement = extract_statement_text(problem, extracted)
     solution_args = explicit_binder_application_args(theorem_statement)
@@ -742,47 +839,361 @@ def render_workspace(
             "namespace Submission.Helpers\n\n"
             "end Submission.Helpers\n"
         ),
-        "WorkspaceTest.lean": (
-            "import Lean\n\n"
-            "open Lean\n\n"
-            "def comparatorExists (comparatorBin : String) : IO Bool := do\n"
-            "  if comparatorBin.contains '/' then\n"
-            "    return (← System.FilePath.pathExists comparatorBin)\n"
-            "  try\n"
-            "    let child ← IO.Process.spawn {\n"
-            '      cmd := "sh"\n'
-            '      args := #["-c", "command -v \\\"$1\\\" >/dev/null 2>&1", "sh", comparatorBin]\n'
-            "    }\n"
-            "    let exitCode ← child.wait\n"
-            "    return exitCode == 0\n"
-            "  catch _ =>\n"
-            "    return false\n\n"
-            "def main : IO UInt32 := do\n"
-            '  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"\n'
-            "  if !(← comparatorExists comparatorBin) then\n"
-            '    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."\n'
-            '    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."\n'
-            '    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."\n'
-            "    pure 1\n"
-            "  else\n"
-            "    try\n"
-            "      let child ← IO.Process.spawn {\n"
-            '        cmd := "lake"\n'
-            '        args := #["env", comparatorBin, "config.json"]\n'
-            "      }\n"
-            "      let exitCode ← child.wait\n"
-            "      pure exitCode\n"
-            "    catch err =>\n"
-            '      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."\n'
-            '      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."\n'
-            '      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."\n'
-            '      IO.eprintln s!"Original error: {err}"\n'
-            "      pure 1\n"
-        ),
+        "WorkspaceTest.lean": _WORKSPACE_TEST_LEAN,
         "config.json": json.dumps(config, indent=2) + "\n",
     }
     if challenge_deps is not None:
         files["ChallengeDeps.lean"] = challenge_deps
+    return files
+
+
+# Lines that appear in source modules to mark eval-problem holes; these get
+# stripped from the generated `Challenge.lean` so that submitters do not see
+# (or accidentally rely on) the `@[eval_problem]` attribute machinery.
+_EVAL_PROBLEM_ATTR_RE = re.compile(r"^\s*@\[eval_problem\]\s*\n", re.MULTILINE)
+_EVAL_TOOLS_IMPORT_RE = re.compile(r"^\s*import\s+EvalTools\.Markers\s*\n", re.MULTILINE)
+
+
+def _strip_problem_markers(source_text: str) -> str:
+    """Remove `@[eval_problem]` attributes and the `EvalTools.Markers` import
+    from source text destined for the generated `Challenge.lean`. The marker
+    machinery exists only on the trusted side and must not leak into a problem
+    workspace (which has no `EvalTools` dependency)."""
+    text = _EVAL_PROBLEM_ATTR_RE.sub("", source_text)
+    text = _EVAL_TOOLS_IMPORT_RE.sub("", text)
+    return text
+
+
+def _scan_header(lines: list[str]) -> tuple[int, int]:
+    """Walk top-of-file lines and classify each as part of the file header
+    (imports, blank lines, line comments `--`, block comments `/- ... -/`)
+    versus the body. Returns `(insert_after_imports, body_start)` line indices.
+
+    `insert_after_imports` is the index where a new `import` line should be
+    inserted (i.e. just after the last existing import; falls back to 0 if
+    there are no imports). `body_start` is the index of the first body line."""
+    in_block_comment = False
+    last_import_idx = -1
+    body_start = len(lines)
+    for idx, raw in enumerate(lines):
+        stripped = raw.strip()
+        if in_block_comment:
+            if "-/" in stripped:
+                in_block_comment = False
+            continue
+        if stripped == "":
+            continue
+        if stripped.startswith("--"):
+            continue
+        if stripped.startswith("/-"):
+            if "-/" not in stripped[2:]:
+                in_block_comment = True
+            continue
+        if stripped.startswith("import "):
+            last_import_idx = idx
+            continue
+        body_start = idx
+        break
+    insert_after_imports = last_import_idx + 1 if last_import_idx >= 0 else 0
+    return insert_after_imports, body_start
+
+
+def _inject_after_imports(source_text: str, line: str) -> str:
+    """Insert `line` (must end in a newline) just after the trailing `import`
+    line at the top of `source_text`. If there are no imports we prepend
+    `import Mathlib` followed by `line`."""
+    lines = source_text.splitlines(keepends=True)
+    insert_at, _ = _scan_header(lines)
+    if insert_at == 0 and not any(l.lstrip().startswith("import ") for l in lines):
+        return "import Mathlib\n" + line + source_text
+    return "".join(lines[:insert_at]) + line + "".join(lines[insert_at:])
+
+
+_TOP_LEVEL_NAMESPACE_RE = re.compile(r"^namespace\s+([A-Za-z_][\w.]*)")
+_END_NAMESPACE_RE = re.compile(r"^end\s+([A-Za-z_][\w.]*)")
+
+
+def _top_level_namespaces(body: str, user_namespace: str) -> list[str]:
+    """Return the names of top-level (depth-0) `namespace X` declarations in
+    `body` to `open` after `namespace Submission`, preserving source order
+    and removing duplicates. We exclude the user-declared namespace
+    (`user_namespace`, typically the source module's last path component)
+    because it is freshly created by the source — `open`ing it before the
+    `namespace user_namespace` line would fail with "unknown namespace".
+    Top-level namespaces that the source merely re-enters (e.g. Mathlib's
+    `AlgebraicGeometry`) DO need to be `open`ed, otherwise unqualified
+    references inside (e.g. `Spec`) won't resolve once we wrap the body in
+    `namespace Submission`."""
+    by_order: list[str] = []
+    seen: set[str] = set()
+    depth = 0
+    for raw in body.splitlines():
+        if raw.lstrip().startswith("--"):
+            continue
+        m = _TOP_LEVEL_NAMESPACE_RE.match(raw)
+        if m:
+            name = m.group(1)
+            if depth == 0 and name != user_namespace and name not in seen:
+                by_order.append(name)
+                seen.add(name)
+            depth += 1
+            continue
+        if _END_NAMESPACE_RE.match(raw):
+            depth -= 1
+    return by_order
+
+
+def _wrap_body_in_submission_namespace(source_text: str, user_namespace: str) -> str:
+    """Wrap everything after the source's import block in
+    `namespace Submission ... end Submission`. The Submission namespace lives
+    OUTSIDE any namespaces declared in the source, so a hole declared in
+    `namespace JacobianChallenge` becomes `Submission.JacobianChallenge.X`.
+
+    We also `open` every top-level namespace declared in the source so that
+    references inside (e.g. `Spec` inside `namespace AlgebraicGeometry`) keep
+    resolving — without the `open`, the body's `namespace AlgebraicGeometry`
+    would land in `Submission.AlgebraicGeometry`, which doesn't have `Spec`."""
+    lines = source_text.splitlines(keepends=True)
+    _, body_start = _scan_header(lines)
+    if body_start >= len(lines):
+        return source_text
+    head = "".join(lines[:body_start])
+    body = "".join(lines[body_start:])
+    if not body.endswith("\n"):
+        body += "\n"
+    opens = "".join(f"open {ns}\n" for ns in _top_level_namespaces(body, user_namespace))
+    return head + "\nnamespace Submission\n\n" + opens + body + "\nend Submission\n"
+
+
+def _hole_decl_signature(decl_text: str, basename: str) -> str:
+    """Strip the body off a sliced hole declaration so callers can append
+    their own body. `decl_text` is the source slice of the form
+
+        @[some_attr] def basename (args) : Type := <body>
+
+    or any other top-level form ending in `:= ...`. Returns the prefix up to
+    and including `:=`.
+    """
+    # Drop attributes (already stripped for Challenge but not necessarily
+    # for our hole-by-hole slicing).
+    text = _EVAL_PROBLEM_ATTR_RE.sub("", decl_text).strip()
+    # Find the LAST `:=` at top level. The declaration body is everything after.
+    # We trust that hole signatures don't contain `:=` (no `let ... :=` in a
+    # type, no anonymous constructors with `:=`). Holes' bodies are `sorry`
+    # so this is safe for the source files we generate from.
+    marker = ":="
+    idx = text.rfind(marker)
+    if idx < 0:
+        raise GenerationError(
+            f"Hole '{basename}' declaration has no `:=` to split: {text!r}"
+        )
+    prefix = text[:idx].rstrip()
+    return prefix + " := "
+
+
+def _render_workspace_multi_hole(
+    problem: ProblemSpec,
+    extracteds: list[ExtractedTheorem],
+    toolchain: str,
+    mathlib_dependency: DependencySpec,
+) -> dict[str, str]:
+    """Multi-hole rendering keeps the source's `variable`/`open`/`namespace`
+    structure intact so each hole's signature still type-checks. Three files
+    are produced from the same source, with body rewrites:
+
+    - `Challenge.lean`: source verbatim minus `@[eval_problem]` markers; all
+      hole bodies stay as `sorry`.
+    - `Solution.lean`: source verbatim with each hole's body rewritten to
+      `Submission.<full-namespaced-name>`. Comparator compares Challenge and
+      Solution by qualified hole name; both files preserve the source's
+      namespace structure so the names match.
+    - `Submission.lean`: source verbatim wrapped in `namespace Submission`,
+      with hole bodies left as `sorry` for the participant to fill in.
+      Submission's holes therefore live at `Submission.<full-namespaced-name>`.
+    """
+    source_path = module_source_path(problem.module)
+    if not source_path.is_file():
+        raise GenerationError(
+            f"Source file for module '{problem.module}' not found: {source_path}"
+        )
+    source_text = source_path.read_text(encoding="utf-8")
+
+    # Sort holes by start position so we can splice into the source text in a
+    # single forward pass (then iterate in reverse when applying replacements
+    # so earlier offsets stay valid).
+    holes_with_ranges = []
+    for extracted in extracteds:
+        full_name = extracted.declaration_name
+        start, end = offset_range_for_source_range(source_text, extracted.source_range)
+        holes_with_ranges.append((start, end, full_name, extracted.kind))
+    holes_with_ranges.sort()
+
+    # Split hole names into theorem_names vs definition_names per comparator's
+    # config schema. Both `def` and `instance` go in `definition_names`.
+    theorem_names: list[str] = []
+    definition_names: list[str] = []
+    for _start, _end, full_name, kind in holes_with_ranges:
+        if kind == "theorem":
+            theorem_names.append(full_name)
+        else:
+            definition_names.append(full_name)
+
+    challenge_body = _strip_problem_markers(source_text)
+    if not challenge_body.lstrip().startswith("import "):
+        challenge_body = "import Mathlib\n\n" + challenge_body
+
+    # Solution.lean: same as source, but each hole's body is replaced by
+    # `Submission.<full_name> <explicit-args>`. We splice replacements into
+    # the source from back to front so earlier offsets remain valid.
+    # Explicit args from the decl's leading binders are applied so the
+    # delegating call has the right type at the body position; implicit
+    # and instance args are inferred by Lean.
+    solution_text = source_text
+    for start, end, full_name, kind in reversed(holes_with_ranges):
+        decl_text = source_text[start:end]
+        basename = full_name.rsplit(".", maxsplit=1)[-1]
+        signature = _hole_decl_signature(decl_text, basename)
+        # Make Solution-side `def`/`instance` holes reducible so later decls in
+        # the same Solution.lean (e.g. a theorem hole that mentions a def hole
+        # in its statement) can defeq-unify their references with the
+        # corresponding `Submission.X` term that the theorem hole's body
+        # delegates to. Inject `@[reducible]` immediately before the
+        # declaration keyword so it sits AFTER the doc comment (Lean rejects
+        # `@[attr] /-- doc -/ def`).
+        if kind != "theorem":
+            keyword_pos = re.search(
+                rf"\b(?:def|instance|abbrev)\s+{re.escape(basename)}\b",
+                signature,
+            )
+            if keyword_pos is None:
+                raise GenerationError(
+                    f"Could not anchor `@[reducible]` injection in signature for hole '{full_name}'."
+                )
+            signature = (
+                signature[: keyword_pos.start()]
+                + "@[reducible] "
+                + signature[keyword_pos.start() :]
+            )
+        # Find the part of the decl text BETWEEN the basename and `:=`, which
+        # is the binder/return-type slice; pass it to the existing argument
+        # extractor.
+        # Anchor to the actual declaration keyword (`def`/`instance`/`theorem`)
+        # followed by the basename — otherwise an earlier `/-- doc comment that
+        # mentions {basename} -/` would steal the match.
+        keyword_match = re.search(
+            rf"\b(?:def|instance|theorem|opaque|lemma|abbrev|class|example)\s+{re.escape(basename)}\b",
+            decl_text,
+        )
+        if keyword_match is None:
+            raise GenerationError(
+                f"Could not locate basename '{basename}' in source decl for hole '{full_name}'."
+            )
+        between = decl_text[keyword_match.end():]
+        last_eq = between.rfind(":=")
+        if last_eq < 0:
+            raise GenerationError(
+                f"Source decl for hole '{full_name}' has no `:=` body marker."
+            )
+        statement = between[:last_eq]
+        explicit_args = explicit_binder_application_args(statement)
+        applied = f"Submission.{full_name}"
+        if explicit_args:
+            applied += " " + " ".join(explicit_args)
+        new_decl = signature + applied
+        solution_text = solution_text[:start] + new_decl + solution_text[end:]
+    solution_body = _strip_problem_markers(solution_text)
+    # Solution must `import Submission` (after the source's other imports) so
+    # that references to `Submission.X` resolve.
+    solution_body = _inject_after_imports(solution_body, "import Submission\n")
+
+    # Submission.lean: source verbatim wrapped in `namespace Submission`. The
+    # source's own imports stay at the top (above the namespace); we add
+    # `import Submission.Helpers` for participant convenience.
+    submission_text = _strip_problem_markers(source_text)
+    submission_text = _inject_after_imports(submission_text, "import Submission.Helpers\n")
+    submission_body = _wrap_body_in_submission_namespace(
+        submission_text, problem.module.rsplit(".", maxsplit=1)[-1]
+    )
+
+    readme_lines = [
+        f"# `{problem.id}`",
+        "",
+        problem.title,
+        "",
+        f"- Problem ID: `{problem.id}`",
+        f"- Test Problem: {'yes' if problem.test else 'no'}",
+        f"- Submitter: {problem.submitter}",
+        f"- Holes ({len(extracteds)}): "
+        + ", ".join(f"`{e.declaration_name}` ({e.kind})" for e in extracteds),
+    ]
+    if problem.notes:
+        readme_lines.append(f"- Notes: {problem.notes}")
+    if problem.source:
+        readme_lines.append(f"- Source: {problem.source}")
+    if problem.informal_solution:
+        readme_lines.append(f"- Informal solution: {problem.informal_solution}")
+    readme_lines.extend(
+        [
+            "",
+            "Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the",
+            "trusted benchmark and fixed by the repository.",
+            "",
+            "This is a multi-hole problem: the challenge declares multiple `def`s,",
+            "`instance`s, and/or `theorem`s as `sorry`. Fill all of them in",
+            "`Submission.lean` (under `namespace Submission`) for comparator to accept",
+            "your solution.",
+            "",
+            "Participants may use Mathlib freely. Any helper code not already available in",
+            "Mathlib must be inlined into the submission workspace.",
+            "",
+            "`lake test` runs comparator for this problem. The command expects a comparator",
+            "binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.",
+        ]
+    )
+
+    config: dict[str, object] = {
+        "challenge_module": "Challenge",
+        "solution_module": "Solution",
+        "theorem_names": theorem_names,
+        "permitted_axioms": FIXED_AXIOMS,
+        "enable_nanoda": False,
+    }
+    if definition_names:
+        config["definition_names"] = definition_names
+
+    files = {
+        "README.md": "\n".join(readme_lines) + "\n",
+        "lean-toolchain": toolchain if toolchain.endswith("\n") else toolchain + "\n",
+        "lakefile.toml": (
+            f'name = "{problem.id}"\n'
+            + 'testDriver = "workspace_test"\n'
+            + 'defaultTargets = ["Challenge", "Solution", "Submission"]\n\n'
+            + "[leanOptions]\n"
+            + 'autoImplicit = false\n\n'
+            + "[[require]]\n"
+            + f'name = "{mathlib_dependency.name}"\n'
+            + f'git = "{mathlib_dependency.git}"\n'
+            + f'rev = "{mathlib_dependency.rev}"\n\n'
+            + "[[lean_lib]]\n"
+            + 'name = "Challenge"\n\n'
+            + "[[lean_lib]]\n"
+            + 'name = "Solution"\n\n'
+            + "[[lean_lib]]\n"
+            + 'name = "Submission"\n\n'
+            + "[[lean_exe]]\n"
+            + 'name = "workspace_test"\n'
+            + 'root = "WorkspaceTest"\n'
+        ),
+        "Challenge.lean": challenge_body if challenge_body.endswith("\n") else challenge_body + "\n",
+        "Solution.lean": solution_body,
+        "Submission.lean": submission_body,
+        "Submission/Helpers.lean": (
+            "namespace Submission.Helpers\n\n"
+            "end Submission.Helpers\n"
+        ),
+        "WorkspaceTest.lean": _WORKSPACE_TEST_LEAN,
+        "config.json": json.dumps(config, indent=2) + "\n",
+    }
     return files
 
 
@@ -883,7 +1294,7 @@ def generate(
     manifest_path: pathlib.Path,
     selected_problem_id: str | None,
     check: bool,
-    extractor: Callable[[ProblemSpec], ExtractedTheorem] = extract_theorem,
+    extractor: Callable[[ProblemSpec, str], ExtractedTheorem] = extract_one,
 ) -> None:
     problems = load_manifest(manifest_path)
     validate_problems(problems)
@@ -901,34 +1312,32 @@ def generate(
         if sync_mismatches:
             raise GenerationError("\n".join(sync_mismatches))
 
-    validate_theorem_proof_shape(problems)
+    validate_hole_shape(problems)
 
     toolchain = (REPO_ROOT / "lean-toolchain").read_text(encoding="utf-8")
     mathlib_dependency = load_root_mathlib_dependency()
 
     build_extractor(problems)
 
-    index_entries: list[dict[str, str]] = []
+    index_entries: list[dict[str, object]] = []
     mismatches: list[str] = []
     for problem in problems:
-        extracted = extractor(problem)
-        files = render_workspace(problem, extracted, toolchain, mathlib_dependency)
+        extracteds = [extractor(problem, hole) for hole in problem.holes]
+        files = render_workspace(problem, extracteds, toolchain, mathlib_dependency)
         problem_dir = GENERATED_ROOT / problem.id
         if check:
             mismatches.extend(check_workspace(problem_dir, files))
         else:
             write_workspace(problem_dir, files)
-        index_entries.append(
-            {
-                "id": problem.id,
-                "title": problem.title,
-                "test": problem.test,
-                "submitter": problem.submitter,
-                "module": problem.module,
-                "theorem": problem.theorem,
-                "generated_path": f"generated/{problem.id}",
-            }
-        )
+        index_entries.append({
+            "id": problem.id,
+            "title": problem.title,
+            "test": problem.test,
+            "submitter": problem.submitter,
+            "module": problem.module,
+            "holes": list(problem.holes),
+            "generated_path": f"generated/{problem.id}",
+        })
 
     if selected_problem_id is None:
         mismatches.extend(write_or_check_index(index_entries, check))

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -35,12 +35,12 @@ class ProblemScore:
 def expected_workspace_files(
     problem: gp.ProblemSpec,
     *,
-    extractor: Callable[[gp.ProblemSpec], gp.ExtractedTheorem],
+    extractor: Callable[[gp.ProblemSpec, str], gp.ExtractedTheorem],
 ) -> dict[str, str]:
     toolchain = (gp.REPO_ROOT / "lean-toolchain").read_text(encoding="utf-8")
     mathlib_dependency = gp.load_root_mathlib_dependency()
-    extracted = extractor(problem)
-    return gp.render_workspace(problem, extracted, toolchain, mathlib_dependency)
+    extracteds = [extractor(problem, hole) for hole in problem.holes]
+    return gp.render_workspace(problem, extracteds, toolchain, mathlib_dependency)
 
 
 def workspace_path_for_problem(
@@ -57,7 +57,7 @@ def workspace_path_for_problem(
 def problem_attempt_mismatches(
     problem: gp.ProblemSpec,
     *,
-    extractor: Callable[[gp.ProblemSpec], gp.ExtractedTheorem],
+    extractor: Callable[[gp.ProblemSpec, str], gp.ExtractedTheorem],
     workspaces_root: pathlib.Path = DEFAULT_WORKSPACES_ROOT,
 ) -> list[str]:
     expected_files = expected_workspace_files(problem, extractor=extractor)
@@ -90,7 +90,7 @@ def run_problem_test(
 def score_problems(
     problems: list[gp.ProblemSpec],
     *,
-    extractor: Callable[[gp.ProblemSpec], gp.ExtractedTheorem] = gp.extract_theorem,
+    extractor: Callable[[gp.ProblemSpec, str], gp.ExtractedTheorem] = gp.extract_one,
     workspaces_root: pathlib.Path = DEFAULT_WORKSPACES_ROOT,
     mismatch_detector: Callable[[gp.ProblemSpec], list[str]] | None = None,
     test_runner: Callable[[str], int] = run_problem_test,

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -13,7 +13,7 @@ def main() -> int:
         problems = gp.load_manifest(manifest_path)
         gp.validate_problems(problems)
         gp.validate_manifest_against_inventory(problems)
-        gp.validate_theorem_proof_shape(problems)
+        gp.validate_hole_shape(problems)
     except gp.GenerationError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/tests/test_evaluate_submission.py
+++ b/tests/test_evaluate_submission.py
@@ -71,7 +71,7 @@ def _write_manifest(path: pathlib.Path, problem_ids: list[str]) -> None:
                 title = "{pid}"
                 test = false
                 module = "Fake.{pid}"
-                theorem = "{pid}"
+                holes = ["{pid}"]
                 submitter = "tester"
                 """
             )

--- a/tests/test_generate_projects.py
+++ b/tests/test_generate_projects.py
@@ -13,6 +13,25 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 import generate_projects as gp  # noqa: E402
 
 
+def _spec(
+    *,
+    id: str = "two_plus_two",
+    title: str = "T",
+    test: bool = False,
+    module: str = "M",
+    holes: tuple[str, ...] = ("t",),
+    submitter: str = "Kim",
+) -> gp.ProblemSpec:
+    return gp.ProblemSpec(
+        id=id,
+        title=title,
+        test=test,
+        module=module,
+        holes=holes,
+        submitter=submitter,
+    )
+
+
 class GenerateProjectsTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -44,88 +63,60 @@ submitter = "Kim"
 
     def test_duplicate_problem_id_rejected(self) -> None:
         problems = [
-            gp.ProblemSpec(
-                id="two_plus_two",
-                title="A",
-                test=False,
-                module="M",
-                theorem="t1",
-                submitter="Kim",
-            ),
-            gp.ProblemSpec(
-                id="two_plus_two",
-                title="B",
-                test=False,
-                module="M",
-                theorem="t2",
-                submitter="Kim",
-            ),
+            _spec(id="two_plus_two", holes=("t1",)),
+            _spec(id="two_plus_two", title="B", holes=("t2",)),
         ]
         with self.assertRaisesRegex(gp.GenerationError, "Duplicate problem id"):
             gp.validate_problems(problems)
 
-    def test_duplicate_theorem_reference_rejected(self) -> None:
+    def test_duplicate_hole_reference_rejected(self) -> None:
         problems = [
-            gp.ProblemSpec(
-                id="a",
-                title="A",
-                test=False,
-                module="M",
-                theorem="t",
-                submitter="Kim",
-            ),
-            gp.ProblemSpec(
-                id="b",
-                title="B",
-                test=False,
-                module="M",
-                theorem="t",
-                submitter="Kim",
-            ),
+            _spec(id="a", holes=("t",)),
+            _spec(id="b", title="B", holes=("t",)),
         ]
-        with self.assertRaisesRegex(gp.GenerationError, "Duplicate theorem reference"):
+        with self.assertRaisesRegex(gp.GenerationError, "Duplicate hole reference"):
             gp.validate_problems(problems)
 
     def test_unique_modules_preserves_order(self) -> None:
         problems = [
-            gp.ProblemSpec(id="a", title="A", test=False, module="M1", theorem="t1", submitter="Kim"),
-            gp.ProblemSpec(id="b", title="B", test=False, module="M2", theorem="t2", submitter="Kim"),
-            gp.ProblemSpec(id="c", title="C", test=False, module="M1", theorem="t3", submitter="Kim"),
+            _spec(id="a", module="M1", holes=("t1",)),
+            _spec(id="b", title="B", module="M2", holes=("t2",)),
+            _spec(id="c", title="C", module="M1", holes=("t3",)),
         ]
         self.assertEqual(gp.unique_modules(problems), ["M1", "M2"])
 
     def test_extract_statement_text_slices_source_range(self) -> None:
-        problem = gp.ProblemSpec(
+        problem = _spec(
             id="two_plus_two",
             title="2 + 2 = 4",
             test=True,
             module="LeanEval.EasyProblems",
-            theorem="two_plus_two_eq_four",
-            submitter="Kim",
+            holes=("two_plus_two_eq_four",),
         )
         extracted = gp.ExtractedTheorem(
             declaration_name="LeanEval.two_plus_two_eq_four",
             module=problem.module,
             source_range=(13, 0, 15, 7),
             same_module_dependencies=(),
+            kind="theorem",
         )
         statement = gp.extract_statement_text(problem, extracted)
         self.assertEqual(statement, ": (2 : Nat) + 2 = 4")
 
     def test_render_workspace_uses_local_theorem_name(self) -> None:
-        problem = gp.ProblemSpec(
+        problem = _spec(
             id="two_plus_two",
             title="2 + 2 = 4",
             test=True,
             module="LeanEval.EasyProblems",
-            theorem="two_plus_two_eq_four",
-            submitter="Kim",
+            holes=("two_plus_two_eq_four",),
         )
         extracted = gp.ExtractedTheorem(
             declaration_name="LeanEval.two_plus_two_eq_four",
             module=problem.module,
             source_range=(13, 0, 15, 7),
             same_module_dependencies=(),
+            kind="theorem",
         )
         dependency = gp.DependencySpec(
             name="mathlib",
@@ -134,7 +125,7 @@ submitter = "Kim"
         )
         files = gp.render_workspace(
             problem,
-            extracted,
+            [extracted],
             "leanprover/lean4:v4.30.0-rc1\n",
             dependency,
         )
@@ -161,45 +152,43 @@ submitter = "Kim"
             mismatches = gp.check_workspace(problem_dir, expected)
             self.assertEqual(mismatches, [f"stale {problem_dir / 'README.md'}"])
 
-    def test_extract_theorem_accepts_full_name(self) -> None:
-        extracted = gp.extract_theorem(
-            gp.ProblemSpec(
-                id="two_plus_two",
-                title="2 + 2 = 4",
-                test=True,
-                module="LeanEval.EasyProblems",
-                theorem="LeanEval.two_plus_two_eq_four",
-                submitter="Kim",
-            )
+    def test_extract_one_accepts_full_name(self) -> None:
+        problem = _spec(
+            id="two_plus_two",
+            title="2 + 2 = 4",
+            test=True,
+            module="LeanEval.EasyProblems",
+            holes=("LeanEval.two_plus_two_eq_four",),
         )
+        extracted = gp.extract_one(problem, problem.holes[0])
         self.assertEqual(extracted.declaration_name, "LeanEval.two_plus_two_eq_four")
         self.assertEqual(len(extracted.source_range), 4)
+        self.assertEqual(extracted.kind, "theorem")
 
-    def test_extract_theorem_rejects_unknown_declaration(self) -> None:
+    def test_extract_one_rejects_unknown_declaration(self) -> None:
+        problem = _spec(
+            id="missing",
+            title="Missing",
+            module="LeanEval.EasyProblems",
+            holes=("does_not_exist",),
+        )
         with self.assertRaisesRegex(gp.GenerationError, "not found"):
-            gp.extract_theorem(
-                gp.ProblemSpec(
-                    id="missing",
-                    title="Missing",
-                    test=False,
-                    module="LeanEval.EasyProblems",
-                    theorem="does_not_exist",
-                    submitter="Kim",
-                )
-            )
+            gp.extract_one(problem, problem.holes[0])
 
-    def test_extract_theorem_rejects_non_theorem(self) -> None:
-        with self.assertRaisesRegex(gp.GenerationError, "not a theorem"):
-            gp.extract_theorem(
-                gp.ProblemSpec(
-                    id="starter_number",
-                    title="starterNumber",
-                    test=False,
-                    module="LeanEval.EasyProblems",
-                    theorem="starterNumber",
-                    submitter="Kim",
-                )
-            )
+    def test_extract_one_rejects_unsupported_kind(self) -> None:
+        # `starterNumber` exists in the source as plain `def`. With
+        # def-hole support added, a `def` is now an accepted kind, so
+        # extraction should succeed with kind="def" rather than failing.
+        # If this changes (e.g. starterNumber is removed or changed), the
+        # test should be updated to point at a genuinely unsupported decl.
+        problem = _spec(
+            id="starter_number",
+            title="starterNumber",
+            module="LeanEval.EasyProblems",
+            holes=("starterNumber",),
+        )
+        extracted = gp.extract_one(problem, problem.holes[0])
+        self.assertEqual(extracted.kind, "def")
 
     def test_manifest_rejects_non_boolean_test_field(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -222,6 +211,28 @@ submitter = "Kim"
             with self.assertRaisesRegex(gp.GenerationError, "non-boolean field 'test'"):
                 gp.load_manifest(manifest_path)
 
+    def test_manifest_accepts_holes_array(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = pathlib.Path(tmpdir) / "problems.toml"
+            manifest_path.write_text(
+                """
+version = 1
+
+[[problem]]
+id = "multi"
+title = "Multi"
+test = true
+module = "LeanEval.Sandbox"
+holes = ["foo", "foo_def"]
+submitter = "Kim"
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            problems = gp.load_manifest(manifest_path)
+            self.assertEqual(len(problems), 1)
+            self.assertEqual(problems[0].holes, ("foo", "foo_def"))
+
     def test_load_root_mathlib_dependency(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             lakefile_path = pathlib.Path(tmpdir) / "lakefile.toml"
@@ -243,6 +254,7 @@ rev = "v4.test"
                 dependency.git, "https://github.com/leanprover-community/mathlib4.git"
             )
             self.assertEqual(dependency.rev, "v4.test")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_eval.py
+++ b/tests/test_run_eval.py
@@ -29,7 +29,7 @@ class RunEvalTests(unittest.TestCase):
             title="Demo",
             test=True,
             module="Demo.Module",
-            theorem="demo_theorem",
+            holes=("demo_theorem",),
             submitter="Kim",
         )
         extracted = gp.ExtractedTheorem(
@@ -37,6 +37,7 @@ class RunEvalTests(unittest.TestCase):
             module=problem.module,
             source_range=(1, 0, 2, 9),
             same_module_dependencies=(),
+            kind="theorem",
         )
         toolchain = "leanprover/lean4:v4.30.0-rc1\n"
 
@@ -74,7 +75,7 @@ rev = "{dependency.rev}"
 ''',
                     encoding="utf-8",
                 )
-                files = gp.render_workspace(problem, extracted, toolchain, dependency)
+                files = gp.render_workspace(problem, [extracted], toolchain, dependency)
                 for relative_path, content in files.items():
                     destination = problem_dir / relative_path
                     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -82,7 +83,7 @@ rev = "{dependency.rev}"
                 (repo_root / "lean-toolchain").write_text(toolchain, encoding="utf-8")
                 mismatches = reval.problem_attempt_mismatches(
                     problem,
-                    extractor=lambda _problem: extracted,
+                    extractor=lambda _problem, _hole: extracted,
                     workspaces_root=repo_root / "workspaces",
                 )
             finally:
@@ -99,7 +100,7 @@ rev = "{dependency.rev}"
                 title="Attempted pass",
                 test=True,
                 module="M",
-                theorem="t1",
+                holes=("t1",),
                 submitter="Kim",
             ),
             gp.ProblemSpec(
@@ -107,7 +108,7 @@ rev = "{dependency.rev}"
                 title="Attempted fail",
                 test=False,
                 module="M",
-                theorem="t2",
+                holes=("t2",),
                 submitter="Kim",
             ),
             gp.ProblemSpec(
@@ -115,7 +116,7 @@ rev = "{dependency.rev}"
                 title="Untouched",
                 test=False,
                 module="M",
-                theorem="t3",
+                holes=("t3",),
                 submitter="Kim",
             ),
         ]
@@ -248,7 +249,7 @@ rev = "{dependency.rev}"
             title="Demo",
             test=True,
             module="Demo.Module",
-            theorem="demo_theorem",
+            holes=("demo_theorem",),
             submitter="Kim",
         )
         extracted = gp.ExtractedTheorem(
@@ -256,6 +257,7 @@ rev = "{dependency.rev}"
             module=problem.module,
             source_range=(1, 0, 2, 9),
             same_module_dependencies=(),
+            kind="theorem",
         )
         toolchain = "leanprover/lean4:v4.30.0-rc1\n"
         dependency = gp.DependencySpec(
@@ -295,7 +297,7 @@ rev = "{dependency.rev}"
 ''',
                     encoding="utf-8",
                 )
-                files = gp.render_workspace(problem, extracted, toolchain, dependency)
+                files = gp.render_workspace(problem, [extracted], toolchain, dependency)
                 for base_dir in [generated_problem_dir, workspace_problem_dir]:
                     for relative_path, content in files.items():
                         destination = base_dir / relative_path
@@ -309,7 +311,7 @@ rev = "{dependency.rev}"
                 (repo_root / "lean-toolchain").write_text(toolchain, encoding="utf-8")
                 mismatches = reval.problem_attempt_mismatches(
                     problem,
-                    extractor=lambda _problem: extracted,
+                    extractor=lambda _problem, _hole: extracted,
                     workspaces_root=workspaces_root,
                 )
             finally:


### PR DESCRIPTION
This PR teaches the eval-problem pipeline to bundle multiple `@[eval_problem]` holes per problem (mixing `def`s, `instance`s and `theorem`s), and uses that to land Kevin Buzzard's Jacobian challenge (differential geometry) and Christian Merten's algebraic-geometry analogue as benchmark problems — two ~24-hole open challenges from the Lean Zulip [#Autoformalization > Jacobian challenge](https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge). Comparator already supports def-holes since [henrikboving/comparator#35](https://github.com/leanprover-community/comparator/pull/35); this is the lean-eval-side wiring.

Manifest entries now require ``holes = [...]``; the singular ``theorem = "..."`` shorthand is gone (existing single-hole entries migrated). Two minimal example problems (``def_hole_example``, ``instance_hole_example``) cover the new code paths under ``LeanEval/Sandbox/``. The README's "Quick Start For Benchmark Problem Contributors" gains a `Multi-hole problems` subsection documenting the named-instance convention.

🤖 Prepared with Claude Code