### PR TITLE
ci: re-enable regenerate-main via dedicated GitHub App; document CI auth

### DIFF
--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -1,15 +1,21 @@
+# Auth and bypass for this workflow are documented in docs/ci-secrets.md
+# (`lean-eval-regenerator` GitHub App + Repository Ruleset bypass list).
 name: Regenerate generated/ on main
 
-# DISABLED: GITHUB_TOKEN cannot push to main because of branch protection
-# (PRs required, "verify" status check required). A follow-up PR will switch
-# this workflow to mint an installation token from a dedicated GitHub App
-# whose principal is in the branch-protection bypass list, and re-enable the
-# push trigger.
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'LeanEval/**'
+      - 'EvalTools/**'
+      - 'manifests/problems.toml'
+      - 'scripts/generate_projects.py'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: regenerate-main
@@ -19,14 +25,31 @@ jobs:
   regenerate:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint lean-eval-regenerator installation token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.LEAN_EVAL_REGENERATOR_APP_ID }}
+          private-key: ${{ secrets.LEAN_EVAL_REGENERATOR_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
 
       - uses: leanprover/lean-action@v1
         with:
           use-mathlib-cache: true
+
+      - name: Re-sync to latest origin/main
+        # Codex finding: regenerate against the freshest source, not whatever
+        # the runner cloned. A merge can land on main between the trigger and
+        # the checkout above; without this, we'd regenerate against stale
+        # source and then push a result that doesn't match HEAD.
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git reset --hard origin/main
 
       - name: Regenerate
         run: python scripts/generate_projects.py
@@ -34,13 +57,18 @@ jobs:
       - name: Commit and push if changed
         run: |
           set -euo pipefail
-          if git diff --quiet generated/ && [ -z "$(git ls-files --others --exclude-standard generated/)" ]; then
+          if git diff --quiet generated/ \
+             && [ -z "$(git ls-files --others --exclude-standard generated/)" ]; then
             echo "No changes to generated/."
             exit 0
           fi
-          git config user.name  "lean-eval-bot"
-          git config user.email "lean-eval-bot@users.noreply.github.com"
+          git config user.name  "lean-eval-regenerator[bot]"
+          git config user.email "lean-eval-regenerator[bot]@users.noreply.github.com"
           git add generated/
           git commit -m "chore: regenerate generated/ workspaces"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          # Retry once if a human commit landed during this run.
+          if ! git push origin HEAD:main; then
+            echo "push rejected; rebasing onto latest main and retrying"
+            git pull --rebase origin main
+            git push origin HEAD:main
+          fi

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -1,3 +1,5 @@
+# Auth (lean-eval-bot GitHub App + LEADERBOARD_WRITE_TOKEN PAT) is
+# documented in docs/ci-secrets.md.
 name: Submission
 
 on:

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -1,0 +1,250 @@
+# CI secrets and access control for `leanprover/lean-eval`
+
+This document is the source of truth for every CI credential and branch-
+protection setting the repository depends on. It is written so that, on a
+fresh clone or a brand-new repo, you can reconstruct the entire CI auth
+posture from this file alone — no UI screenshots, no tribal knowledge.
+
+## Audit checklist
+
+| Item | Type | Stored as | Used by |
+| --- | --- | --- | --- |
+| `lean-eval-bot` | GitHub App (owner: `kim-em`) | `LEAN_EVAL_BOT_APP_ID`, `LEAN_EVAL_BOT_PRIVATE_KEY` | `submission.yml` |
+| `lean-eval-regenerator` | GitHub App (owner: `kim-em`) | `LEAN_EVAL_REGENERATOR_APP_ID`, `LEAN_EVAL_REGENERATOR_PRIVATE_KEY` | `regenerate-main.yml` |
+| `LEADERBOARD_WRITE_TOKEN` | Fine-grained PAT | `LEADERBOARD_WRITE_TOKEN` | `submission.yml` |
+| Ruleset `main protection` | Repository Ruleset | (config in this repo, applied via API) | branch protection on `main` |
+
+To check the live state at any time:
+
+```bash
+gh secret list -R leanprover/lean-eval
+gh api /repos/leanprover/lean-eval/rules/branches/main \
+    --jq '[.[].type]'
+```
+
+## GitHub App: `lean-eval-bot`
+
+Used by [`.github/workflows/submission.yml`](../.github/workflows/submission.yml)
+to mint installation tokens that fetch submission source from contributor
+repositories (which may be private).
+
+### App settings
+
+- Owner account: `kim-em` (User account).
+- Webhook: deactivated.
+- Repository permissions:
+  - `Contents: Read`
+- Where can this GitHub App be installed: **Any account**. Contributors
+  install it on their own submission repos so the workflow can clone them.
+
+### Repository secrets (in `leanprover/lean-eval`)
+
+- `LEAN_EVAL_BOT_APP_ID` — the App ID number.
+- `LEAN_EVAL_BOT_PRIVATE_KEY` — the full PEM contents of a private key
+  generated for the app.
+
+### Where used
+
+[`.github/workflows/submission.yml`](../.github/workflows/submission.yml),
+in the `Mint lean-eval-bot installation token` step, via
+`actions/create-github-app-token@v1`. The minted token is then used to
+fetch the contributor's submission source.
+
+The issue template
+[`.github/ISSUE_TEMPLATE/submit.yml`](../.github/ISSUE_TEMPLATE/submit.yml)
+instructs contributors to install this app on their submission repo as
+part of the submission workflow.
+
+### Reconstruction from scratch
+
+1. As the desired app owner, visit <https://github.com/settings/apps/new>.
+2. Fill in:
+   - Name: `lean-eval-bot`
+   - Homepage URL: `https://github.com/leanprover/lean-eval`
+   - Webhook → Active: unchecked
+   - Repository permissions → Contents: Read
+   - Where can this GitHub App be installed: **Any account**
+3. Save → record the App ID.
+4. Generate a private key, download the `.pem`.
+5. Install the app on `leanprover/lean-eval` (so it has an installation
+   the workflow can mint tokens against).
+6. Set the secrets:
+   ```bash
+   gh secret set LEAN_EVAL_BOT_APP_ID -R leanprover/lean-eval --body <APP_ID>
+   gh secret set LEAN_EVAL_BOT_PRIVATE_KEY -R leanprover/lean-eval < path/to/key.pem
+   ```
+
+## GitHub App: `lean-eval-regenerator`
+
+Used by [`.github/workflows/regenerate-main.yml`](../.github/workflows/regenerate-main.yml)
+to push regenerated `generated/` workspaces directly to `main`, bypassing
+branch protection.
+
+### App settings
+
+- Owner account: `kim-em` (User account).
+- Webhook: deactivated.
+- Repository permissions:
+  - `Contents: Read and write`
+- Where can this GitHub App be installed: **Any account**. (Required so
+  the org can install it; the only intended installation is on
+  `leanprover/lean-eval` itself.)
+- Installed on: `leanprover/lean-eval` only (single-repo installation).
+
+### Repository secrets (in `leanprover/lean-eval`)
+
+- `LEAN_EVAL_REGENERATOR_APP_ID` — the App ID number.
+- `LEAN_EVAL_REGENERATOR_PRIVATE_KEY` — the full PEM contents of a private
+  key generated for the app.
+
+### Where used
+
+[`.github/workflows/regenerate-main.yml`](../.github/workflows/regenerate-main.yml),
+in the `Mint lean-eval-regenerator installation token` step, via
+`actions/create-github-app-token@v1`. The token is used both for
+`actions/checkout` (so subsequent `git push` carries the same auth) and
+for the explicit push step that lands the regenerated workspaces on
+`main`.
+
+### Why an app and not `GITHUB_TOKEN`
+
+`GITHUB_TOKEN`-authored pushes cannot bypass branch protection (no actor
+can put `github-actions[bot]` itself in the bypass list at workflow
+granularity). A dedicated app's principal can be in the bypass list (see
+the Ruleset section below); the bypass is then narrow because only this
+workflow has the app's secrets.
+
+### Reconstruction from scratch
+
+There is a helper script [`scripts/create_regenerator_app.py`](../scripts/create_regenerator_app.py)
+that automates most of this via the GitHub App Manifest flow. Manual
+fallback steps:
+
+1. As the desired app owner, visit <https://github.com/settings/apps/new>.
+2. Fill in:
+   - Name: `lean-eval-regenerator`
+   - Homepage URL: `https://github.com/leanprover/lean-eval`
+   - Webhook → Active: unchecked
+   - Repository permissions → Contents: Read and write (everything else
+     stays "No access")
+   - Where can this GitHub App be installed: **Any account**
+3. Save → record the App ID.
+4. Generate a private key, download the `.pem`.
+5. Install the app on `leanprover/lean-eval` only (Org owner must do this
+   if the repo is in an org with restricted third-party app access).
+6. Set the secrets:
+   ```bash
+   gh secret set LEAN_EVAL_REGENERATOR_APP_ID -R leanprover/lean-eval --body <APP_ID>
+   gh secret set LEAN_EVAL_REGENERATOR_PRIVATE_KEY -R leanprover/lean-eval < path/to/key.pem
+   ```
+7. Add the App ID to the `main` ruleset's bypass list (see Ruleset
+   section below).
+
+## PAT: `LEADERBOARD_WRITE_TOKEN`
+
+Fine-grained Personal Access Token used by
+[`.github/workflows/submission.yml`](../.github/workflows/submission.yml)
+to push to the leaderboard repository
+(<https://github.com/leanprover/lean-eval-leaderboard>) when a submission
+succeeds.
+
+### Repository secret
+
+- `LEADERBOARD_WRITE_TOKEN` — the PAT.
+
+### Reconstruction from scratch
+
+1. Open <https://github.com/settings/personal-access-tokens/new>.
+2. Resource owner: **leanprover** (requires org owner approval — this
+   was the
+   [`personal-access-token-requests` step](https://github.com/organizations/leanprover/settings/personal-access-token-requests)
+   referenced when the leaderboard moved into the org).
+3. Repository access: **Only select repositories** →
+   `leanprover/lean-eval-leaderboard`.
+4. Repository permissions: **Contents: Read and write**.
+5. Save the token, then:
+   ```bash
+   gh secret set LEADERBOARD_WRITE_TOKEN -R leanprover/lean-eval --body <TOKEN>
+   ```
+
+## Branch protection on `main` (Repository Ruleset)
+
+`main` is protected by a Repository Ruleset (not classic branch
+protection). The `lean-eval-regenerator` app is on the bypass list so its
+workflow can push directly; everyone and everything else must go through
+a PR with a passing `verify` check.
+
+### Live state inspection
+
+```bash
+gh api /repos/leanprover/lean-eval/rules/branches/main \
+    --jq '.[] | {type, ruleset_id}'
+gh api /repos/leanprover/lean-eval/rulesets \
+    --jq '.[] | {id, name, target, enforcement}'
+gh api "/repos/leanprover/lean-eval/rulesets/<ID>" \
+    --jq '{name, bypass_actors}'
+```
+
+### Ruleset payload (canonical)
+
+The `<REGEN_APP_ID>` placeholder is the `lean-eval-regenerator` App ID.
+`integration_id: 15368` pins the `verify` status check to the GitHub
+Actions app (id 15368), so a hostile third-party app can't satisfy it
+with a bogus check of the same name.
+
+```json
+{
+  "name": "main protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false } },
+    { "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [ { "context": "verify", "integration_id": 15368 } ] } }
+  ],
+  "bypass_actors": [
+    { "actor_id": <REGEN_APP_ID>, "actor_type": "Integration", "bypass_mode": "always" }
+  ]
+}
+```
+
+### Reconstruction from scratch
+
+1. Make sure the `lean-eval-regenerator` app exists, is installed on the
+   repo, and you know its App ID.
+2. Save the payload above to `/tmp/main-ruleset.json`, substituting the
+   App ID.
+3. Apply:
+   ```bash
+   gh api -X POST /repos/leanprover/lean-eval/rulesets \
+       --input /tmp/main-ruleset.json
+   ```
+4. If migrating from classic branch protection, delete the classic
+   protection only after the ruleset is confirmed active:
+   ```bash
+   gh api /repos/leanprover/lean-eval/rules/branches/main \
+       --jq '[.[].type]'   # expect 4 rules
+   gh api -X DELETE /repos/leanprover/lean-eval/branches/main/protection
+   ```
+
+### Acceptable consequences of the bypass
+
+- `regenerate-main.yml`'s pushes to `main` will *not* trigger downstream
+  workflows (anti-loop protection still applies; bypass doesn't change
+  this). The regen workflow validates `python scripts/generate_projects.py`
+  inside the workflow, so the artifact landing on `main` is already
+  vetted.
+- Anyone who can land a PR that modifies `regenerate-main.yml` to push
+  arbitrary content to `main` could, after merge, exfiltrate that
+  capability. This is the same trust boundary as merging any PR.

--- a/scripts/create_regenerator_app.py
+++ b/scripts/create_regenerator_app.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Create the lean-eval-regenerator GitHub App via the App Manifest flow.
+
+Spins up a local server, opens GitHub's confirmation page in the browser
+with a pre-filled manifest, captures the redirect callback, exchanges the
+temporary code for an App ID + private key, sets the repo secrets, and
+prints the install URL.
+
+User interaction: click "Create GitHub App" once on github.com, then click
+through the install flow.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import secrets
+import socketserver
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+
+PORT = 8989
+STATE = secrets.token_urlsafe(16)
+REPO = "leanprover/lean-eval"
+
+MANIFEST = {
+    "name": "lean-eval-regenerator",
+    "url": "https://github.com/leanprover/lean-eval",
+    "hook_attributes": {"active": False, "url": "https://example.com/unused"},
+    "redirect_url": f"http://localhost:{PORT}/callback",
+    "public": False,
+    "default_permissions": {"contents": "write"},
+    "default_events": [],
+}
+
+result: dict = {}
+done = threading.Event()
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *_):  # quiet
+        pass
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == "/start":
+            html = f"""<!doctype html><html><body>
+<p>Submitting manifest to GitHub…</p>
+<form id="f" action="https://github.com/settings/apps/new?state={STATE}" method="post">
+  <input type="hidden" name="manifest" value='{json.dumps(MANIFEST).replace("'", "&apos;")}'>
+</form>
+<script>document.getElementById('f').submit();</script>
+</body></html>
+"""
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(html.encode())
+            return
+
+        if parsed.path == "/callback":
+            qs = urllib.parse.parse_qs(parsed.query)
+            if qs.get("state", [""])[0] != STATE:
+                self.send_response(400); self.end_headers()
+                self.wfile.write(b"state mismatch"); return
+            code = qs.get("code", [""])[0]
+            try:
+                req = urllib.request.Request(
+                    f"https://api.github.com/app-manifests/{code}/conversions",
+                    method="POST",
+                    headers={"Accept": "application/vnd.github+json"},
+                )
+                with urllib.request.urlopen(req) as resp:
+                    result.update(json.loads(resp.read()))
+            except Exception as e:
+                self.send_response(500); self.end_headers()
+                self.wfile.write(f"conversion failed: {e}".encode())
+                done.set(); return
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<h1>App created. You can close this window and return to your terminal.</h1>"
+            )
+            done.set()
+            return
+
+        self.send_response(404); self.end_headers()
+
+
+def main():
+    server = socketserver.TCPServer(("localhost", PORT), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    start_url = f"http://localhost:{PORT}/start"
+    print(f"Opening {start_url} in your browser…", flush=True)
+    print("On the GitHub page that appears, click 'Create GitHub App'.", flush=True)
+    webbrowser.open(start_url)
+
+    if not done.wait(timeout=600):
+        print("timed out waiting for callback", file=sys.stderr); sys.exit(1)
+
+    server.shutdown()
+
+    if "id" not in result:
+        print("conversion did not return an app:", result, file=sys.stderr); sys.exit(1)
+
+    app_id = result["id"]
+    pem = result["pem"]
+    slug = result["slug"]
+    html_url = result["html_url"]
+
+    print(f"\nApp created.")
+    print(f"  Name: {result.get('name')}")
+    print(f"  Slug: {slug}")
+    print(f"  ID:   {app_id}")
+    print(f"  URL:  {html_url}")
+
+    # Persist PEM to disk in case secret-set fails — user can rerun manually.
+    pem_path = tempfile.NamedTemporaryFile(
+        prefix="lean-eval-regenerator-", suffix=".pem", delete=False
+    ).name
+    with open(pem_path, "w") as f:
+        f.write(pem)
+    os.chmod(pem_path, 0o600)
+    print(f"  PEM:  {pem_path} (chmod 600)")
+
+    # Set the repo secrets via gh CLI.
+    print(f"\nSetting repo secrets on {REPO}…", flush=True)
+    subprocess.run(
+        ["gh", "secret", "set", "LEAN_EVAL_REGENERATOR_APP_ID",
+         "-R", REPO, "--body", str(app_id)],
+        check=True,
+    )
+    with open(pem_path) as f:
+        subprocess.run(
+            ["gh", "secret", "set", "LEAN_EVAL_REGENERATOR_PRIVATE_KEY",
+             "-R", REPO],
+            input=f.read(), text=True, check=True,
+        )
+
+    print("\nSecrets set:")
+    subprocess.run(
+        ["gh", "secret", "list", "-R", REPO,
+         "--json", "name", "--jq",
+         '.[] | select(.name | startswith("LEAN_EVAL_REGENERATOR"))'],
+        check=False,
+    )
+
+    print(f"\n=> Now click this to install on the repo (1 click + select repo + confirm):")
+    print(f"   {html_url}/installations/new")
+    print(f"\n=> When done, tell Claude the App ID is {app_id}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR completes the auto-regenerate-on-main work started in https://github.com/leanprover/lean-eval/pull/31. The previous attempt was disabled in https://github.com/leanprover/lean-eval/pull/34 because \`GITHUB_TOKEN\`-authored pushes can't bypass branch protection. This switches to a dedicated GitHub App whose principal is on the ruleset bypass list, so only \`regenerate-main.yml\` (which mounts the app's secrets) can push directly to \`main\`.

Out-of-band changes already applied:
- Created GitHub App \`lean-eval-regenerator\` (App ID 3554839, owner \`kim-em\`, \`Contents: Read and write\` only) and installed it on \`leanprover/lean-eval\`.
- Set repo secrets \`LEAN_EVAL_REGENERATOR_APP_ID\` and \`LEAN_EVAL_REGENERATOR_PRIVATE_KEY\`.
- Migrated \`main\` from classic branch protection to a Repository Ruleset (id 15775740). The ruleset preserves the existing rules (PR required, \`verify\` status check required, no force-push, no deletion) and adds the regenerator app to the bypass list. \`integration_id: 15368\` pins the \`verify\` check to the GitHub Actions app.

In-repo changes:
- \`.github/workflows/regenerate-main.yml\`: re-enabled \`push: branches: [main]\` trigger; mints an installation token via \`actions/create-github-app-token@v1\`; resyncs to fresh \`origin/main\` before regenerating; retries the push once on rejection.
- \`docs/ci-secrets.md\`: in-repo source of truth for the two GitHub Apps (\`lean-eval-bot\`, \`lean-eval-regenerator\`), the \`LEADERBOARD_WRITE_TOKEN\` PAT, and the ruleset payload. Each section has verbatim reconstruction steps so the entire CI auth posture can be recreated from this file alone.
- \`scripts/create_regenerator_app.py\`: automates regenerator app creation via the GitHub App Manifest flow (used to set up the live app; preserved for reproducibility).
- \`.github/workflows/submission.yml\`: top-of-file pointer to \`docs/ci-secrets.md\`.

Acceptable consequences (acknowledged in docs):
- Bot-authored pushes to \`main\` don't trigger downstream workflows (anti-loop). The regen workflow already validates generation inside the workflow before pushing, so the artifact landing on \`main\` is vetted.

🤖 Prepared with Claude Code