### PR TITLE
submission: per-issue concurrency group, not per-user

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -7,7 +7,14 @@ on:
     types: [labeled]
 
 concurrency:
-  group: submission-${{ github.event.issue.user.login }}
+  # Per-issue concurrency: each submission issue gets its own group so
+  # parallel submissions from the same user do not cancel each other.
+  # GitHub keeps at most 1 running + 1 pending per group, and any newer
+  # pending run cancels the previously-pending one — which manifested as
+  # silent dropouts when several issues were filed in quick succession.
+  # Concurrent leaderboard pushes from sibling runs are already handled
+  # by the `record` job's push-retry loop below.
+  group: submission-issue-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Filing several submission issues in quick succession from the same user caused silent CI dropouts. GitHub's `concurrency` feature keeps at most 1 running + 1 pending per group, and any newer pending run cancels the previously-pending one. With the previous group key `submission-${{ github.event.issue.user.login }}`, that meant only the LATEST queued submission per user survived; everything in between was cancelled and silently failed to record. We hit this in the wild today seeding several model rows in parallel — issues #44, #46, #48, #49 had their CI cancelled and never updated the leaderboard.

Switching the group to be per-issue (`submission-issue-${{ github.event.issue.number }}`) lets parallel submissions from the same user run independently. Concurrent leaderboard pushes are already handled by the existing push-retry loop in the `record` job (5 attempts with `git fetch && reset --hard origin/main` between each), so the only thing the per-user group was buying us — serialising leaderboard writes — wasn't actually necessary.

Within a single issue we still get the original guarantee: no two CI runs for the same submission issue overlap (e.g. for re-triggers).

🤖 Prepared with Claude Code
