### PR TITLE
doc: point leaderboard link at lean-lang.org/eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lean Eval
 
-**[View the leaderboard →](https://leanprover.github.io/lean-eval-leaderboard/)**
+**[View the leaderboard →](https://lean-lang.org/eval/)**
 
 This repository is a comparator-based Lean benchmark for formal mathematics.
 Benchmark authors write trusted problem statements once in shared Lean modules, and the


### PR DESCRIPTION
This PR updates the leaderboard link in the README to point at the new https://lean-lang.org/eval/ URL.

🤖 Prepared with Claude Code