### PR TITLE
fix: record submission_kind so gist proof links resolve

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -257,6 +257,7 @@ jobs:
           # Read frozen metadata fields
           SUBMITTED_BY=$(python -c "import json,sys; print(json.load(open(sys.argv[1]))['submitted_by'])" "$METADATA_PATH")
           MODEL=$(python -c "import json,sys; print(json.load(open(sys.argv[1]))['model'])" "$METADATA_PATH")
+          SUBMISSION_KIND=$(python -c "import json,sys; print(json.load(open(sys.argv[1]))['submission_kind'])" "$METADATA_PATH")
           SUBMISSION_REPO=$(python -c "import json,sys; print(json.load(open(sys.argv[1]))['submission_repo'])" "$METADATA_PATH")
           SUBMISSION_REF=$(python -c "import json,sys; print(json.load(open(sys.argv[1]))['submission_ref'])" "$METADATA_PATH")
           SUBMISSION_PUBLIC=$(python -c "import json,sys; print(str(json.load(open(sys.argv[1]))['submission_public']).lower())" "$METADATA_PATH")
@@ -281,6 +282,7 @@ jobs:
               --leaderboard-dir leaderboard \
               --results-json "$RESULTS_PATH" \
               --benchmark-commit "${{ github.sha }}" \
+              --submission-kind "$SUBMISSION_KIND" \
               --submission-repo "$SUBMISSION_REPO" \
               --submission-ref "$SUBMISSION_REF" \
               $PUBLIC_FLAG \

--- a/scripts/fetch_submission.py
+++ b/scripts/fetch_submission.py
@@ -399,6 +399,7 @@ def fetch_submission(
 
     metadata = {
         "source_url": fields["source_url"],
+        "submission_kind": descriptor.kind,
         "submission_repo": submission_repo_identifier(descriptor),
         "submission_ref": sha,
         "submission_public": submission_public,

--- a/scripts/update_leaderboard.py
+++ b/scripts/update_leaderboard.py
@@ -18,10 +18,11 @@ import re
 import sys
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 1
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9._-]+$")
+OWNER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9._-]+$")
 LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
+SUBMISSION_KINDS = ("github_repo", "gist")
 PRODUCTION_DESCRIPTION_MAX_LEN = 4000
 
 
@@ -34,9 +35,16 @@ def _require_sha(field: str, value: str) -> None:
         raise UpdateError(f"{field} must be a 40-char hex SHA, got {value!r}")
 
 
-def _require_repo(value: str) -> None:
-    if not REPO_RE.fullmatch(value):
-        raise UpdateError(f"submission-repo must look like owner/repo, got {value!r}")
+def _require_owner_name(value: str) -> None:
+    if not OWNER_NAME_RE.fullmatch(value):
+        raise UpdateError(f"submission-repo must look like owner/name, got {value!r}")
+
+
+def _require_submission_kind(value: str) -> None:
+    if value not in SUBMISSION_KINDS:
+        raise UpdateError(
+            f"submission-kind must be one of {SUBMISSION_KINDS}, got {value!r}"
+        )
 
 
 def _require_login(value: str) -> None:
@@ -92,6 +100,7 @@ def update_leaderboard(
     leaderboard_dir: pathlib.Path,
     passed: list[str],
     benchmark_commit: str,
+    submission_kind: str,
     submission_repo: str,
     submission_ref: str,
     submission_public: bool,
@@ -103,7 +112,8 @@ def update_leaderboard(
     _require_login(user)
     _require_sha("benchmark-commit", benchmark_commit)
     _require_sha("submission-ref", submission_ref)
-    _require_repo(submission_repo)
+    _require_submission_kind(submission_kind)
+    _require_owner_name(submission_repo)
     if issue_number <= 0:
         raise UpdateError(f"issue-number must be positive, got {issue_number}")
     if not model.strip():
@@ -130,6 +140,7 @@ def update_leaderboard(
         record = {
             "solved_at": now,
             "benchmark_commit": benchmark_commit,
+            "submission_kind": submission_kind,
             "submission_repo": submission_repo,
             "submission_ref": submission_ref,
             "submission_public": submission_public,
@@ -186,6 +197,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Path to a JSON file of the form {'passed': [problem_id, ...]}.",
     )
     parser.add_argument("--benchmark-commit", required=True)
+    parser.add_argument(
+        "--submission-kind",
+        required=True,
+        choices=SUBMISSION_KINDS,
+        help="Source kind: github_repo or gist. Determines how the leaderboard "
+        "renders the proof link.",
+    )
     parser.add_argument("--submission-repo", required=True)
     parser.add_argument("--submission-ref", required=True)
     parser.add_argument(
@@ -219,6 +237,7 @@ def main(argv: list[str] | None = None) -> int:
             leaderboard_dir=args.leaderboard_dir,
             passed=passed,
             benchmark_commit=args.benchmark_commit,
+            submission_kind=args.submission_kind,
             submission_repo=args.submission_repo,
             submission_ref=args.submission_ref,
             submission_public=args.submission_public,

--- a/tests/test_fetch_submission.py
+++ b/tests/test_fetch_submission.py
@@ -317,6 +317,7 @@ class FetchSubmissionEndToEndTests(unittest.TestCase):
                     app_token=None,
                     skip_clone=True,
                 )
+            self.assertEqual(metadata["submission_kind"], "github_repo")
             self.assertEqual(metadata["submission_repo"], "alice/my-proofs")
             self.assertEqual(metadata["submission_ref"], sha)
             self.assertTrue(metadata["submission_public"])
@@ -355,6 +356,35 @@ class FetchSubmissionEndToEndTests(unittest.TestCase):
                 metadata["production_description"],
                 "Custom orchestrator + Claude Opus 4.7; ~30 min human review.",
             )
+
+    def test_dry_run_emits_gist_kind_for_gist_submission(self) -> None:
+        gist_body = SAMPLE_BODY.replace(
+            "https://github.com/alice/my-proofs/commit/8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f",
+            "https://gist.github.com/alice/abc123def456abc123def456abc123de",
+        )
+        event = {
+            "issue": {
+                "number": 42,
+                "user": {"login": "alice"},
+                "body": gist_body,
+            }
+        }
+        sha = "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f"
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("fetch_submission.resolve_repo_visibility", return_value=True):
+                with patch("fetch_submission.resolve_ref", return_value=sha):
+                    metadata = fs.fetch_submission(
+                        event_payload=event,
+                        output_dir=pathlib.Path(tmp),
+                        app_token=None,
+                        skip_clone=True,
+                    )
+            self.assertEqual(metadata["submission_kind"], "gist")
+            self.assertEqual(
+                metadata["submission_repo"],
+                "alice/abc123def456abc123def456abc123de",
+            )
+            self.assertEqual(metadata["submission_ref"], sha)
 
     def test_secret_gist_is_rejected(self) -> None:
         gist_body = SAMPLE_BODY.replace(

--- a/tests/test_update_leaderboard.py
+++ b/tests/test_update_leaderboard.py
@@ -24,6 +24,8 @@ def default_call(
     user: str = "alice",
     now: str = "2026-04-11T10:45:00Z",
     submission_public: bool = True,
+    submission_kind: str = "github_repo",
+    submission_repo: str = "alice/proofs",
     model: str = "Claude Opus 4.6",
     issue_number: int = 42,
     benchmark_commit: str = BENCHMARK_COMMIT,
@@ -34,7 +36,8 @@ def default_call(
         leaderboard_dir=leaderboard_dir,
         passed=passed,
         benchmark_commit=benchmark_commit,
-        submission_repo="alice/proofs",
+        submission_kind=submission_kind,
+        submission_repo=submission_repo,
         submission_ref=SUBMISSION_REF,
         submission_public=submission_public,
         model=model,
@@ -45,7 +48,7 @@ def default_call(
 
 
 class UpdateLeaderboardTests(unittest.TestCase):
-    def test_first_write_creates_file_with_schema_v2(self) -> None:
+    def test_first_write_creates_file_with_schema_v1(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             lb = pathlib.Path(tmp)
             result = default_call(leaderboard_dir=lb, passed=["two_plus_two"])
@@ -58,18 +61,46 @@ class UpdateLeaderboardTests(unittest.TestCase):
             target = lb / "results" / "alice.json"
             self.assertTrue(target.is_file())
             data = json.loads(target.read_text())
-            self.assertEqual(data["schema_version"], 2)
+            self.assertEqual(data["schema_version"], 1)
             self.assertEqual(data["user"], "alice")
             self.assertIn("Claude Opus 4.6", data["solved"])
             record = data["solved"]["Claude Opus 4.6"]["two_plus_two"]
             self.assertEqual(record["solved_at"], "2026-04-11T10:45:00Z")
             self.assertEqual(record["benchmark_commit"], BENCHMARK_COMMIT)
+            self.assertEqual(record["submission_kind"], "github_repo")
             self.assertEqual(record["submission_repo"], "alice/proofs")
             self.assertEqual(record["submission_ref"], SUBMISSION_REF)
             self.assertTrue(record["submission_public"])
             self.assertEqual(record["issue_number"], 42)
             self.assertNotIn("model", record)
             self.assertNotIn("production_description", record)
+
+    def test_gist_submission_records_kind(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lb = pathlib.Path(tmp)
+            default_call(
+                leaderboard_dir=lb,
+                passed=["two_plus_two"],
+                submission_kind="gist",
+                submission_repo="alice/abc123def456abc123def456abc123de",
+            )
+            data = json.loads((lb / "results" / "alice.json").read_text())
+            record = data["solved"]["Claude Opus 4.6"]["two_plus_two"]
+            self.assertEqual(record["submission_kind"], "gist")
+            self.assertEqual(
+                record["submission_repo"],
+                "alice/abc123def456abc123def456abc123de",
+            )
+
+    def test_invalid_submission_kind_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            lb = pathlib.Path(tmp)
+            with self.assertRaisesRegex(ul.UpdateError, "submission-kind"):
+                default_call(
+                    leaderboard_dir=lb,
+                    passed=["x"],
+                    submission_kind="bitbucket",
+                )
 
     def test_duplicate_same_model_is_noop_and_preserves_solved_at(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -160,17 +191,17 @@ class UpdateLeaderboardTests(unittest.TestCase):
             with self.assertRaisesRegex(ul.UpdateError, "schema_version"):
                 default_call(leaderboard_dir=lb, passed=["x"])
 
-    def test_v1_file_rejected(self) -> None:
-        # Ensure a v1-shaped file is rejected so callers must run the
-        # leaderboard repo's migration script before retrying.
+    def test_old_v2_file_rejected(self) -> None:
+        # The (model, problem)-keyed v2 layout that briefly shipped is
+        # rejected; operators must wipe affected results files and replay.
         with tempfile.TemporaryDirectory() as tmp:
             lb = pathlib.Path(tmp)
             target = lb / "results" / "alice.json"
             target.parent.mkdir(parents=True)
             target.write_text(json.dumps({
-                "schema_version": 1,
+                "schema_version": 2,
                 "user": "alice",
-                "solved": {"two_plus_two": {"model": "old", "solved_at": "x"}},
+                "solved": {"Claude Opus 4.6": {"two_plus_two": {}}},
             }))
             with self.assertRaisesRegex(ul.UpdateError, "schema_version"):
                 default_call(leaderboard_dir=lb, passed=["x"])
@@ -277,6 +308,7 @@ class UpdateLeaderboardTests(unittest.TestCase):
                     "--leaderboard-dir", str(lb),
                     "--results-json", str(results_path),
                     "--benchmark-commit", BENCHMARK_COMMIT,
+                    "--submission-kind", "github_repo",
                     "--submission-repo", "alice/proofs",
                     "--submission-ref", SUBMISSION_REF,
                     "--submission-public",


### PR DESCRIPTION
This PR teaches the leaderboard record where a submission lives, so the website can build the right proof URL for both repo and gist submissions.

The Harmonic record on https://lean-lang.org/eval/problems/substInv_X_sub_X_sq_eq_catalan/ links to `https://github.com/kim-em/ba837b9520ea4ec64c7945bb1f0cf10f/tree/<sha>/generated/...` and 404s, because the stored `submission_repo` is a gist ID but the website templates a `github.com/.../tree/<sha>/...` URL unconditionally. There is no way to recover from the stored data alone — gists live on `gist.github.com`, have no per-subdirectory tree view, and store revisions as `/<rev>` not `/tree/<rev>`.

Adds a `submission_kind: "github_repo" | "gist"` discriminator to each record. Plumbs it from `fetch_submission.py` (which already had `descriptor.kind`) through `metadata.json` and the workflow into `update_leaderboard.py`, which now writes it next to `submission_repo` and `submission_ref`. The website can then pick the right URL template by kind: `github.com/<repo>/tree/<sha>/generated/<problem>` for repos, `gist.github.com/<repo>/<sha>` for gists.

Resets `SCHEMA_VERSION` to 1 — the schema is pre-1.0 and we are still iterating freely on shape; bumping for every additive change is not pulling its weight here. Existing `results/*.json` files in `leanprover/lean-eval-leaderboard` are still on the previous shape and will be migrated by a companion PR; until then the next submission for any user with an existing file would error on the schema_version mismatch.

🤖 Prepared with Claude Code