### PR TITLE
feat: add three knot-theory benchmark problems

### DIFF
--- a/LeanEval/KnotTheory/Chiral.lean
+++ b/LeanEval/KnotTheory/Chiral.lean
@@ -13,21 +13,23 @@ chirality requires an invariant *that is not preserved under reflection*,
 and choosing the right such invariant is part of the problem.
 -/
 
-/-- **Existence of a chiral smooth knot.**
+/-- **Existence of a chiral oriented smooth knot.**
 
-There exists a smooth knot in `ℝ³` whose image is not ambient-isotopic to
-its mirror image (the reflection of the image through the `xy`-plane).
+There exists an oriented smooth knot in `ℝ³` that is not ambient-isotopic
+to its mirror image (the reflection of the image through the `xy`-plane).
 
 *Suggestion.* The right-handed trefoil is chiral. Parametrize it for
 instance as
 
   `t ↦ (sin t + 2 sin (2 t), cos t − 2 cos (2 t), −sin (3 t))`.
 
-Proving chirality requires an ambient-isotopy invariant that takes
-*different* values on a knot and its mirror image. The figure-eight knot
-*is* isotopic to its mirror, so the invariant must be sensitive to chirality
-— in particular, the knot determinant and the Alexander polynomial alone do
-*not* suffice (both are mirror-symmetric).
+Here chirality is understood in the orientation-sensitive sense induced by
+the benchmark's notion of isotopy. Proving chirality therefore requires an
+ambient-isotopy invariant that takes *different* values on a knot and its
+mirror image. The figure-eight knot *is* isotopic to its mirror in the usual
+unoriented sense, so the invariant must be sensitive to chirality — in
+particular, the knot determinant and the Alexander polynomial alone do *not*
+suffice (both are mirror-symmetric).
 
 Standard chirality-detecting invariants:
 

--- a/LeanEval/KnotTheory/Chiral.lean
+++ b/LeanEval/KnotTheory/Chiral.lean
@@ -1,0 +1,50 @@
+import LeanEval.KnotTheory.Prelude
+import EvalTools.Markers
+
+namespace LeanEval
+namespace KnotTheory
+
+/-!
+# Existence of a chiral knot
+
+The challenge problem of the knot-theory benchmark. Unlike the previous two
+problems — where the relevant invariant is suggested explicitly — proving
+chirality requires an invariant *that is not preserved under reflection*,
+and choosing the right such invariant is part of the problem.
+-/
+
+/-- **Existence of a chiral smooth knot.**
+
+There exists a smooth knot in `ℝ³` whose image is not ambient-isotopic to
+its mirror image (the reflection of the image through the `xy`-plane).
+
+*Suggestion.* The right-handed trefoil is chiral. Parametrize it for
+instance as
+
+  `t ↦ (sin t + 2 sin (2 t), cos t − 2 cos (2 t), −sin (3 t))`.
+
+Proving chirality requires an ambient-isotopy invariant that takes
+*different* values on a knot and its mirror image. The figure-eight knot
+*is* isotopic to its mirror, so the invariant must be sensitive to chirality
+— in particular, the knot determinant and the Alexander polynomial alone do
+*not* suffice (both are mirror-symmetric).
+
+Standard chirality-detecting invariants:
+
+* The **knot signature** `σ(K) ∈ ℤ`, computed from a Seifert matrix
+  `V` as the signature of `V + Vᵀ`. Mirroring negates the signature, so
+  any knot with `σ(K) ≠ 0` is chiral. The right-handed trefoil has
+  `σ = −2`.
+* The **Jones polynomial** `V_K(t) ∈ ℤ[t^{1/2}, t^{-1/2}]`. Mirroring
+  sends `V_K(t)` to `V_K(t⁻¹)`, so any knot whose Jones polynomial is not
+  symmetric under `t ↔ t⁻¹` is chiral. The right-handed trefoil has
+  `V_K(t) = −t^{−4} + t^{−3} + t^{−1}`.
+
+See <https://en.wikipedia.org/wiki/Chirality_(mathematics)> and
+<https://en.wikipedia.org/wiki/Trefoil_knot>. -/
+@[eval_problem]
+theorem exists_chiral_knot : ∃ K : Knot, K.Chiral := by
+  sorry
+
+end KnotTheory
+end LeanEval

--- a/LeanEval/KnotTheory/Linking.lean
+++ b/LeanEval/KnotTheory/Linking.lean
@@ -13,10 +13,10 @@ ambient-isotopy invariant defined by an explicit double integral over the
 two parametrizations — no diagrammatic machinery needed.
 -/
 
-/-- **Existence of a non-isotopic pair of two-component links.**
+/-- **Existence of a non-isotopic pair of oriented two-component links.**
 
-There exist two smooth two-component links in `ℝ³` that are not ambient-
-isotopic.
+There exist two oriented smooth two-component links in `ℝ³` that are not
+ambient-isotopic.
 
 *Suggestion.* Take `L₁` to be the **unlink** — for instance, the two unit
 circles in the planes `z = 0` and `z = 2`, both centered on the `z`-axis —
@@ -29,10 +29,10 @@ To distinguish them, use the **Gauss linking integral**
               `⟨K(s) − L(t), K′(s) × L′(t)⟩ / ‖K(s) − L(t)‖³ ds dt`,
 
 which is well-defined when the components have disjoint images, takes the
-value `0` on the unlink and `±1` on the Hopf link, and is invariant under
-ambient isotopy of the link. (Invariance follows from a Stokes-style
-computation: the integrand is the pullback of a closed 2-form on
-`ℝ³ \ {0}`.)
+value `0` on the unlink and `±1` on the Hopf link depending on the chosen
+orientations, and is invariant under ambient isotopy of the oriented link.
+(Invariance follows from a Stokes-style computation: the integrand is the
+pullback of a closed 2-form on `ℝ³ \ {0}`.)
 
 See <https://en.wikipedia.org/wiki/Linking_number> for a reference. -/
 @[eval_problem]

--- a/LeanEval/KnotTheory/Linking.lean
+++ b/LeanEval/KnotTheory/Linking.lean
@@ -1,0 +1,43 @@
+import LeanEval.KnotTheory.Prelude
+import EvalTools.Markers
+
+namespace LeanEval
+namespace KnotTheory
+
+/-!
+# Existence of non-isotopic two-component links
+
+A warmup for the knot-theory benchmark. Two-component links are easier to
+distinguish than knots because the *Gauss linking integral* is a real-valued
+ambient-isotopy invariant defined by an explicit double integral over the
+two parametrizations — no diagrammatic machinery needed.
+-/
+
+/-- **Existence of a non-isotopic pair of two-component links.**
+
+There exist two smooth two-component links in `ℝ³` that are not ambient-
+isotopic.
+
+*Suggestion.* Take `L₁` to be the **unlink** — for instance, the two unit
+circles in the planes `z = 0` and `z = 2`, both centered on the `z`-axis —
+and `L₂` to be the **Hopf link** — for instance, the unit circle in the
+`xy`-plane together with the unit circle in the `xz`-plane shifted by `(1, 0, 0)`.
+
+To distinguish them, use the **Gauss linking integral**
+
+  `lk(K, L) = (1 / (4π)) ∫₀^{2π} ∫₀^{2π}`
+              `⟨K(s) − L(t), K′(s) × L′(t)⟩ / ‖K(s) − L(t)‖³ ds dt`,
+
+which is well-defined when the components have disjoint images, takes the
+value `0` on the unlink and `±1` on the Hopf link, and is invariant under
+ambient isotopy of the link. (Invariance follows from a Stokes-style
+computation: the integrand is the pullback of a closed 2-form on
+`ℝ³ \ {0}`.)
+
+See <https://en.wikipedia.org/wiki/Linking_number> for a reference. -/
+@[eval_problem]
+theorem exists_nonisotopic_link : ∃ L₁ L₂ : TwoLink, ¬ L₁.Isotopic L₂ := by
+  sorry
+
+end KnotTheory
+end LeanEval

--- a/LeanEval/KnotTheory/NonIsotopicKnots.lean
+++ b/LeanEval/KnotTheory/NonIsotopicKnots.lean
@@ -1,0 +1,46 @@
+import LeanEval.KnotTheory.Prelude
+import EvalTools.Markers
+
+namespace LeanEval
+namespace KnotTheory
+
+/-!
+# Existence of non-isotopic knots
+
+Distinguishing two knots is genuinely harder than distinguishing two links:
+no `lk`-style integral does the job, so any proof has to construct an
+ambient-isotopy invariant of single-component knots and compute it on two
+explicit parametrizations.
+-/
+
+/-- **Existence of a non-isotopic pair of smooth knots.**
+
+There exist two smooth knots in `ℝ³` that are not ambient-isotopic.
+
+*Suggestion.* Take `K₁` to be the **unknot**, parametrized as the round
+unit circle in the `xy`-plane, and `K₂` to be the **right-handed trefoil**,
+parametrized for instance by
+
+  `t ↦ (sin t + 2 sin (2 t), cos t − 2 cos (2 t), −sin (3 t))`
+
+(this is a smooth, 2π-periodic immersion, and it is injective on `[0, 2π)`).
+
+To distinguish them, you must construct an ambient-isotopy invariant of
+knots. Two computationally tractable options, each fully developed from
+elementary ingredients:
+
+* The **knot determinant** `|Δ_K(−1)|`, where `Δ_K ∈ ℤ[t, t⁻¹]` is the
+  Alexander polynomial. The unknot has determinant `1`; the trefoil has
+  determinant `3`.
+* The number of **Fox 3-colorings** of any diagram of `K`, which counts
+  homomorphisms from the knot group to the dihedral group `D₃` and is an
+  isotopy invariant. The unknot admits only monochromatic 3-colorings
+  (3 of them); the trefoil admits 9.
+
+See <https://en.wikipedia.org/wiki/Knot_invariant> for a survey. -/
+@[eval_problem]
+theorem exists_nonisotopic_knots : ∃ K₁ K₂ : Knot, ¬ K₁.Isotopic K₂ := by
+  sorry
+
+end KnotTheory
+end LeanEval

--- a/LeanEval/KnotTheory/NonIsotopicKnots.lean
+++ b/LeanEval/KnotTheory/NonIsotopicKnots.lean
@@ -13,9 +13,9 @@ ambient-isotopy invariant of single-component knots and compute it on two
 explicit parametrizations.
 -/
 
-/-- **Existence of a non-isotopic pair of smooth knots.**
+/-- **Existence of a non-isotopic pair of oriented smooth knots.**
 
-There exist two smooth knots in `ℝ³` that are not ambient-isotopic.
+There exist two oriented smooth knots in `ℝ³` that are not ambient-isotopic.
 
 *Suggestion.* Take `K₁` to be the **unknot**, parametrized as the round
 unit circle in the `xy`-plane, and `K₂` to be the **right-handed trefoil**,

--- a/LeanEval/KnotTheory/Prelude.lean
+++ b/LeanEval/KnotTheory/Prelude.lean
@@ -1,0 +1,100 @@
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.Calculus.ContDiff.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+
+namespace LeanEval
+namespace KnotTheory
+
+/-!
+# Smooth knots, links, ambient isotopy, and chirality
+
+Minimal definitions to support the three knot-theory benchmark problems
+(`Linking`, `NonIsotopicKnots`, `Chiral`). Mathlib has essentially no knot
+theory, so we set up just enough infrastructure to state the questions
+faithfully in terms of smooth maps `S¹ → ℝ³` and ambient isotopies of `ℝ³`.
+
+A *knot* is a smooth, 2π-periodic, injective immersion `ℝ → ℝ³`. A
+*two-component link* is a pair of knots with disjoint images. An *ambient
+isotopy* is a smooth one-parameter family of diffeomorphisms of `ℝ³`
+starting at the identity, presented here as a forward map and an inverse
+map jointly smooth in `(t, x)`.
+
+Two knots / links are *isotopic* if some ambient isotopy carries the image
+of the first to the image of the second. A knot is *chiral* if its image is
+not isotopic to its mirror image (under reflection through the `xy`-plane).
+
+These definitions trade some Mathlib idiomaticity for being self-contained
+and easy to read; in particular, we do not go through `Diffeomorph` or
+`ContMDiff` on a manifold structure for `ℝ³`, since `ContDiff ℝ ⊤` over the
+ambient normed space says exactly what we need.
+-/
+
+/-- The ambient space `ℝ³`, as a Euclidean inner-product space. -/
+abbrev R3 : Type := EuclideanSpace ℝ (Fin 3)
+
+/-- A smooth knot in `ℝ³`: a 2π-periodic, smooth, injective immersion. -/
+structure Knot where
+  /-- The parametrizing map. -/
+  curve : ℝ → R3
+  /-- The map is smooth. -/
+  smooth : ContDiff ℝ (⊤ : ℕ∞) curve
+  /-- The map has period `2π`. -/
+  periodic : ∀ t, curve (t + 2 * Real.pi) = curve t
+  /-- The map is injective on a fundamental period. -/
+  injOn : Set.InjOn curve (Set.Ico 0 (2 * Real.pi))
+  /-- The map is an immersion (its derivative is everywhere nonzero). -/
+  immersion : ∀ t, deriv curve t ≠ 0
+
+/-- A two-component smooth link in `ℝ³`: a pair of knots with disjoint
+images. -/
+structure TwoLink where
+  /-- The first component. -/
+  K : Knot
+  /-- The second component. -/
+  L : Knot
+  /-- The two components have disjoint images in `ℝ³`. -/
+  disjoint : Disjoint (Set.range K.curve) (Set.range L.curve)
+
+/-- A smooth ambient isotopy of `ℝ³`: a one-parameter family `H t : ℝ³ → ℝ³`
+of diffeomorphisms, jointly smooth in `(t, x)`, starting at the identity.
+The inverse family `Hinv` is also jointly smooth. -/
+structure AmbientIsotopy where
+  /-- The forward family. -/
+  H : ℝ → R3 → R3
+  /-- The inverse family. -/
+  Hinv : ℝ → R3 → R3
+  /-- The forward family is jointly smooth in `(t, x)`. -/
+  smooth : ContDiff ℝ (⊤ : ℕ∞) (Function.uncurry H)
+  /-- The inverse family is jointly smooth in `(t, x)`. -/
+  smooth_inv : ContDiff ℝ (⊤ : ℕ∞) (Function.uncurry Hinv)
+  /-- `Hinv t` is a left inverse of `H t`. -/
+  inv_left : ∀ t x, Hinv t (H t x) = x
+  /-- `Hinv t` is a right inverse of `H t`. -/
+  inv_right : ∀ t x, H t (Hinv t x) = x
+  /-- The isotopy starts at the identity. -/
+  start : H 0 = id
+
+/-- Two knots are ambient-isotopic if some ambient isotopy of `ℝ³` carries
+the image of the first to the image of the second. -/
+def Knot.Isotopic (K₁ K₂ : Knot) : Prop :=
+  ∃ Φ : AmbientIsotopy, Φ.H 1 '' Set.range K₁.curve = Set.range K₂.curve
+
+/-- Two two-component links are ambient-isotopic if a single ambient isotopy
+carries each component image to the corresponding component image. -/
+def TwoLink.Isotopic (L₁ L₂ : TwoLink) : Prop :=
+  ∃ Φ : AmbientIsotopy,
+    Φ.H 1 '' Set.range L₁.K.curve = Set.range L₂.K.curve ∧
+    Φ.H 1 '' Set.range L₁.L.curve = Set.range L₂.L.curve
+
+/-- Reflection through the `xy`-plane in `ℝ³`: `(x, y, z) ↦ (x, y, -z)`. -/
+def reflectZ (p : R3) : R3 :=
+  WithLp.toLp 2 (fun i : Fin 3 => if i = 2 then -p.ofLp i else p.ofLp i)
+
+/-- A knot is *chiral* if its image is not ambient-isotopic to its mirror
+image (the reflection of the image through the `xy`-plane). -/
+def Knot.Chiral (K : Knot) : Prop :=
+  ¬ ∃ Φ : AmbientIsotopy,
+    Φ.H 1 '' Set.range K.curve = reflectZ '' Set.range K.curve
+
+end KnotTheory
+end LeanEval

--- a/LeanEval/KnotTheory/Prelude.lean
+++ b/LeanEval/KnotTheory/Prelude.lean
@@ -19,9 +19,13 @@ isotopy* is a smooth one-parameter family of diffeomorphisms of `ℝ³`
 starting at the identity, presented here as a forward map and an inverse
 map jointly smooth in `(t, x)`.
 
-Two knots / links are *isotopic* if some ambient isotopy carries the image
-of the first to the image of the second. A knot is *chiral* if its image is
-not isotopic to its mirror image (under reflection through the `xy`-plane).
+The parametrization is part of the data, so each knot or link component
+comes with an orientation induced from the standard orientation on `S¹`.
+Accordingly, isotopy is understood in the oriented sense: an ambient isotopy
+must carry the parametrized components of the source to those of the target,
+up to orientation-preserving reparametrization of the source circle. A knot
+is *chiral* here in this same orientation-sensitive sense: it is not isotopic
+to its mirror image (under reflection through the `xy`-plane).
 
 These definitions trade some Mathlib idiomaticity for being self-contained
 and easy to read; in particular, we do not go through `Diffeomorph` or
@@ -32,7 +36,8 @@ ambient normed space says exactly what we need.
 /-- The ambient space `ℝ³`, as a Euclidean inner-product space. -/
 abbrev R3 : Type := EuclideanSpace ℝ (Fin 3)
 
-/-- A smooth knot in `ℝ³`: a 2π-periodic, smooth, injective immersion. -/
+/-- An oriented smooth knot in `ℝ³`: a 2π-periodic, smooth, injective immersion.
+The orientation is the one induced by the parametrization. -/
 structure Knot where
   /-- The parametrizing map. -/
   curve : ℝ → R3
@@ -45,8 +50,8 @@ structure Knot where
   /-- The map is an immersion (its derivative is everywhere nonzero). -/
   immersion : ∀ t, deriv curve t ≠ 0
 
-/-- A two-component smooth link in `ℝ³`: a pair of knots with disjoint
-images. -/
+/-- An oriented two-component smooth link in `ℝ³`: a pair of oriented knots
+with disjoint images. -/
 structure TwoLink where
   /-- The first component. -/
   K : Knot
@@ -74,27 +79,50 @@ structure AmbientIsotopy where
   /-- The isotopy starts at the identity. -/
   start : H 0 = id
 
-/-- Two knots are ambient-isotopic if some ambient isotopy of `ℝ³` carries
-the image of the first to the image of the second. -/
-def Knot.Isotopic (K₁ K₂ : Knot) : Prop :=
-  ∃ Φ : AmbientIsotopy, Φ.H 1 '' Set.range K₁.curve = Set.range K₂.curve
+structure CircleReparam where
+  /-- A lift `ℝ → ℝ` of a circle self-map. -/
+  f : ℝ → ℝ
+  /-- A lifted inverse. -/
+  finv : ℝ → ℝ
+  /-- The lift is smooth. -/
+  smooth : ContDiff ℝ (⊤ : ℕ∞) f
+  /-- The inverse lift is smooth. -/
+  smooth_inv : ContDiff ℝ (⊤ : ℕ∞) finv
+  /-- `finv` is a left inverse to `f`. -/
+  left_inv : ∀ t, finv (f t) = t
+  /-- `finv` is a right inverse to `f`. -/
+  right_inv : ∀ t, f (finv t) = t
+  /-- The lift descends to a map of `S¹ = ℝ / 2πℤ`. -/
+  periodic : ∀ t, f (t + 2 * Real.pi) = f t + 2 * Real.pi
+  /-- The inverse lift also descends to `S¹`. -/
+  periodic_inv : ∀ t, finv (t + 2 * Real.pi) = finv t + 2 * Real.pi
+  /-- The induced circle map preserves orientation. -/
+  mono : StrictMono f
 
-/-- Two two-component links are ambient-isotopic if a single ambient isotopy
-carries each component image to the corresponding component image. -/
+/-- Two oriented knots are ambient-isotopic if some ambient isotopy of `ℝ³`
+carries the parametrized knot `K₁` to the parametrized knot `K₂`, up to an
+orientation-preserving smooth reparametrization of the source circle. -/
+def Knot.Isotopic (K₁ K₂ : Knot) : Prop :=
+  ∃ Φ : AmbientIsotopy, ∃ σ : CircleReparam, ∀ t, Φ.H 1 (K₁.curve t) = K₂.curve (σ.f t)
+
+/-- Two oriented two-component links are ambient-isotopic if a single ambient
+isotopy carries each oriented component of the first link to the
+corresponding oriented component of the second. -/
 def TwoLink.Isotopic (L₁ L₂ : TwoLink) : Prop :=
-  ∃ Φ : AmbientIsotopy,
-    Φ.H 1 '' Set.range L₁.K.curve = Set.range L₂.K.curve ∧
-    Φ.H 1 '' Set.range L₁.L.curve = Set.range L₂.L.curve
+  ∃ Φ : AmbientIsotopy, ∃ σ τ : CircleReparam,
+    (∀ t, Φ.H 1 (L₁.K.curve t) = L₂.K.curve (σ.f t)) ∧
+    (∀ t, Φ.H 1 (L₁.L.curve t) = L₂.L.curve (τ.f t))
 
 /-- Reflection through the `xy`-plane in `ℝ³`: `(x, y, z) ↦ (x, y, -z)`. -/
 def reflectZ (p : R3) : R3 :=
   WithLp.toLp 2 (fun i : Fin 3 => if i = 2 then -p.ofLp i else p.ofLp i)
 
-/-- A knot is *chiral* if its image is not ambient-isotopic to its mirror
-image (the reflection of the image through the `xy`-plane). -/
+/-- A knot is *chiral* if it is not ambient-isotopic, in the
+orientation-sensitive sense used in this benchmark, to its mirror image (the
+reflection of the image through the `xy`-plane). -/
 def Knot.Chiral (K : Knot) : Prop :=
-  ¬ ∃ Φ : AmbientIsotopy,
-    Φ.H 1 '' Set.range K.curve = reflectZ '' Set.range K.curve
+  ¬ ∃ Φ : AmbientIsotopy, ∃ σ : CircleReparam,
+    ∀ t, Φ.H 1 (K.curve t) = reflectZ (K.curve (σ.f t))
 
 end KnotTheory
 end LeanEval

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -413,3 +413,36 @@ holes = ["WidgetCarrier", "instInhabitedWidget"]
 submitter = "Kim Morrison"
 notes = "Minimal example exercising instance + theorem holes; instances must be named so the comparator can address them."
 
+
+[[problem]]
+id = "exists_nonisotopic_link"
+title = "Existence of a non-isotopic pair of two-component links"
+test = false
+module = "LeanEval.KnotTheory.Linking"
+holes = ["exists_nonisotopic_link"]
+submitter = "Kim Morrison"
+notes = "Warmup for the knot-theory benchmark. Asks for two smooth two-component links in R^3 that are not ambient-isotopic. The Gauss linking integral is suggested as a tractable real-valued isotopy invariant distinguishing the unlink (lk = 0) from the Hopf link (lk = +/- 1)."
+source = "Classical; see https://en.wikipedia.org/wiki/Linking_number."
+informal_solution = "Take L1 = unlink (two unit circles in parallel planes) and L2 = Hopf link. Define lk(K, L) by the Gauss double integral (1/4 pi) int int <K(s) - L(t), K'(s) x L'(t)> / |K(s) - L(t)|^3 ds dt. Prove lk is invariant under ambient isotopy by exhibiting it as the integral of a closed 2-form on R^3 minus the origin pulled back along (K, L), so Stokes-style arguments show invariance. Compute lk(unlink) = 0 by an odd-symmetry argument and lk(Hopf) = 1 by direct evaluation. Conclude L1 and L2 are not ambient-isotopic."
+
+[[problem]]
+id = "exists_nonisotopic_knots"
+title = "Existence of a non-isotopic pair of knots"
+test = false
+module = "LeanEval.KnotTheory.NonIsotopicKnots"
+holes = ["exists_nonisotopic_knots"]
+submitter = "Kim Morrison"
+notes = "Asks for two smooth knots in R^3 that are not ambient-isotopic. Mathlib has no knot-invariant infrastructure, so the model must construct an isotopy invariant from scratch. Suggested: the Alexander polynomial / knot determinant, or the Fox 3-coloring count, both of which distinguish the unknot from the trefoil."
+source = "Classical; see https://en.wikipedia.org/wiki/Knot_invariant."
+informal_solution = "Take K1 = unknot (round circle in the xy-plane) and K2 = right-handed trefoil parametrized as t -> (sin t + 2 sin 2t, cos t - 2 cos 2t, -sin 3t). Construct an ambient-isotopy invariant; the simplest computable choice is the number of Fox 3-colorings of any diagram of K, which counts homomorphisms from the knot group to D_3. The unknot admits 3 such colorings (all monochromatic); the trefoil admits 9. Hence the two knots are not ambient-isotopic."
+
+[[problem]]
+id = "exists_chiral_knot"
+title = "Existence of a chiral knot"
+test = false
+module = "LeanEval.KnotTheory.Chiral"
+holes = ["exists_chiral_knot"]
+submitter = "Kim Morrison"
+notes = "Challenge problem of the knot-theory benchmark. Asks for a smooth knot whose image is not ambient-isotopic to its mirror image (under reflection through the xy-plane). The model must construct an ambient-isotopy invariant that takes different values on a knot and its mirror -- the knot determinant and Alexander polynomial alone do not suffice, since the figure-eight is achiral."
+source = "Classical; see https://en.wikipedia.org/wiki/Chirality_(mathematics) and https://en.wikipedia.org/wiki/Trefoil_knot."
+informal_solution = "Take K = right-handed trefoil. Construct the knot signature sigma(K) from a Seifert matrix V as the signature of V + V^T, and verify that sigma is an ambient-isotopy invariant of knots that negates under mirror reflection. Compute sigma(right trefoil) = -2, so sigma(K) != sigma(mirror K) and K is chiral. (Alternatively, use the Jones polynomial V_K(t) = -t^{-4} + t^{-3} + t^{-1}, which is not symmetric under t <-> t^{-1}.)"

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -416,33 +416,33 @@ notes = "Minimal example exercising instance + theorem holes; instances must be 
 
 [[problem]]
 id = "exists_nonisotopic_link"
-title = "Existence of a non-isotopic pair of two-component links"
+title = "Existence of a non-isotopic pair of oriented two-component links"
 test = false
 module = "LeanEval.KnotTheory.Linking"
 holes = ["exists_nonisotopic_link"]
 submitter = "Kim Morrison"
-notes = "Warmup for the knot-theory benchmark. Asks for two smooth two-component links in R^3 that are not ambient-isotopic. The Gauss linking integral is suggested as a tractable real-valued isotopy invariant distinguishing the unlink (lk = 0) from the Hopf link (lk = +/- 1)."
+notes = "Warmup for the knot-theory benchmark. Asks for two oriented smooth two-component links in R^3 that are not ambient-isotopic. The benchmark uses an orientation-sensitive notion of isotopy induced by the parametrizations, so the Gauss linking integral is a natural real-valued invariant distinguishing the unlink (lk = 0) from the Hopf link (lk = +/- 1, depending on orientation choice)."
 source = "Classical; see https://en.wikipedia.org/wiki/Linking_number."
-informal_solution = "Take L1 = unlink (two unit circles in parallel planes) and L2 = Hopf link. Define lk(K, L) by the Gauss double integral (1/4 pi) int int <K(s) - L(t), K'(s) x L'(t)> / |K(s) - L(t)|^3 ds dt. Prove lk is invariant under ambient isotopy by exhibiting it as the integral of a closed 2-form on R^3 minus the origin pulled back along (K, L), so Stokes-style arguments show invariance. Compute lk(unlink) = 0 by an odd-symmetry argument and lk(Hopf) = 1 by direct evaluation. Conclude L1 and L2 are not ambient-isotopic."
+informal_solution = "Take L1 = unlink (two unit circles in parallel planes) and L2 = Hopf link, with explicit orientations induced by the parametrizations. Define lk(K, L) by the Gauss double integral (1/4 pi) int int <K(s) - L(t), K'(s) x L'(t)> / |K(s) - L(t)|^3 ds dt. Prove lk is invariant under ambient isotopy of oriented links by exhibiting it as the integral of a closed 2-form on R^3 minus the origin pulled back along (K, L), so Stokes-style arguments show invariance. Compute lk(unlink) = 0 and choose the Hopf-link orientations so that lk(Hopf) = 1. Conclude L1 and L2 are not ambient-isotopic."
 
 [[problem]]
 id = "exists_nonisotopic_knots"
-title = "Existence of a non-isotopic pair of knots"
+title = "Existence of a non-isotopic pair of oriented knots"
 test = false
 module = "LeanEval.KnotTheory.NonIsotopicKnots"
 holes = ["exists_nonisotopic_knots"]
 submitter = "Kim Morrison"
-notes = "Asks for two smooth knots in R^3 that are not ambient-isotopic. Mathlib has no knot-invariant infrastructure, so the model must construct an isotopy invariant from scratch. Suggested: the Alexander polynomial / knot determinant, or the Fox 3-coloring count, both of which distinguish the unknot from the trefoil."
+notes = "Asks for two oriented smooth knots in R^3 that are not ambient-isotopic. The benchmark uses an orientation-sensitive notion of isotopy induced by the parametrizations. Mathlib has no knot-invariant infrastructure, so the model must construct an isotopy invariant from scratch. Suggested: the Alexander polynomial / knot determinant, or the Fox 3-coloring count, both of which distinguish the unknot from the trefoil."
 source = "Classical; see https://en.wikipedia.org/wiki/Knot_invariant."
 informal_solution = "Take K1 = unknot (round circle in the xy-plane) and K2 = right-handed trefoil parametrized as t -> (sin t + 2 sin 2t, cos t - 2 cos 2t, -sin 3t). Construct an ambient-isotopy invariant; the simplest computable choice is the number of Fox 3-colorings of any diagram of K, which counts homomorphisms from the knot group to D_3. The unknot admits 3 such colorings (all monochromatic); the trefoil admits 9. Hence the two knots are not ambient-isotopic."
 
 [[problem]]
 id = "exists_chiral_knot"
-title = "Existence of a chiral knot"
+title = "Existence of a chiral oriented knot"
 test = false
 module = "LeanEval.KnotTheory.Chiral"
 holes = ["exists_chiral_knot"]
 submitter = "Kim Morrison"
-notes = "Challenge problem of the knot-theory benchmark. Asks for a smooth knot whose image is not ambient-isotopic to its mirror image (under reflection through the xy-plane). The model must construct an ambient-isotopy invariant that takes different values on a knot and its mirror -- the knot determinant and Alexander polynomial alone do not suffice, since the figure-eight is achiral."
+notes = "Challenge problem of the knot-theory benchmark. Asks for an oriented smooth knot whose image is not ambient-isotopic to its mirror image (under reflection through the xy-plane), using the benchmark's orientation-sensitive notion of isotopy induced by the parametrization. The model must construct an ambient-isotopy invariant that takes different values on a knot and its mirror -- the knot determinant and Alexander polynomial alone do not suffice, since the figure-eight is amphichiral in the usual unoriented sense."
 source = "Classical; see https://en.wikipedia.org/wiki/Chirality_(mathematics) and https://en.wikipedia.org/wiki/Trefoil_knot."
 informal_solution = "Take K = right-handed trefoil. Construct the knot signature sigma(K) from a Seifert matrix V as the signature of V + V^T, and verify that sigma is an ambient-isotopy invariant of knots that negates under mirror reflection. Compute sigma(right trefoil) = -2, so sigma(K) != sigma(mirror K) and K is chiral. (Alternatively, use the Jones polynomial V_K(t) = -t^{-4} + t^{-3} + t^{-1}, which is not symmetric under t <-> t^{-1}.)"

--- a/scripts/generate_projects.py
+++ b/scripts/generate_projects.py
@@ -444,6 +444,39 @@ def module_source_path(module_name: str) -> pathlib.Path:
     return REPO_ROOT.joinpath(*module_name.split(".")).with_suffix(".lean")
 
 
+def source_imports(source_text: str) -> list[str]:
+    imports: list[str] = []
+    for raw in source_text.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("import "):
+            imports.append(stripped.split(maxsplit=1)[1])
+    return imports
+
+
+def repo_local_import_modules(module_name: str, seen: set[str] | None = None) -> list[str]:
+    if seen is None:
+        seen = set()
+    source_path = module_source_path(module_name)
+    if not source_path.is_file():
+        return []
+    source_text = source_path.read_text(encoding="utf-8")
+    modules: list[str] = []
+    for imported in source_imports(source_text):
+        if imported.startswith("Mathlib.") or imported == "Mathlib":
+            continue
+        if imported.startswith("EvalTools."):
+            continue
+        if imported == module_name or imported in seen:
+            continue
+        imported_path = module_source_path(imported)
+        if not imported_path.is_file():
+            continue
+        seen.add(imported)
+        modules.extend(repo_local_import_modules(imported, seen))
+        modules.append(imported)
+    return modules
+
+
 def offset_for_line_column(text: str, line: int, column: int) -> int:
     if line < 1:
         raise GenerationError(f"Invalid source line {line}")
@@ -549,59 +582,74 @@ def render_challenge_deps(problem: ProblemSpec, extracted: ExtractedTheorem) -> 
         raise GenerationError(f"Source file for module '{problem.module}' not found: {source_path}")
 
     source_text = source_path.read_text(encoding="utf-8")
-    body_start = import_prelude_length(source_text)
+    challenge_deps_parts: list[str] = []
+
+    for imported_module in repo_local_import_modules(problem.module):
+        imported_path = module_source_path(imported_module)
+        imported_text = imported_path.read_text(encoding="utf-8")
+        imported_body = _strip_problem_markers(imported_text[import_prelude_length(imported_text):]).lstrip("\n")
+        if imported_body and not imported_body.endswith("\n"):
+            imported_body += "\n"
+        if imported_body:
+            challenge_deps_parts.append(imported_body)
+
     metadata = load_ilean_metadata(problem.module)
     keep_declarations = set(extracted.same_module_dependencies)
-    if not keep_declarations:
+    if keep_declarations:
+        body_start = import_prelude_length(source_text)
+        all_declarations = {
+            str(name): value
+            for name, value in metadata.get("decls", {}).items()
+            if isinstance(name, str) and isinstance(value, list) and len(value) >= 4
+        }
+
+        declaration_starts: list[tuple[str, int]] = []
+        for declaration_name, raw_range in all_declarations.items():
+            declaration_start = offset_for_line_column(
+                source_text,
+                int(raw_range[0]) + 1,
+                int(raw_range[1]),
+            )
+            declaration_starts.append((declaration_name, declaration_start))
+        declaration_starts.sort(key=lambda item: item[1])
+
+        theorem_start, theorem_end = offset_range_for_source_range(source_text, extracted.source_range)
+        remove_ranges: list[tuple[int, int]] = []
+        for index, (declaration_name, declaration_start) in enumerate(declaration_starts):
+            if declaration_name in keep_declarations:
+                continue
+            if declaration_name == extracted.declaration_name:
+                remove_ranges.append((theorem_start, theorem_end))
+                continue
+
+            if index + 1 < len(declaration_starts):
+                next_start = declaration_starts[index + 1][1]
+            else:
+                next_start = find_top_level_end_offset(source_text, declaration_start)
+            remove_ranges.append((declaration_start, next_start))
+
+        remove_ranges.sort()
+        pieces: list[str] = []
+        cursor = body_start
+        for start, end in remove_ranges:
+            if end <= body_start:
+                continue
+            start = max(start, body_start)
+            if start < cursor:
+                continue
+            pieces.append(source_text[cursor:start])
+            cursor = end
+        pieces.append(source_text[cursor:])
+        challenge_deps_body = "".join(pieces).lstrip("\n")
+        if challenge_deps_body and not challenge_deps_body.endswith("\n"):
+            challenge_deps_body += "\n"
+        if challenge_deps_body:
+            challenge_deps_parts.append(challenge_deps_body)
+
+    if not challenge_deps_parts:
         return None
-    all_declarations = {
-        str(name): value
-        for name, value in metadata.get("decls", {}).items()
-        if isinstance(name, str) and isinstance(value, list) and len(value) >= 4
-    }
 
-    declaration_starts: list[tuple[str, int]] = []
-    for declaration_name, raw_range in all_declarations.items():
-        declaration_start = offset_for_line_column(
-            source_text,
-            int(raw_range[0]) + 1,
-            int(raw_range[1]),
-        )
-        declaration_starts.append((declaration_name, declaration_start))
-    declaration_starts.sort(key=lambda item: item[1])
-
-    theorem_start, theorem_end = offset_range_for_source_range(source_text, extracted.source_range)
-    remove_ranges: list[tuple[int, int]] = []
-    for index, (declaration_name, declaration_start) in enumerate(declaration_starts):
-        if declaration_name in keep_declarations:
-            continue
-        if declaration_name == extracted.declaration_name:
-            remove_ranges.append((theorem_start, theorem_end))
-            continue
-
-        if index + 1 < len(declaration_starts):
-            next_start = declaration_starts[index + 1][1]
-        else:
-            next_start = find_top_level_end_offset(source_text, declaration_start)
-        remove_ranges.append((declaration_start, next_start))
-
-    remove_ranges.sort()
-    pieces: list[str] = []
-    cursor = body_start
-    for start, end in remove_ranges:
-        if end <= body_start:
-            continue
-        start = max(start, body_start)
-        if start < cursor:
-            continue
-        pieces.append(source_text[cursor:start])
-        cursor = end
-    pieces.append(source_text[cursor:])
-    challenge_deps_body = "".join(pieces).lstrip("\n")
-    if challenge_deps_body and not challenge_deps_body.endswith("\n"):
-        challenge_deps_body += "\n"
-
-    return "import Mathlib\n\n" + challenge_deps_body
+    return "import Mathlib\n\n" + "\n".join(part.rstrip("\n") for part in challenge_deps_parts) + "\n"
 
 
 def extract_context_opens(problem: ProblemSpec, *, include_namespaces: bool = False) -> str:
@@ -778,9 +826,7 @@ def render_workspace(
         if challenge_deps is not None
         else "import Mathlib\nimport Submission.Helpers\n\n"
     )
-    context_open_block = extract_context_opens(
-        problem, include_namespaces=challenge_deps is not None
-    )
+    context_open_block = extract_context_opens(problem, include_namespaces=True)
     if context_open_block and not context_open_block.endswith("\n\n"):
         context_open_block += "\n"
     readme_lines = [

--- a/scripts/generate_projects.py
+++ b/scripts/generate_projects.py
@@ -576,7 +576,11 @@ def find_top_level_end_offset(source_text: str, start: int) -> int:
     return start + match.start()
 
 
-def render_challenge_deps(problem: ProblemSpec, extracted: ExtractedTheorem) -> str | None:
+def render_challenge_deps(
+    problem: ProblemSpec,
+    extracted: ExtractedTheorem,
+    local_imports: list[str] | None = None,
+) -> str | None:
     source_path = module_source_path(problem.module)
     if not source_path.is_file():
         raise GenerationError(f"Source file for module '{problem.module}' not found: {source_path}")
@@ -584,7 +588,10 @@ def render_challenge_deps(problem: ProblemSpec, extracted: ExtractedTheorem) -> 
     source_text = source_path.read_text(encoding="utf-8")
     challenge_deps_parts: list[str] = []
 
-    for imported_module in repo_local_import_modules(problem.module):
+    if local_imports is None:
+        local_imports = repo_local_import_modules(problem.module)
+
+    for imported_module in local_imports:
         imported_path = module_source_path(imported_module)
         imported_text = imported_path.read_text(encoding="utf-8")
         imported_body = _strip_problem_markers(imported_text[import_prelude_length(imported_text):]).lstrip("\n")
@@ -814,7 +821,8 @@ def render_workspace(
     solution_exact = f"Submission.{theorem_name}"
     if solution_args:
         solution_exact += " " + " ".join(solution_args)
-    challenge_deps = render_challenge_deps(problem, extracted)
+    local_imports = repo_local_import_modules(problem.module)
+    challenge_deps = render_challenge_deps(problem, extracted, local_imports)
     challenge_import = "import ChallengeDeps\n\n" if challenge_deps is not None else "import Mathlib\n\n"
     solution_imports = (
         "import ChallengeDeps\nimport Submission\n\n"
@@ -826,7 +834,10 @@ def render_workspace(
         if challenge_deps is not None
         else "import Mathlib\nimport Submission.Helpers\n\n"
     )
-    context_open_block = extract_context_opens(problem, include_namespaces=True)
+    context_open_block = extract_context_opens(
+        problem,
+        include_namespaces=(challenge_deps is not None or bool(local_imports)),
+    )
     if context_open_block and not context_open_block.endswith("\n\n"):
         context_open_block += "\n"
     readme_lines = [


### PR DESCRIPTION
This PR adds a self-contained knot-theory benchmark to lean-eval. Mathlib has essentially no knot theory, so a small Prelude defines smooth knots in `ℝ³`, two-component links, ambient isotopy, and chirality directly in terms of smooth maps and ambient diffeomorphisms of `ℝ³`; the three problems sit on top.

The problems, in order of expected difficulty:

- `exists_nonisotopic_link` — there exist two ambient-isotopy-inequivalent two-component smooth links. The note suggests the unlink and the Hopf link, distinguished by the Gauss linking integral.
- `exists_nonisotopic_knots` — there exist two ambient-isotopy-inequivalent smooth knots. The note suggests the unknot and the right-handed trefoil, distinguished by Fox 3-colorings or the knot determinant.
- `exists_chiral_knot` — there exists a smooth knot whose image is not ambient-isotopic to its mirror image (under reflection through the `xy`-plane). The note suggests the right-handed trefoil, distinguished by the knot signature or the Jones polynomial.

In all three cases the model must construct an ambient-isotopy invariant from scratch — the Prelude scaffolds only definitions, not invariants. Each problem requires a different invariant and each is a substantial formalisation in its own right.

🤖 Prepared with Claude Code