### PR TITLE
fix(ci): scope Submission Policy Diff Check to pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,27 +96,21 @@ jobs:
       - name: Submission Policy Check
         run: python scripts/validate_submission.py --file generated/two_plus_two/Solution.lean
 
+      # Submission diff validation is a PR-time contributor policy: it
+      # decides whether a PR that only touches `generated/` looks like a
+      # well-formed submission. On `push` to `main` the diffs we see are
+      # either merged PR results or the regenerator bot's
+      # `chore: regenerate generated/ workspaces` commit, neither of
+      # which the submission policy applies to. `main` itself is
+      # PR-protected for humans (see docs/ci-secrets.md), so we lose no
+      # meaningful coverage by gating this step on `pull_request`.
       - name: Submission Policy Diff Check
+        if: github.event_name == 'pull_request'
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          CURRENT_SHA: ${{ github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            BASE_SHA="$PR_BASE_SHA"
-            HEAD_SHA="$PR_HEAD_SHA"
-          else
-            BASE_SHA="$PUSH_BEFORE_SHA"
-            HEAD_SHA="$CURRENT_SHA"
-          fi
-
-          if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
-            BASE_SHA="$(git rev-list --max-parents=0 "$HEAD_SHA" | tail -n 1)"
-          fi
 
           mapfile -t CHANGED_FILES < <(git diff --name-only "$BASE_SHA..$HEAD_SHA")
 


### PR DESCRIPTION
This PR scopes the `Submission Policy Diff Check` step in [.github/workflows/ci.yml](.github/workflows/ci.yml) to `pull_request` events only, and removes the now-dead `push`-event branch from the script body.

The diff check is a contributor-policy gate for PRs that touch only `generated/` — it asserts that submitters edit only `Solution.lean` and `Submission.lean` (status `M`). On `push` to `main` the only diffs that match the all-paths-under-`generated/` shape are the regenerator bot's `chore: regenerate generated/ workspaces` commits from [.github/workflows/regenerate-main.yml](.github/workflows/regenerate-main.yml), whose newly-added problem files (`Challenge.lean`, `holes.json`, `lakefile.toml`, `lean-toolchain`, …) and `A`-status `Solution.lean` / `Submission.lean` are correctly outside the submission whitelist. So the check fires and fails on every problem-add PR — most recently on the regen commit after https://github.com/leanprover/lean-eval/pull/77 ([run 25241665878](https://github.com/leanprover/lean-eval/actions/runs/25241665878)), and previously on at least [run 25240682630](https://github.com/leanprover/lean-eval/actions/runs/25240682630).

This is a policy/domain mismatch, not a bad whitelist: the submission policy doesn't apply to merged-PR results or regenerator output. `main` is PR-protected for humans (the regenerator app is the only bypass actor in the Repository Ruleset documented at [docs/ci-secrets.md](docs/ci-secrets.md#L74-L124)), so gating the step on `pull_request` doesn't lose meaningful coverage. The other steps in the `verify` job (`Submission Policy Check`, `Run Submission Policy Tests`, generator/scoring tests, build checks) are unchanged and still run on every event.

I considered three alternatives and rejected each:

- Whitelist new-problem-add diffs in `validate_submission.py` — couples submission policy to generator internals and creates a brittle second policy engine.
- Filter by commit author / message — weak and easy to outgrow.
- `paths-ignore: ['generated/**']` on the whole `verify` job for `push` — too broad; loses unrelated unit-test coverage.

A workflow comment now records the trust model so future "simplifications" don't reintroduce the bug.

🤖 Prepared with Claude Code