### PR TITLE
fix: post fallback comment when submission pipeline fails before record

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -361,3 +361,34 @@ jobs:
           gh issue close ${{ github.event.issue.number }} \
             --repo "${{ github.repository }}" \
             --reason "completed"
+
+  # Catches the case where `fetch` succeeded but the pipeline did not
+  # complete cleanly — most often `evaluate` failing because the
+  # submitter's Submission.lean did not compile. Without this, the
+  # `record` job is skipped (its `needs: evaluate` dependency was unmet)
+  # and the submitter sees no comment at all.
+  notify:
+    needs: [fetch, evaluate, record]
+    if: always() && needs.fetch.result == 'success' && needs.record.result != 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Comment on workflow failure and close issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVALUATE_RESULT: ${{ needs.evaluate.result }}
+          RECORD_RESULT: ${{ needs.record.result }}
+        run: |
+          if [ "$EVALUATE_RESULT" = "success" ]; then
+            BODY="❌ Recording the submission to the leaderboard did not complete (record job: $RECORD_RESULT). See the workflow logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            BODY="❌ Submission evaluation did not produce results (evaluate job: $EVALUATE_RESULT). The most common cause is that \`Submission.lean\` failed to compile. See the workflow logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo "${{ github.repository }}" \
+            --body "$BODY"
+          gh issue close ${{ github.event.issue.number }} \
+            --repo "${{ github.repository }}" \
+            --reason "not planned" || true


### PR DESCRIPTION
This PR adds a `notify` job to the submission workflow so that submitters always see a comment on their issue, even when evaluation fails before the `record` job can run.

Currently, every submission whose `Submission.lean` fails to compile is a silent dropout: `evaluate_submission.py` exits non-zero, the `evaluate` job fails, and the `record` job (which has `needs: evaluate`) is skipped — including its existing fallback "missing results" comment. Submitters see nothing on their issue. See e.g. issues #63, #68, #69, #70, #72, #74, #75.

The new `notify` job runs whenever `fetch` succeeded but `record` did not (covers `evaluate` failure, `evaluate` cancellation, `record` failure, and the artifact-missing case the existing fallback comment was meant to handle). It posts a comment with a link to the workflow logs and closes the issue.

This is the smallest fix to stop the silent dropouts. Two follow-ups worth doing:
1. Split `_prime_workspace` so a `Submission` compile failure can be reported as a normal benchmark outcome (with the actual Lean error inlined into the per-problem comment) rather than a workflow failure.
2. Isolate per-workspace failures in the `for match in matches` loop so one broken workspace cannot abort the rest of a multi-problem submission.

🤖 Prepared with Claude Code