### PR TITLE
doc: clarify regenerator-bypass downstream-workflow scope

### DIFF
--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -240,11 +240,24 @@ with a bogus check of the same name.
 
 ### Acceptable consequences of the bypass
 
-- `regenerate-main.yml`'s pushes to `main` will *not* trigger downstream
-  workflows (anti-loop protection still applies; bypass doesn't change
-  this). The regen workflow validates `python scripts/generate_projects.py`
-  inside the workflow, so the artifact landing on `main` is already
-  vetted.
+- `regenerate-main.yml`'s pushes to `main` will *not* re-trigger
+  `regenerate-main.yml` itself: that workflow's `paths:` filter only
+  fires on source changes (`LeanEval/**`, `EvalTools/**`,
+  `manifests/problems.toml`, `scripts/generate_projects.py`,
+  `lakefile.toml`, `lean-toolchain`), and the bot only writes under
+  `generated/`. The bypass doesn't change this; the `paths:` filter
+  is what prevents the loop.
+
+  Other workflows on `main` push events *do* run on regenerator
+  commits — most notably `ci.yml`'s `verify` job, which has no
+  `paths:` filter. That is intentional: it exercises the regenerated
+  workspace. Per-step gating is the regenerator's responsibility when
+  a check is genuinely PR-only (see the `pull_request`-gated
+  Submission Policy Diff Check in `ci.yml`).
+
+  The regen workflow itself runs `python scripts/generate_projects.py`
+  before pushing, so the artifact landing on `main` is already vetted
+  against the source.
 - Anyone who can land a PR that modifies `regenerate-main.yml` to push
   arbitrary content to `main` could, after merge, exfiltrate that
   capability. This is the same trust boundary as merging any PR.


### PR DESCRIPTION
This PR rewrites the misleading bullet in [docs/ci-secrets.md](docs/ci-secrets.md) under \"Acceptable consequences of the bypass\" that claimed regenerator pushes to \`main\` \"do *not* trigger downstream workflows.\"

The previous text conflated two distinct facts. The regenerator workflow won't re-trigger itself, but that's because of the \`paths:\` filter at [.github/workflows/regenerate-main.yml:8-14](.github/workflows/regenerate-main.yml#L8-L14) — the bot only writes under \`generated/\`, and that path isn't on its trigger list. The bypass doesn't enter into it. Meanwhile, other workflows do run on regenerator commits — most visibly [.github/workflows/ci.yml](.github/workflows/ci.yml)'s \`verify\` job, which has no \`paths:\` filter, so it fires on every push to \`main\` (regenerator or not). That's intentional coverage of the regenerated workspace. The new text says so plainly and points at the \`pull_request\`-gated Submission Policy Diff Check (recently added in https://github.com/leanprover/lean-eval/pull/79 - fix(ci): scope Submission Policy Diff Check to pull_request events) as the model for per-step gating when a check is genuinely PR-only.

🤖 Prepared with Claude Code