### PR TITLE
fix: replace Rouché logCounting equality with multiplicity zero count

### DIFF
--- a/LeanEval/ComplexAnalysis/Rouche.lean
+++ b/LeanEval/ComplexAnalysis/Rouche.lean
@@ -7,7 +7,8 @@ namespace ComplexAnalysis
 open MeromorphicOn
 
 /-!
-Rouché's theorem, stated as equality of multiplicity-counted zero counts on a closed disk
+Rouché's theorem (zero-count formulation, extended to the meromorphic case via divisors),
+stated as equality of multiplicity-counted zero counts on the closed disk of radius `R`
 centered at `0`.
 
 The previous formulation used `ValueDistribution.logCounting f 0 R`, the **log-weighted**
@@ -17,8 +18,8 @@ inside the disk, but the log-weighted count depends on where each zero sits. Con
 `f(z) = z` and `g(z) = -1/2` satisfy `|g| = 1/2 < 2 = |z| = |f|` on `|z| = 2`, yet
 `logCounting f 0 2 = log 2` while `logCounting (f + g) 0 2 = log(2 / (1/2)) = log 4`.
 
-We instead state the conclusion in terms of the multiplicity sum of the zero divisor
-restricted to the closed disk of radius `R`, which is the standard form of Rouché.
+We instead state the conclusion as the equality of the multiplicity sums of the zero
+divisors of `f` and `f + g` taken on the closed disk of radius `R`.
 -/
 
 @[eval_problem]
@@ -28,8 +29,8 @@ theorem rouche_zero_count_eq
     (hf : MeromorphicOn f Set.univ)
     (hg : AnalyticOn ℂ g Set.univ)
     (hbound : ∀ z : ℂ, ‖z‖ = R → ‖g z‖ < ‖f z‖) :
-    (∑ᶠ z, ((divisor (f + g) Set.univ)⁺.toClosedBall R) z) =
-      (∑ᶠ z, ((divisor f Set.univ)⁺.toClosedBall R) z) := by
+    (∑ᶠ z, ((divisor (f + g) (Metric.closedBall 0 R))⁺) z) =
+      (∑ᶠ z, ((divisor f (Metric.closedBall 0 R))⁺) z) := by
   sorry
 
 end ComplexAnalysis

--- a/LeanEval/ComplexAnalysis/Rouche.lean
+++ b/LeanEval/ComplexAnalysis/Rouche.lean
@@ -4,23 +4,32 @@ import EvalTools.Markers
 namespace LeanEval
 namespace ComplexAnalysis
 
-open ValueDistribution
+open MeromorphicOn
 
 /-!
-Rouché's theorem, stated here as equality of zero-counting functions on a circle centered at `0`.
+Rouché's theorem, stated as equality of multiplicity-counted zero counts on a closed disk
+centered at `0`.
 
-The hypotheses are intentionally phrased in terms of the existing meromorphic/analytic and
-`ValueDistribution.logCounting` APIs.
+The previous formulation used `ValueDistribution.logCounting f 0 R`, the **log-weighted**
+Nevanlinna counting function — which is *not* the conclusion of Rouché. Under `‖g‖ < ‖f‖`
+on the boundary, `f` and `f + g` have the same number of zeros (counted with multiplicity)
+inside the disk, but the log-weighted count depends on where each zero sits. Concretely,
+`f(z) = z` and `g(z) = -1/2` satisfy `|g| = 1/2 < 2 = |z| = |f|` on `|z| = 2`, yet
+`logCounting f 0 2 = log 2` while `logCounting (f + g) 0 2 = log(2 / (1/2)) = log 4`.
+
+We instead state the conclusion in terms of the multiplicity sum of the zero divisor
+restricted to the closed disk of radius `R`, which is the standard form of Rouché.
 -/
 
 @[eval_problem]
-theorem rouche_logCounting_zero_eq
+theorem rouche_zero_count_eq
     {f g : ℂ → ℂ} {R : ℝ}
-    (hR : 1 ≤ R)
-    (hf : Meromorphic f)
+    (hR : 0 < R)
+    (hf : MeromorphicOn f Set.univ)
     (hg : AnalyticOn ℂ g Set.univ)
     (hbound : ∀ z : ℂ, ‖z‖ = R → ‖g z‖ < ‖f z‖) :
-    logCounting (f + g) 0 R = logCounting f 0 R := by
+    (∑ᶠ z, ((divisor (f + g) Set.univ)⁺.toClosedBall R) z) =
+      (∑ᶠ z, ((divisor f Set.univ)⁺.toClosedBall R) z) := by
   sorry
 
 end ComplexAnalysis

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -155,13 +155,13 @@ source = "Classical theorem in finite group theory."
 informal_solution = "Use character theory and induction on the group order to prove solvability."
 
 [[problem]]
-id = "rouche_logCounting_zero_eq"
+id = "rouche_zero_count_eq"
 title = "Rouche theorem via zero counting"
 test = false
 module = "LeanEval.ComplexAnalysis.Rouche"
-holes = ["rouche_logCounting_zero_eq"]
+holes = ["rouche_zero_count_eq"]
 submitter = "Kim Morrison"
-notes = "Phrases Rouché's theorem as equality of zero-counting functions for f and f + g."
+notes = "Phrases Rouché's theorem as equality of multiplicity-counted zero counts for f and f + g on the closed disk of radius R."
 source = "Classical theorem in complex analysis."
 informal_solution = "If |g| < |f| on the boundary circle, then f and f + g have the same number of zeros inside, counted with multiplicity."
 


### PR DESCRIPTION
This PR replaces the leaderboard problem `rouche_logCounting_zero_eq` with a corrected formulation `rouche_zero_count_eq`. The previous statement equated `ValueDistribution.logCounting (f + g) 0 R` with `logCounting f 0 R` under the Rouché hypothesis `‖g‖ < ‖f‖` on `|z| = R`. That equality is **not** the conclusion of Rouché's theorem: the Nevanlinna log-weighted counting function depends on the locations of zeros, not just their multiplicity sum. Aristotle exhibited a clean counterexample with `f(z) = z`, `g(z) = -1/2`, `R = 2`: `‖g‖ = 1/2 < 2 = ‖f‖` on `|z| = 2`, but `logCounting f 0 2 = log 2` while `logCounting (f + g) 0 2 = log 4`.

The corrected statement instead asserts equality of the multiplicity sum of the zero divisor of `f` and `f + g` on the closed disk of radius `R`, which is the standard form of Rouché. The hypothesis `1 ≤ R` is also relaxed to `0 < R` since the new formulation does not need the log-counting domain restriction, and `Meromorphic f` is replaced by `MeromorphicOn f Set.univ` to match the API used by `divisor`.

🤖 Prepared with Claude Code