### PR TITLE
security: disable submission workflow pending sandbox audit

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -19,7 +19,12 @@ concurrency:
 
 jobs:
   fetch:
-    if: github.event.label.name == 'submission'
+    # SECURITY: workflow disabled while we investigate / fix unsandboxed
+    # elaboration of user-supplied Submission.lean in
+    # scripts/evaluate_submission.py:_prime_workspace. Do not re-enable
+    # without confirming comparator's landrun sandbox is the only place
+    # the submitter's Lean code is built.
+    if: false && github.event.label.name == 'submission'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
This PR disables the submission workflow while we investigate and fix unsandboxed elaboration of user-supplied \`Submission.lean\` in [scripts/evaluate_submission.py:_prime_workspace](scripts/evaluate_submission.py#L283).

\`_prime_workspace\` runs \`lake build Challenge Solution Submission\` outside landrun on each overlaid workspace before comparator runs. \`Solution.lean\` imports \`Submission\`, so both \`lake build Solution\` and \`lake build Submission\` elaborate the attacker-controlled file unsandboxed. Lean elaboration runs IO via \`#eval\`, \`initialize\`, custom elaborators, and macros, so this is RCE-equivalent on the evaluate runner. The intended security model — untrusted Lean is only ever built inside comparator's landrun sandbox — is broken.

The regression was introduced 2026-04-12 by 3474943 ("Pre-build Challenge, Solution, Submission during workspace priming"), motivated by making "comparator's sandboxed lake build a no-op" with no mention of the security implication.

Follow-up PR will strip the unsandboxed \`lake build\` args from \`_prime_workspace\`. Comparator-side landrun policy fix (so its internal sandboxed build can do its legitimate writes without the priming workaround) is a separate concern, tracked separately.

🤖 Prepared with Claude Code