### PR TITLE
security: stop building user code outside landrun in _prime_workspace

### DIFF
--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -283,28 +283,37 @@ def _share_packages(
 def _prime_workspace(target: pathlib.Path) -> None:
     """Populate the workspace's packages outside of landrun.
 
-    `lake update` and `lake exe cache get` need network access and
-    write to `lake-manifest.json` and the package cache, both of which
-    comparator's landrun policy denies. They do not elaborate any
-    project source files (only fetch packages and Mathlib oleans), so
-    running them outside the sandbox is safe.
+    Per comparator's README assumptions, `lake exe cache get` before
+    invoking comparator is explicitly allowed. `lake update` is needed
+    here too because comparator's landrun policy denies the
+    `lake-manifest.json` writes lake update performs. Neither command
+    elaborates project source files, so neither violates comparator's
+    trust model.
 
-    SECURITY: do NOT add `lake build <target>` here for any target whose
-    transitive imports include `Submission` (the user-controlled file
-    overlaid by overlay_match). Lean elaboration runs arbitrary IO via
-    #eval, initialize, custom elaborators, and macros; building such a
-    target outside landrun is RCE-equivalent on the runner. In the
-    generated workspaces, `Solution` imports `Submission` and
-    `Submission` imports `Submission.Helpers` — so `Solution` and
+    SECURITY: do NOT add `lake build <target>` here for any target
+    whose transitive imports include `Submission` (the user-controlled
+    file overlaid by overlay_match). Comparator's README assumption #2
+    requires that the Solution file (and any other potentially
+    adversarial file) has not been pre-compiled before comparator
+    runs, because pre-compilation can let an adversarial Submission
+    compromise Challenge so that comparator appears to verify a
+    different theorem than the intended one. Concretely, in the
+    generated workspaces `Solution` imports `Submission` and
+    `Submission` imports `Submission.Helpers`, so `Solution` and
     `Submission` are off-limits here. Even `Challenge`, although it
     does not currently import `Submission`, should not be added back
-    without explicit auditing of every problem's `Challenge.lean`.
+    without auditing every problem's `Challenge.lean`.
 
-    Comparator's sandboxed `lake build` is responsible for building
-    Submission. If that build fails because comparator's landrun policy
-    is too restrictive for lake's legitimate writes, fix the policy in
-    comparator (or pass lake flags to suppress those writes); do not
-    pre-build outside the sandbox as a workaround.
+    Aside from breaking comparator's correctness guarantee, building
+    `Submission` outside landrun also runs arbitrary attacker IO on
+    the runner: Lean elaboration executes IO via #eval, initialize,
+    custom elaborators, and macros.
+
+    Comparator's sandboxed `lake build` inside landrun is the intended
+    place for `Submission` to be elaborated. Comparator + landrun (from
+    upstream `main`, per its README and check_comparator_installation.py)
+    is designed to handle this on a workspace primed only with `lake
+    update` + `lake exe cache get`.
     """
     commands = (
         ["lake", "update"],

--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -281,22 +281,34 @@ def _share_packages(
 
 
 def _prime_workspace(target: pathlib.Path) -> None:
-    """Populate the workspace's packages and pre-build Challenge, Solution,
-    and Submission *outside* of landrun, so comparator's sandboxed
-    `lake build` is effectively a no-op.
+    """Populate the workspace's packages outside of landrun.
 
-    Comparator's safeLakeBuild whitelists reads on `projectDir` and writes
-    on `projectDir/.lake` only. If lake tries to touch `lake-manifest.json`
-    (not inside `.lake`) or clone packages into scratch dirs, landrun
-    denies. Pre-building everything outside the sandbox avoids every
-    such write.
+    `lake update` and `lake exe cache get` need network access and
+    write to `lake-manifest.json` and the package cache, both of which
+    comparator's landrun policy denies. They do not elaborate any
+    project source files (only fetch packages and Mathlib oleans), so
+    running them outside the sandbox is safe.
 
-    Matches the priming in scripts/check_comparator_installation.py.
+    SECURITY: do NOT add `lake build <target>` here for any target whose
+    transitive imports include `Submission` (the user-controlled file
+    overlaid by overlay_match). Lean elaboration runs arbitrary IO via
+    #eval, initialize, custom elaborators, and macros; building such a
+    target outside landrun is RCE-equivalent on the runner. In the
+    generated workspaces, `Solution` imports `Submission` and
+    `Submission` imports `Submission.Helpers` — so `Solution` and
+    `Submission` are off-limits here. Even `Challenge`, although it
+    does not currently import `Submission`, should not be added back
+    without explicit auditing of every problem's `Challenge.lean`.
+
+    Comparator's sandboxed `lake build` is responsible for building
+    Submission. If that build fails because comparator's landrun policy
+    is too restrictive for lake's legitimate writes, fix the policy in
+    comparator (or pass lake flags to suppress those writes); do not
+    pre-build outside the sandbox as a workaround.
     """
     commands = (
         ["lake", "update"],
         ["lake", "exe", "cache", "get"],
-        ["lake", "build", "Challenge", "Solution", "Submission"],
     )
     for args in commands:
         result = subprocess.run(


### PR DESCRIPTION
This PR drops \`lake build Challenge Solution Submission\` from [scripts/evaluate_submission.py:_prime_workspace](scripts/evaluate_submission.py#L283), closing the unsandboxed-elaboration hole introduced by 3474943 on 2026-04-12.

\`Solution.lean\` imports \`Submission\`, so \`lake build Solution\` and \`lake build Submission\` both elaborated the attacker-controlled \`Submission.lean\` outside landrun. Lean elaboration runs IO via \`#eval\`, \`initialize\`, custom elaborators, and macros, so this was RCE-equivalent on the evaluate runner.

After this PR, \`_prime_workspace\` only runs \`lake update\` and \`lake exe cache get\` outside landrun — neither elaborates project source. Comparator's sandboxed \`lake build\` inside landrun is the intended (and now sole) place \`Submission\` is built. If comparator's landrun policy is too restrictive for lake's legitimate writes, the fix belongs in comparator (or in lake flags), not in pre-building outside the sandbox.

The docstring is replaced with an explicit SECURITY note explaining why no \`lake build <target>\` may be added back here for any target whose transitive imports include \`Submission\` (and that even \`Challenge\` should not be added without auditing every problem's \`Challenge.lean\`).

Pairs with #91, which disables the submission workflow until the comparator-side fix lands. Together: #91 stops new submissions; this PR closes the latent vulnerability so re-enabling does not reopen it. \`scripts/check_comparator_installation.py\` has a similar maintainer-only pattern that should be audited separately.

🤖 Prepared with Claude Code