### PR TITLE
fix: relax complementary-polynomial degree constraint to inequality

### DIFF
--- a/LeanEval/ComplexAnalysis/ComplementaryPolynomials.lean
+++ b/LeanEval/ComplexAnalysis/ComplementaryPolynomials.lean
@@ -13,16 +13,22 @@ Complementary polynomials on the unit circle.
 This is the basic existence statement appearing in quantum signal processing: if a complex
 polynomial has sup norm at most `1` on the unit circle, then it admits a complementary polynomial
 whose squared moduli add up to `1` on the circle.
+
+The previous statement asked for `Q.natDegree = P.natDegree` (strict equality), which fails on
+the boundary case `P = X`: there `|P(z)| = 1` on the entire unit circle, so any complementary `Q`
+must vanish on the circle and hence be the zero polynomial; but `natDegree 0 = 0 ≠ 1 = natDegree X`.
+We relax the constraint to `≤`, which is what Fejér-Riesz / spectral factorization actually
+delivers (the degree of `Q` is at most that of `P`, with equality generically).
 -/
 
-/-- If `P` is bounded by `1` on the unit circle, then there is a polynomial `Q` of the same degree
-whose squared moduli complement `P` to `1` on the unit circle. -/
+/-- If `P` is bounded by `1` on the unit circle, then there is a polynomial `Q` of degree at most
+that of `P` whose squared moduli complement `P` to `1` on the unit circle. -/
 @[eval_problem]
 theorem exists_complementary_polynomial_on_unit_circle
     (P : ℂ[X])
     (hP : ∀ z : Circle, ‖P.eval (z : ℂ)‖ ≤ 1) :
     ∃ Q : ℂ[X],
-      Q.natDegree = P.natDegree ∧
+      Q.natDegree ≤ P.natDegree ∧
         ∀ z : Circle, ‖P.eval (z : ℂ)‖ ^ 2 + ‖Q.eval (z : ℂ)‖ ^ 2 = 1 := by
   sorry
 


### PR DESCRIPTION
This PR relaxes the leaderboard problem `exists_complementary_polynomial_on_unit_circle` from `Q.natDegree = P.natDegree` (strict equality) to `Q.natDegree ≤ P.natDegree`. Aristotle exhibited a clean counterexample with `P = X`: there `|P(z)| = |z| = 1` on the entire unit circle, so the equation `|P|² + |Q|² = 1` forces `|Q(z)| = 0` for every `z` with `|z| = 1`, hence `Q = 0` (a polynomial vanishing on uncountably many points must be zero), but `natDegree 0 = 0 ≠ 1 = natDegree X`.

The relaxed `≤` constraint matches what Fejér-Riesz / spectral factorization actually delivers: the degree of the complementary polynomial is at most that of `P`, with equality generically (whenever `|P| < 1` somewhere on the circle) and a drop on the boundary case `|P| ≡ 1`.

🤖 Prepared with Claude Code