### PR TITLE
security: re-enable submission workflow after _prime_workspace fix

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -19,12 +19,7 @@ concurrency:
 
 jobs:
   fetch:
-    # SECURITY: workflow disabled while we investigate / fix unsandboxed
-    # elaboration of user-supplied Submission.lean in
-    # scripts/evaluate_submission.py:_prime_workspace. Do not re-enable
-    # without confirming comparator's landrun sandbox is the only place
-    # the submitter's Lean code is built.
-    if: false && github.event.label.name == 'submission'
+    if: github.event.label.name == 'submission'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
This PR re-enables the submission workflow disabled in #91 now that #92 has removed the unsandboxed \`lake build Challenge Solution Submission\` from [scripts/evaluate_submission.py:_prime_workspace](scripts/evaluate_submission.py#L283).

Verification: the post-#92 production flow is exactly what [scripts/check_comparator_installation.py:213-248](scripts/check_comparator_installation.py#L213-L248) exercises — copy a generated workspace, set Submission.lean to a known-good proof, run \`lake update\` + \`lake exe cache get\` + \`lake test\`. That last step invokes WorkspaceTest → \`comparator\` → comparator's sandboxed \`lake build\` inside landrun. The check passed on #92's CI run as the "Run Comparator Installation Checks" step, against landrun installed from \`@main\` and the pinned comparator rev. So we know the post-#92 flow works on Linux runners with the production setup.

Outstanding follow-ups (not blocking re-enable):
- Audit remaining wisdom about \`_prime_workspace\` so a future contributor cannot accidentally re-add a \`lake build <user-target>\` line; the docstring SECURITY note from #92 covers this in prose, but a regression test that asserts \`_prime_workspace\` does not invoke \`lake build\` would make it harder to undo.
- Backfill \`scripts/check_comparator_installation.py\` with a comment pointing at the comparator README assumption #2 so its no-prebuild design is similarly hardened.

🤖 Prepared with Claude Code