### PR TITLE
doc: harden the no-prebuild rule against future regressions

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -1,5 +1,14 @@
 # Auth (lean-eval-bot GitHub App + LEADERBOARD_WRITE_TOKEN PAT) is
 # documented in docs/ci-secrets.md.
+#
+# Security model: untrusted submitter Lean code is ONLY ever elaborated
+# inside comparator's landrun sandbox (invoked from `lake test` via
+# WorkspaceTest.lean). The non-negotiable invariants of this workflow
+# (read-only token in the evaluate job, .git stripped before lake runs,
+# `_prime_workspace` not pre-building any user-controlled targets, etc.)
+# are documented in LANDRUN.md → "What must not regress when this is
+# fixed". Read that section before editing this file or
+# `scripts/evaluate_submission.py`.
 name: Submission
 
 on:

--- a/LANDRUN.md
+++ b/LANDRUN.md
@@ -416,3 +416,31 @@ environment (kernel, landlock ABI, filesystem layout).
 - The three-job split with `LEADERBOARD_WRITE_TOKEN` in `record` only.
 - The landrun sandbox itself. This file exists *because* the sandbox is
   non-negotiable for this project.
+- **`_prime_workspace` (in `scripts/evaluate_submission.py`) must NEVER
+  invoke `lake build <target>` for any target whose transitive imports
+  include `Submission`.** That includes `Submission` itself, `Solution`
+  (which imports `Submission` in every generated workspace), and any
+  `Challenge` whose imports reach `Submission` (none today, but audit
+  every problem's `Challenge.lean` before adding it back). The only
+  shell-outs `_prime_workspace` may perform outside landrun are `lake
+  update` and `lake exe cache get`, both of which fetch packages and
+  Mathlib oleans without elaborating any project source. Comparator's
+  sandboxed `lake build` inside landrun is the sole intended place for
+  `Submission` to be elaborated.
+
+  Why this matters: Lean elaboration runs arbitrary IO via `#eval`,
+  `initialize`, custom elaborators, and macros, so building
+  attacker-controlled `Submission.lean` outside landrun is
+  RCE-equivalent on the runner. Independently, comparator's README
+  assumption #2 explicitly forbids pre-compiling `Solution` (or any
+  potentially adversarial file) before invoking comparator —
+  pre-compilation can let an adversarial submission compromise the
+  `Challenge` file so comparator appears to verify a different theorem
+  than the intended one. So the rule protects both runner integrity
+  and comparator's correctness guarantee.
+
+  This rule was violated on 2026-04-12 by commit 3474943 ("Pre-build
+  Challenge, Solution, Submission during workspace priming"), reverted
+  on 2026-05-02 in #92 ("security: stop building user code outside
+  landrun in `_prime_workspace`"). The current docstring in
+  `_prime_workspace` carries the same warning at the call site.

--- a/scripts/check_comparator_installation.py
+++ b/scripts/check_comparator_installation.py
@@ -1,6 +1,19 @@
 #!/usr/bin/env python3
 """
 Run a real comparator check against a tiny generated workspace.
+
+This script edits a `Submission.lean` with a maintainer-controlled proof
+(`norm_num` for `2 + 2 = 4`) and then runs `lake update` + `lake exe
+cache get` + `lake test` outside landrun. The `lake test` step invokes
+WorkspaceTest -> comparator, and comparator's sandboxed `lake build`
+inside landrun is what compiles the (maintainer-controlled) `Submission`.
+The Submission content here is hardcoded by the maintainer, NEVER fed
+from a submitter, so this script's pattern is safe even though it
+superficially resembles `_prime_workspace` in scripts/evaluate_submission.py.
+
+Do not generalize this script to accept submitter-supplied Submission
+content without re-reading LANDRUN.md "What must not regress when this
+is fixed".
 """
 
 from __future__ import annotations

--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -10,6 +10,11 @@ overlays the matched `Submission.lean` + `Submission/**/*.lean` onto a
 copy of the pristine `generated/<id>/` workspace, invokes
 `lake exe lean-eval run-eval --json --problem <id>... --workspaces-root <tempdir>`,
 and writes results.json + summary.json artifacts for the `record` job.
+
+SECURITY: untrusted submitter Lean code is ONLY ever elaborated inside
+comparator's landrun sandbox. `_prime_workspace` (below) must not invoke
+`lake build` for any user-controlled target. See LANDRUN.md "What must
+not regress when this is fixed" for the full rule and rationale.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
This PR documents the rule that 3474943 (2026-04-12) violated and #92 restored, in places where a future contributor (or AI assistant) editing the affected files will see it before they make the same mistake.

Specifically:

- [LANDRUN.md](LANDRUN.md) "What must not regress when this is fixed" gains an explicit bullet stating that \`_prime_workspace\` must never invoke \`lake build\` for any target whose transitive imports include \`Submission\`, with cross-reference to comparator's README assumption #2 (which forbids pre-compiling \`Solution\` independently for correctness reasons, not just security).
- [.github/workflows/submission.yml](.github/workflows/submission.yml) gains a top-of-file SECURITY block pointing at LANDRUN.md.
- [scripts/evaluate_submission.py](scripts/evaluate_submission.py) module docstring gains the same pointer.
- [scripts/check_comparator_installation.py](scripts/check_comparator_installation.py) gains a docstring explaining why its similar pre-build pattern is safe (maintainer-controlled input only) and warning against generalizing it to a submitter-fed path.

No code changes.

🤖 Prepared with Claude Code