### PR TITLE
chore(ci): notify leaderboard when main advances (snapshot-bump trigger)

### DIFF
--- a/.github/workflows/notify-leaderboard.yml
+++ b/.github/workflows/notify-leaderboard.yml
@@ -1,0 +1,40 @@
+name: Notify leaderboard of main advance
+
+# Wakes up the leaderboard repo whenever a problem-affecting change
+# lands on `main`, so it can advance benchmark-snapshot/.benchmark-commit
+# and (transitively) re-deploy the live site.
+#
+# The dispatched SHA is advisory only — the leaderboard's
+# bump-benchmark-snapshot.yml re-resolves origin/main itself.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'LeanEval/**'
+      - 'EvalTools/**'
+      - 'manifests/problems.toml'
+      - 'scripts/generate_projects.py'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
+  workflow_dispatch:
+
+concurrency:
+  group: notify-leaderboard
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire repository_dispatch into lean-eval-leaderboard
+        env:
+          GH_TOKEN: ${{ secrets.LEADERBOARD_WRITE_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          gh api repos/leanprover/lean-eval-leaderboard/dispatches \
+            -X POST \
+            -F event_type=lean-eval-main-advanced \
+            -F "client_payload[sha]=$SHA"


### PR DESCRIPTION
This PR adds [.github/workflows/notify-leaderboard.yml](.github/workflows/notify-leaderboard.yml), which fires `repository_dispatch` into `leanprover/lean-eval-leaderboard` whenever a problem-affecting change lands on `main`. The leaderboard repo's companion workflow (https://github.com/leanprover/lean-eval-leaderboard/pull/32) advances `benchmark-snapshot/.benchmark-commit` and re-deploys the live site.

Triggers only on changes to `LeanEval/`, `EvalTools/`, `manifests/problems.toml`, `scripts/generate_projects.py`, `lakefile.toml`, `lean-toolchain` — i.e. things that affect the catalog of problems. Doc-only and CI-only commits don't fire it.

Auth: existing `LEADERBOARD_WRITE_TOKEN` (Contents:write on leaderboard, sufficient for `repository_dispatch` per [GitHub's fine-grained PAT permission docs for that endpoint](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event)).

This is half of a two-repo change; the leaderboard side is at https://github.com/leanprover/lean-eval-leaderboard/pull/32. Either PR can land first — the dispatch is a no-op until the listener exists, and the listener is dormant until something dispatches.

Trust-surface note: this widens what `LEADERBOARD_WRITE_TOKEN` is used for from "submission records only" to "also wakes the leaderboard's snapshot-bump pipeline." It does not introduce a new actor or new write paths — the leaderboard workflow's commit is what moves state, and that workflow only ever rewrites `benchmark-snapshot/`.

🤖 Prepared with Claude Code