### PR TITLE
fix: walk to eval_problem decl when extracting context opens

### DIFF
--- a/scripts/generate_projects.py
+++ b/scripts/generate_projects.py
@@ -659,32 +659,49 @@ def render_challenge_deps(
     return "import Mathlib\n\n" + "\n".join(part.rstrip("\n") for part in challenge_deps_parts) + "\n"
 
 
-def extract_context_opens(problem: ProblemSpec, *, include_namespaces: bool = False) -> str:
+def extract_context_opens(
+    problem: ProblemSpec,
+    extracted: ExtractedTheorem | None = None,
+    *,
+    include_namespaces: bool = False,
+) -> str:
     source_path = module_source_path(problem.module)
     if not source_path.is_file():
         raise GenerationError(f"Source file for module '{problem.module}' not found: {source_path}")
     lines = source_path.read_text(encoding="utf-8").splitlines()
-    context_lines: list[str] = []
+    target_line = extracted.source_range[0] if extracted is not None else None
     namespace_stack: list[str] = []
+    # `open` directives encountered, partitioned per namespace nesting level.
+    # Index 0 is top-level; each `namespace` push adds a new layer that is
+    # popped (and its scoped opens discarded) when the matching `end` runs.
+    open_layers: list[list[str]] = [[]]
     in_body = False
-    for line in lines:
+    for index, line in enumerate(lines, start=1):
+        if target_line is not None and index >= target_line:
+            break
         stripped = line.strip()
         if not in_body:
             if stripped.startswith("import ") or stripped == "":
                 continue
             in_body = True
-        if stripped.startswith("@[") or re.match(
-            r"^(theorem|lemma|def|abbrev|opaque|axiom|instance|class|structure)\b",
-            stripped,
+        if target_line is None and (
+            stripped.startswith("@[")
+            or re.match(
+                r"^(theorem|lemma|def|abbrev|opaque|axiom|instance|class|structure)\b",
+                stripped,
+            )
         ):
             break
         if stripped.startswith("namespace "):
             namespace_stack.append(stripped.split(maxsplit=1)[1].strip())
+            open_layers.append([])
         elif re.match(r"^end\b", stripped):
             if namespace_stack:
                 namespace_stack.pop()
+                open_layers.pop()
         elif stripped.startswith("open "):
-            context_lines.append(line)
+            open_layers[-1].append(line)
+    context_lines = [line for layer in open_layers for line in layer]
     if include_namespaces and namespace_stack:
         context_lines.insert(0, "open " + ".".join(namespace_stack))
     return "\n".join(context_lines) + ("\n\n" if context_lines else "")
@@ -836,6 +853,7 @@ def render_workspace(
     )
     context_open_block = extract_context_opens(
         problem,
+        extracted,
         include_namespaces=(challenge_deps is not None or bool(local_imports)),
     )
     if context_open_block and not context_open_block.endswith("\n\n"):

--- a/tests/test_generate_projects.py
+++ b/tests/test_generate_projects.py
@@ -143,6 +143,66 @@ submitter = "Kim"
         self.assertIn("- Test Problem: yes", files["README.md"])
         self.assertIn('rev = "example-rev"', files["lakefile.toml"])
 
+    def test_extract_context_opens_walks_to_eval_problem_line(self) -> None:
+        # When the @[eval_problem] declaration is preceded by other top-level
+        # definitions inside their own namespaces (or by `open` directives
+        # nested inside the theorem's namespace), the generator must still
+        # collect every `open` that's in scope at the theorem and emit an
+        # `open` for the theorem's containing namespace. The bug fixed here
+        # caused only `open Complex` (the namespace of the *first* declaration
+        # in the file) to leak into Challenge.lean / Submission.lean.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = "LeanEval.Topology.SurfacesFixture"
+            src_dir = pathlib.Path(tmpdir) / "LeanEval" / "Topology"
+            src_dir.mkdir(parents=True)
+            (src_dir / "SurfacesFixture.lean").write_text(
+                "import Mathlib\n"
+                "\n"
+                "namespace Complex\n"
+                "\n"
+                "abbrev Aux : Nat := 0\n"
+                "\n"
+                "end Complex\n"
+                "\n"
+                "namespace LeanEval.Topology.SurfacesFixture\n"
+                "\n"
+                "open Complex Set\n"
+                "\n"
+                "inductive R : Prop\n"
+                "  | a\n"
+                "\n"
+                "open scoped Manifold\n"
+                "\n"
+                "@[eval_problem]\n"
+                "theorem foo : True := by trivial\n"
+                "\n"
+                "end LeanEval.Topology.SurfacesFixture\n",
+                encoding="utf-8",
+            )
+            problem = _spec(id="x", title="x", module=module, holes=("foo",))
+            extracted = gp.ExtractedTheorem(
+                declaration_name=f"{module}.foo",
+                module=module,
+                # `@[eval_problem]` sits on line 18 of the fixture above.
+                source_range=(18, 0, 19, 25),
+                same_module_dependencies=(f"{module}.R",),
+                kind="theorem",
+            )
+            saved_root = gp.REPO_ROOT
+            gp.REPO_ROOT = pathlib.Path(tmpdir)
+            try:
+                block = gp.extract_context_opens(
+                    problem, extracted, include_namespaces=True
+                )
+            finally:
+                gp.REPO_ROOT = saved_root
+        self.assertEqual(
+            block,
+            "open LeanEval.Topology.SurfacesFixture\n"
+            "open Complex Set\n"
+            "open scoped Manifold\n\n",
+        )
+
     def test_check_workspace_detects_stale_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             problem_dir = pathlib.Path(tmpdir) / "two_plus_two"


### PR DESCRIPTION
This PR fixes a bug in `scripts/generate_projects.py` where `extract_context_opens` stops at the first declaration in the source module rather than at the `@[eval_problem]` declaration. When a problem file contains helper definitions earlier in the file (e.g. inside an earlier `namespace` block), the generator emits only the *first* declaration's namespace as the `open` for `Challenge.lean` / `Submission.lean`, and drops every `open` directive nested inside the theorem's own namespace. The generated workspace then fails to resolve names defined in `ChallengeDeps`.

This was first hit by https://github.com/leanprover/lean-eval/pull/76, where `LeanEval.Topology.ClassificationOfSurfaces` defines `Complex.ClosedUnitDisc` ahead of `inductive OrientableRel` in the theorem's namespace, and CI failed with `Unknown identifier OrientableRel` even though the inductive was correctly inlined into `ChallengeDeps.lean`.

The fix walks to the line of the `@[eval_problem]` declaration (which we already know from `ExtractedTheorem.source_range`) and tracks namespace nesting with a per-level layer of `open` directives, so opens scoped to a closed namespace get dropped. For problem files where the eval_problem theorem is the first declaration (every existing problem), the function produces byte-identical output.

A regression test on a fixture mirroring the surfaces-PR layout is included.

🤖 Prepared with Claude Code