### PR TITLE
ci: add orphan-submission reconciler

### DIFF
--- a/.github/workflows/submission-reconciler.yml
+++ b/.github/workflows/submission-reconciler.yml
@@ -1,0 +1,43 @@
+# Safety net for the Submission workflow: if an issue is labeled
+# `submission` but no bot comment has appeared within 2 hours, post a
+# generic orphan-notice and close. Catches cases the in-workflow
+# handlers cannot:
+#   - workflow administratively disabled (run conclusion = skipped)
+#   - workflow file has a syntax error / never dispatches
+#   - runner died before the `if: failure()` step ran in `fetch`
+#   - the `notify` job itself failed
+#
+# 2h threshold > evaluate's 90 min timeout, so legitimate long runs are
+# not closed prematurely.
+name: Submission reconciler
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  actions: read
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # actions/checkout pinned to 11bd7190 (= refs/tags/v4.2.2 as of 2026-05-04).
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      # actions/setup-python pinned to a26af69b (= refs/tags/v5.6.0 as of 2026-05-04).
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.11.10'
+
+      - name: Reconcile orphaned submission issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: python scripts/reconcile_orphan_submissions.py

--- a/scripts/reconcile_orphan_submissions.py
+++ b/scripts/reconcile_orphan_submissions.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Close `submission`-labeled issues that the Submission workflow never
+responded to. See .github/workflows/submission-reconciler.yml."""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+
+ORPHAN_THRESHOLD = dt.timedelta(hours=2)
+BOT_AUTHORS = {"github-actions[bot]", "lean-eval-bot[bot]"}
+SUBMISSION_WORKFLOW = "submission.yml"
+
+
+def gh(args: list[str]) -> str:
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def gh_json(args: list[str]):
+    return json.loads(gh(args))
+
+
+def parse_iso(value: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def find_run_for_issue(repo: str, issue_title: str) -> str | None:
+    """Best-effort fuzzy match: latest submission-workflow run on `issues`
+    event whose display_title equals the issue title."""
+    runs = gh_json(
+        [
+            "api",
+            f"repos/{repo}/actions/workflows/{SUBMISSION_WORKFLOW}/runs",
+            "--jq",
+            "[.workflow_runs[] | select(.event == \"issues\") "
+            "| {id, display_title, html_url}]",
+            "-X",
+            "GET",
+            "-F",
+            "per_page=50",
+        ]
+    )
+    for run in runs:
+        if run["display_title"] == issue_title:
+            return run["html_url"]
+    return None
+
+
+def main() -> int:
+    repo = os.environ["REPO"]
+    server_url = os.environ["SERVER_URL"]
+    now = dt.datetime.now(dt.timezone.utc)
+
+    issues = gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            "submission",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,createdAt,comments",
+        ]
+    )
+
+    for issue in issues:
+        number = issue["number"]
+        created = parse_iso(issue["createdAt"])
+        if now - created < ORPHAN_THRESHOLD:
+            continue
+        has_bot_comment = any(
+            c["author"]["login"] in BOT_AUTHORS for c in issue["comments"]
+        )
+        if has_bot_comment:
+            continue
+
+        run_url = find_run_for_issue(repo, issue["title"])
+        if run_url:
+            run_line = f"Most recent workflow run: {run_url}."
+        else:
+            run_line = (
+                f"No matching workflow run was found in the recent history "
+                f"({server_url}/{repo}/actions/workflows/{SUBMISSION_WORKFLOW})."
+            )
+
+        body = (
+            "⚠️ The submission pipeline did not post a result for this "
+            f"issue within {int(ORPHAN_THRESHOLD.total_seconds() // 3600)}h. "
+            f"{run_line} Closing as orphaned — please re-submit if you'd "
+            "like to try again."
+        )
+        print(f"reconciling #{number}: {issue['title']!r}", file=sys.stderr)
+        gh(["issue", "comment", str(number), "--repo", repo, "--body", body])
+        gh(
+            [
+                "issue",
+                "close",
+                str(number),
+                "--repo",
+                repo,
+                "--reason",
+                "not planned",
+            ]
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds a scheduled safety net for the Submission workflow. An hourly job (\`submission-reconciler.yml\`) lists open \`submission\`-labeled issues, and for any older than 2h with no comment from a bot account, posts a generic orphan-notice and closes as \"not planned\". 2h is comfortably above evaluate's 90 min timeout, so legitimate long-running submissions are not closed prematurely.

The motivating gap: every comment-and-close path in \`submission.yml\` (the per-job handlers, the \`notify\` fallback added in #84) lives inside the same workflow run that's failing. When the workflow is administratively disabled, the file has a syntax error, the runner dies before the \`if: failure()\` step ran, or the \`notify\` job itself fails, no comment is posted and the issue stays open silently. We hit this on May 2: 6 issues (#86, #87, #88, #97, #98, #100) sat open for two days — three because they predated the \`notify\` fallback, three because they ran during the brief sandbox-audit disable window. Those have been hand-closed; this PR prevents future orphans.

Run-link discovery is fuzzy (matches by \`display_title == issue.title\` against recent submission-workflow runs); when no match is found the comment links to the workflow page instead.

🤖 Prepared with Claude Code