### PR TITLE
fix(ODE): require IsPreconnected J in sturm_separation

### DIFF
--- a/LeanEval/Analysis/ODE/SturmSeparation.lean
+++ b/LeanEval/Analysis/ODE/SturmSeparation.lean
@@ -31,7 +31,8 @@ with `p, q` continuous on `J`, and their Wronskian is nonzero at some point of `
 @[eval_problem]
 theorem sturm_separation
     (p q y₁ y₂ : ℝ → ℝ) (a b : ℝ) (hab : a < b)
-    (J : Set ℝ) (hJ_open : IsOpen J) (hJ_sub : Set.Icc a b ⊆ J)
+    (J : Set ℝ) (hJ_open : IsOpen J) (hJ_conn : IsPreconnected J)
+    (hJ_sub : Set.Icc a b ⊆ J)
     (hp : ContinuousOn p J) (hq : ContinuousOn q J)
     (hy₁ : ∀ x ∈ J, HasDerivAt y₁ (deriv y₁ x) x)
     (hy₁' : ∀ x ∈ J, HasDerivAt (deriv y₁) (-(p x * deriv y₁ x + q x * y₁ x)) x)


### PR DESCRIPTION
This PR adds an `IsPreconnected J` hypothesis to the `sturm_separation` benchmark problem. The original statement asked only that `J` be open and contain `[a,b]`, but the Sturm separation argument needs `J` connected — otherwise zeros of `y₁` could live in a component disjoint from the one containing `[a,b]`, and the "between two consecutive zeros of `y₁` lies a zero of `y₂`" reasoning breaks.

Found by Claude while attempting the proof, which noticed the gap. After merge, `lean-eval-regenerator` will refresh `generated/sturm_separation/` to match the new signature.

🤖 Prepared with Claude Code