### PR TITLE
fix(NumberTheory): correct first disjunct in CMS house theorem

### DIFF
--- a/LeanEval/NumberTheory/SmallHouse.lean
+++ b/LeanEval/NumberTheory/SmallHouse.lean
@@ -32,7 +32,7 @@ theorem cyclotomic_integer_house_between_two_and_76_33
     (hβ_int : IsIntegral ℤ β)
     (hβ_real : β ∈ NumberField.maximalRealSubfield K) :
     (2 < house β ∧ house β < (76 : ℝ) / 33) →
-      house β = (7 + Real.sqrt 3) / 2 ∨
+      house β = (Real.sqrt 7 + Real.sqrt 3) / 2 ∨
       house β = Real.sqrt 5 ∨
       house β = 1 + 2 * Real.cos (2 * Real.pi / 7) ∨
       house β = (1 + Real.sqrt 5) / Real.sqrt 2 ∨


### PR DESCRIPTION
The first value in Theorem 1.0.5 of Calegari--Morrison--Snyder (arXiv:1004.0665) is `(√7 + √3)/2 ≈ 2.18890`, not `(7 + √3)/2 ≈ 4.366`. The latter is well above the upper bound `76/33 ≈ 2.303` of the hypothesis, so under the typo the disjunct is unreachable and the theorem is strictly weaker than CMS.