### PR TITLE
Fix Perron-Frobenius index nonemptiness

### DIFF
--- a/LeanEval/LinearAlgebra/PerronFrobenius.lean
+++ b/LeanEval/LinearAlgebra/PerronFrobenius.lean
@@ -13,11 +13,14 @@ A Perron-Frobenius style statement for irreducible nonnegative real matrices.
 
 Mathlib already exposes irreducibility of nonnegative matrices via `Matrix.IsIrreducible`, and
 spectral radius via `spectralRadius`.
+
+The `[Nonempty n]` assumption is necessary: for `n = Empty`, `Matrix.IsIrreducible` is vacuous,
+but `Module.End.HasEigenvector` still requires a nonzero vector.
 -/
 
 @[eval_problem]
 theorem irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius
-    {n : Type*} [Fintype n] [DecidableEq n]
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
     (A : Matrix n n ℝ)
     (hA : A.IsIrreducible) :
     ∃ v : n → ℝ,


### PR DESCRIPTION
Fixes a statement issue in the Perron-Frobenius benchmark.

As currently stated, the theorem is false for `n = Empty`. In that case, `(0 : Matrix Empty Empty ℝ).IsIrreducible` is provable because the nonnegativity and strong-connectivity fields are vacuous. But the conclusion asks for a `Module.End.HasEigenvector`, and `HasEigenvector` requires the vector to be nonzero; no function `Empty → ℝ` can be nonzero.

This PR adds `[Nonempty n]`, matching the intended finite nonempty matrix statement.

Verified with:

```sh
lake build LeanEval.LinearAlgebra.PerronFrobenius
```