### PR TITLE
fix: require MeromorphicNFOn in rouche_zero_count_eq

### DIFF
--- a/LeanEval/ComplexAnalysis/Rouche.lean
+++ b/LeanEval/ComplexAnalysis/Rouche.lean
@@ -20,13 +20,21 @@ inside the disk, but the log-weighted count depends on where each zero sits. Con
 
 We instead state the conclusion as the equality of the multiplicity sums of the zero
 divisors of `f` and `f + g` taken on the closed disk of radius `R`.
+
+We also require `f` to be in *normal form* (`MeromorphicNFOn`) rather than merely
+`MeromorphicOn`. A bare `MeromorphicOn` hypothesis admits functions whose pointwise values
+disagree with their meromorphic order at exceptional points (any `=ᶠ[codiscreteWithin]`
+modification is still meromorphic), and that pointwise disagreement is enough to make the
+divisor identity fail. See the Zulip discussion at
+https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/near/593331158
+for a concrete counterexample to the previous `MeromorphicOn`-only formulation.
 -/
 
 @[eval_problem]
 theorem rouche_zero_count_eq
     {f g : ℂ → ℂ} {R : ℝ}
     (hR : 0 < R)
-    (hf : MeromorphicOn f Set.univ)
+    (hf : MeromorphicNFOn f Set.univ)
     (hg : AnalyticOn ℂ g Set.univ)
     (hbound : ∀ z : ℂ, ‖z‖ = R → ‖g z‖ < ‖f z‖) :
     (∑ᶠ z, ((divisor (f + g) (Metric.closedBall 0 R))⁺) z) =

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -163,7 +163,7 @@ holes = ["rouche_zero_count_eq"]
 submitter = "Kim Morrison"
 notes = "Phrases Rouché's theorem as equality of multiplicity-counted zero counts for f and f + g on the closed disk of radius R."
 source = "Classical theorem in complex analysis."
-informal_solution = "If |g| < |f| on the boundary circle, then f and f + g have the same number of zeros inside, counted with multiplicity."
+informal_solution = "Assuming f is meromorphic in normal form on ℂ and |g| < |f| on the boundary circle, f and f + g have the same number of zeros inside the disk, counted with multiplicity."
 
 [[problem]]
 id = "mem_convexHull_finset_extremePoints_of_mem_compact_convex"


### PR DESCRIPTION
This PR strengthens the meromorphicity hypothesis on `f` in `rouche_zero_count_eq` from `MeromorphicOn f Set.univ` to `MeromorphicNFOn f Set.univ`, so the statement is no longer disprovable.

A bare `MeromorphicOn` hypothesis admits functions whose pointwise values disagree with their meromorphic order at exceptional points (any `=ᶠ[codiscreteWithin]` modification of a meromorphic function is still meromorphic), and that pointwise disagreement is enough to make the divisor identity fail. `MeromorphicNFOn` rules this out by forcing each point to either be locally zero or look like `(· - x)^n • g` with `g` analytic and nonzero at `x`.

Counterexample to the previous formulation reported by Mikhail Mayorov: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/near/593331158 — credit to him for finding it and to Junyan Xu for identifying the `MeromorphicNFOn` fix.

The `informal_solution` in `manifests/problems.toml` is updated to mention the normal-form requirement. The `generated/rouche_zero_count_eq/` workspace will be regenerated by the `regenerate-main` CI job after merge.

🤖 Prepared with Claude Code