### PR TITLE
chore: enable issues with a problem-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
+  - name: Discussion on Zulip
+    url: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/with/594108910
+    about: General questions and discussion about lean-eval happen in the #Model-comparisons-for-Lean > LeanEval topic on the Lean Zulip.
   - name: Benchmark source code and documentation
     url: https://github.com/leanprover/lean-eval
     about: Read the README for submission requirements before opening a submission issue.

--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -1,0 +1,47 @@
+name: Report a problem with a benchmark problem
+description: Flag an issue with a lean-eval benchmark problem (wrong statement, broken source link, unprovable, etc.).
+title: "[problem] "
+labels:
+  - problem-report
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to report a problem with one of the benchmark problems
+        themselves — for example: the formal statement does not match the
+        informal description, the source link is wrong or dead, the problem
+        is unprovable as stated, imports are missing, or the intended
+        interpretation is ambiguous.
+
+        For submitting a solution, use the "Submit benchmark solution"
+        template instead.
+
+  - type: input
+    id: problem_id
+    attributes:
+      label: Problem id
+      description: The benchmark problem id (the `name` field in its `lakefile.toml`).
+      placeholder: e.g. chudnovsky
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What is wrong
+      description: |
+        Describe the issue. If the formal statement disagrees with the
+        informal description or the cited source, please quote the relevant
+        parts. If you have a counterexample or a minimized reproducer,
+        include it here.
+    validations:
+      required: true
+
+  - type: input
+    id: source_link
+    attributes:
+      label: Relevant link (optional)
+      description: Permalink to the offending file/line in `generated/`, or to the source the problem cites.
+      placeholder: https://github.com/leanprover/lean-eval/blob/main/generated/...
+    validations:
+      required: false


### PR DESCRIPTION
This PR re-enables GitHub issues on the repo and adds a structured template for reporting problems with benchmark problems (wrong statement, broken source link, unprovable as written, etc.). Triggered by Mikhail Mayorov, who tried to file an issue about `rouche_zero_count_eq` on Zulip and couldn't because `blank_issues_enabled` was off and no template covered "this problem is broken."

Also adds a contact link from the issue picker to the #Model-comparisons-for-Lean > LeanEval Zulip topic, matching where discussion already happens.

🤖 Prepared with Claude Code