### PR TITLE
fix: portable command-existence check (works on Windows)

### DIFF
--- a/EvalTools/Main.lean
+++ b/EvalTools/Main.lean
@@ -26,11 +26,18 @@ def requireRepoRoot : IO System.FilePath := do
         "Could not find the repository root. Run `lake exe lean-eval ...` from this repo or a subdirectory of it."
   pure root
 
+/-- Try to spawn `cmd --version`, return whether the OS could resolve `cmd` and
+    the process exited successfully. Portable across Linux/macOS/Windows: the
+    OS's executable resolution is what we want to test (no `sh -c command -v`
+    indirection, which fails on Windows where `sh` isn't on PATH). -/
 def commandExists (cmd : String) : IO Bool := do
   try
     let child ← IO.Process.spawn {
-      cmd := "sh"
-      args := #["-c", "command -v \"$1\" >/dev/null 2>&1", "sh", cmd]
+      cmd := cmd
+      args := #["--version"]
+      stdin := .null
+      stdout := .null
+      stderr := .null
     }
     return (← child.wait) == 0
   catch _ =>

--- a/scripts/generate_projects.py
+++ b/scripts/generate_projects.py
@@ -41,39 +41,21 @@ IGNORED_PATH_NAMES = {".lake", "build", ".cache", "lake-manifest.json"}
 _WORKSPACE_TEST_LEAN = (
     "import Lean\n\n"
     "open Lean\n\n"
-    "def comparatorExists (comparatorBin : String) : IO Bool := do\n"
-    "  if comparatorBin.contains '/' then\n"
-    "    return (← System.FilePath.pathExists comparatorBin)\n"
-    "  try\n"
-    "    let child ← IO.Process.spawn {\n"
-    '      cmd := "sh"\n'
-    '      args := #["-c", "command -v \\\"$1\\\" >/dev/null 2>&1", "sh", comparatorBin]\n'
-    "    }\n"
-    "    let exitCode ← child.wait\n"
-    "    return exitCode == 0\n"
-    "  catch _ =>\n"
-    "    return false\n\n"
     "def main : IO UInt32 := do\n"
     '  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"\n'
-    "  if !(← comparatorExists comparatorBin) then\n"
+    "  try\n"
+    "    let child ← IO.Process.spawn {\n"
+    '      cmd := "lake"\n'
+    '      args := #["env", comparatorBin, "config.json"]\n'
+    "    }\n"
+    "    let exitCode ← child.wait\n"
+    "    pure exitCode\n"
+    "  catch err =>\n"
     '    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."\n'
     '    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."\n'
     '    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."\n'
+    '    IO.eprintln s!"Original error: {err}"\n'
     "    pure 1\n"
-    "  else\n"
-    "    try\n"
-    "      let child ← IO.Process.spawn {\n"
-    '        cmd := "lake"\n'
-    '        args := #["env", comparatorBin, "config.json"]\n'
-    "      }\n"
-    "      let exitCode ← child.wait\n"
-    "      pure exitCode\n"
-    "    catch err =>\n"
-    '      IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."\n'
-    '      IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."\n'
-    '      IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."\n'
-    '      IO.eprintln s!"Original error: {err}"\n'
-    "      pure 1\n"
 )
 
 


### PR DESCRIPTION
The previous `commandExists` shelled out to `sh -c "command -v …"`, which doesn't exist on Windows. The spawn raised, the catch returned `false`, and `pythonCommand` reported "could not find python3 or python" even when `python` was on PATH. Reported by Junyan Xu on Zulip: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval

Replace with `IO.Process.spawn { cmd, args := #["--version"] }` plus a try/catch — the OS does the executable resolution we actually care about, with no shell dependency.

The same broken `sh -c` pattern was embedded in the per-problem `WorkspaceTest.lean` template generated by `scripts/generate_projects.py`. That code only protected an upfront "is `comparator` on PATH?" check before invoking `lake env comparatorBin config.json`; drop the existence check entirely and rely on the lake env spawn's own failure — the existing catch already prints the helpful "make sure comparator is installed" message. Generated workspaces will be regenerated by CI.

Verified locally on macOS: `lake exe lean-eval validate-manifest` runs end-to-end.

🤖 Prepared with Claude Code