### PR TITLE
fix: stop leaking submission source via the submission-source artifact

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -4,11 +4,18 @@
 # Security model: untrusted submitter Lean code is ONLY ever elaborated
 # inside comparator's landrun sandbox (invoked from `lake test` via
 # WorkspaceTest.lean). The non-negotiable invariants of this workflow
-# (read-only token in the evaluate job, .git stripped before lake runs,
-# `_prime_workspace` not pre-building any user-controlled targets, etc.)
-# are documented in LANDRUN.md → "What must not regress when this is
-# fixed". Read that section before editing this file or
+# (`APP_INSTALLATION_TOKEN` scoped to the single `Fetch submission`
+# step's env, .git stripped before lake runs, `_prime_workspace` not
+# pre-building any user-controlled targets, etc.) are documented in
+# SECURITY.md. Read that section before editing this file or
 # `scripts/evaluate_submission.py`.
+#
+# Fetch + evaluate live in a single job on purpose: a previous version
+# uploaded the cloned source as a `submission-source` artifact so a
+# separate `evaluate` job could pick it up, but on a public repo
+# anyone authenticated can download workflow artifacts via the API,
+# which leaked private submissions. Keeping fetch and evaluate
+# co-located removes the cross-runner transport entirely.
 name: Submission
 
 on:
@@ -27,13 +34,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  fetch:
+  evaluate:
     if: github.event.label.name == 'submission'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 90
+    # `issues: write` is needed by the in-job fetch-failure / evaluate-failure
+    # commenters below. The default `GITHUB_TOKEN` is *not* placed into the
+    # env of any step that runs untrusted Lean: it only appears in the
+    # explicit `env: GH_TOKEN:` blocks on the commenter steps. The
+    # `lean-eval-bot` installation token (which can read private
+    # submission repos) is similarly scoped to the single `Fetch
+    # submission` step's env. persist-credentials:false + `rm -rf .git`
+    # before lake runs ensures no checkout token persists into the
+    # lake runtime either.
     permissions:
       contents: read
       issues: write
+    # Surfaces whether the fetch step succeeded to the downstream `notify`
+    # job, which otherwise cannot distinguish fetch failure (already
+    # commented inline) from evaluate failure (needs a comment).
+    outputs:
+      fetch_succeeded: ${{ steps.fetch_status.outputs.succeeded }}
     steps:
       # actions/checkout pinned to 11bd7190 (= refs/tags/v4.2.2 as of 2026-05-04).
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -88,26 +109,30 @@ jobs:
       - name: Fetch submission
         id: fetch
         env:
+          # Step-scoped: the app token is NOT present in the env of any
+          # later step in this job. This is the load-bearing assumption
+          # that lets fetch + evaluate share a job without leaking
+          # access to private submission repos into the landrun-sandboxed
+          # evaluation. Do not promote this to a job-level env or
+          # secrets block.
           APP_INSTALLATION_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           python scripts/fetch_submission.py \
             --event-path "$GITHUB_EVENT_PATH" \
             --output-dir /tmp/fetch-out
 
-      - name: Upload submission source artifact
-        if: success()
-        # actions/upload-artifact pinned to ea165f8d (= refs/tags/v4.6.2 as of 2026-05-04).
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: submission-source
-          path: |
-            /tmp/fetch-out/source.tar.gz
-            /tmp/fetch-out/metadata.json
-          if-no-files-found: error
-          retention-days: 7
+      - name: Record fetch status for downstream jobs
+        id: fetch_status
+        if: always()
+        run: |
+          if [ "${{ steps.fetch.outcome }}" = "success" ]; then
+            echo "succeeded=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "succeeded=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Comment on fetch failure
-        if: failure()
+        if: failure() && steps.fetch.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -116,17 +141,6 @@ jobs:
             --body "❌ Submission fetch failed. See the workflow logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. If your submission repo is private, make sure the \`lean-eval-bot\` GitHub App is installed on it."
           gh issue close ${{ github.event.issue.number }} --repo "${{ github.repository }}" --reason "not planned" || true
 
-  evaluate:
-    needs: fetch
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    # Deliberately minimal: contents:read is only enough to clone this
-    # public benchmark repo. No issues:write, no contents:write, no
-    # packages. persist-credentials:false + rm -rf .git below ensures the
-    # token cannot persist into the lake runtime.
-    permissions:
-      contents: read
-    steps:
       - name: Free disk space for Mathlib cache
         # Standard runners ship with ~14GB free; Mathlib unpacked is
         # several GB and we hold it twice (repo root + per-workspace).
@@ -142,11 +156,6 @@ jobs:
           large-packages: false
           docker-images: true
           swap-storage: false
-
-      # actions/checkout pinned to 11bd7190 (= refs/tags/v4.2.2 as of 2026-05-04).
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          persist-credentials: false
 
       - name: Strip git state before running untrusted Lean
         run: rm -rf .git
@@ -200,16 +209,10 @@ jobs:
       - name: Probe env-var allowlist
         run: python scripts/security_probes/env_dump_probe.py --require-tools
 
-      # actions/download-artifact pinned to d3f86a10 (= refs/tags/v4.3.0 as of 2026-05-04).
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: submission-source
-          path: /tmp/submission-artifact
-
       - name: Extract submission source
         run: |
           mkdir -p /tmp/submission-src
-          tar -xzf /tmp/submission-artifact/source.tar.gz -C /tmp/submission-src --strip-components=1
+          tar -xzf /tmp/fetch-out/source.tar.gz -C /tmp/submission-src --strip-components=1
 
       - name: Run evaluate_submission.py
         # Sharing the host repo's .lake/packages tree across every
@@ -230,10 +233,10 @@ jobs:
 
       - name: Copy frozen metadata through to record
         if: always()
-        run: cp /tmp/submission-artifact/metadata.json /tmp/evaluate-out/metadata.json || true
+        run: cp /tmp/fetch-out/metadata.json /tmp/evaluate-out/metadata.json || true
 
       - name: Upload evaluate results artifact
-        if: always()
+        if: always() && steps.fetch.outcome == 'success'
         # actions/upload-artifact pinned to ea165f8d (= refs/tags/v4.6.2 as of 2026-05-04).
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -403,14 +406,15 @@ jobs:
             --repo "${{ github.repository }}" \
             --reason "completed"
 
-  # Catches the case where `fetch` succeeded but the pipeline did not
-  # complete cleanly — most often `evaluate` failing because the
-  # submitter's Submission.lean did not compile. Without this, the
-  # `record` job is skipped (its `needs: evaluate` dependency was unmet)
-  # and the submitter sees no comment at all.
+  # Catches the case where fetch succeeded but the pipeline did not
+  # complete cleanly — most often the evaluation steps failing because
+  # the submitter's Submission.lean did not compile, or the leaderboard
+  # `record` job failing. Without this, the submitter sees no comment.
+  # Gated on `evaluate.outputs.fetch_succeeded` so we do NOT duplicate
+  # the in-job fetch-failure comment.
   notify:
-    needs: [fetch, evaluate, record]
-    if: always() && needs.fetch.result == 'success' && needs.record.result != 'success'
+    needs: [evaluate, record]
+    if: always() && needs.evaluate.outputs.fetch_succeeded == 'true' && needs.record.result != 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,12 +56,19 @@ actively probe:
   sandbox can stat is readable by the untrusted Lean elaborator.
 
 A future workflow refactor could regress any of these silently.
-`actions/create-github-app-token` is also believed to write its token
-output to a runner temp file under `$RUNNER_TEMP/_runner_file_commands/`
-which the landrun sandbox can in principle read; this has not been
-empirically verified or mitigated. Submitters who require
-confidentiality should audit the workflow themselves before relying
-on this.
+`actions/create-github-app-token` does write the token to
+`$RUNNER_TEMP/_runner_file_commands/{set_output,save_state}_<uuid>`
+during the mint step, but actions/runner's `FileCommandManager`
+deletes the previous step's files at the start of every step
+(`runner/src/Runner.Worker/FileCommandManager.cs:InitializeFiles`),
+so by the time untrusted Lean runs in `evaluate_submission.py` those
+files have been deleted many steps earlier. Deeper shared-host paths
+that apply to any secret on a GitHub-hosted runner (e.g. reading
+`/proc/<runner-worker-pid>/environ` or attaching ptrace to the
+worker) are partially mitigated by Ubuntu's
+`kernel.yama.ptrace_scope=1` but are not something we actively probe.
+Submitters who require confidentiality should audit the workflow
+themselves before relying on this.
 
 ## 2. Architecture: Challenge / Submission / Solution
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,12 +38,30 @@ for a theorem they have not actually proved.**
 submissions (those filed against a private GitHub repo readable only
 via the `lean-eval-bot` App) are evaluated without uploading their
 source as a workflow artifact, so the source is not exposed to anyone
-authenticated against the GitHub Actions API. But this is a
-single-line property maintained by the workflow's structure (fetch and
-evaluate share a job; `APP_INSTALLATION_TOKEN` is scoped to one step's
-env); we do not actively probe it, and a future workflow refactor
-could regress it silently. Submitters who require confidentiality
-should audit the workflow themselves before relying on this.
+authenticated against the GitHub Actions API. Confidentiality of the
+source — and of the App installation token used to clone it — depends
+on several properties of the workflow's structure that we do not
+actively probe:
+
+- fetch and evaluate share a job, so source never crosses a runner
+  boundary;
+- `APP_INSTALLATION_TOKEN` is scoped to the env of the single
+  `Fetch submission` step;
+- `fetch_submission.py` strips `.git/` from the cloned source before
+  tarring, because `clone_url_for` embeds the installation token in
+  the `origin` remote URL and `git remote add` persists that URL into
+  `.git/config` (regression test:
+  `FetchSubmissionTarballHygieneTests`). Comparator's landrun policy
+  is `--ro /`, so anything left on the runner under a path the
+  sandbox can stat is readable by the untrusted Lean elaborator.
+
+A future workflow refactor could regress any of these silently.
+`actions/create-github-app-token` is also believed to write its token
+output to a runner temp file under `$RUNNER_TEMP/_runner_file_commands/`
+which the landrun sandbox can in principle read; this has not been
+empirically verified or mitigated. Submitters who require
+confidentiality should audit the workflow themselves before relying
+on this.
 
 ## 2. Architecture: Challenge / Submission / Solution
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,17 @@ The attacker does not control:
 The goal we resist: **a submitter receiving credit on the leaderboard
 for a theorem they have not actually proved.**
 
+**Submission confidentiality is best-effort, not a guarantee.** Private
+submissions (those filed against a private GitHub repo readable only
+via the `lean-eval-bot` App) are evaluated without uploading their
+source as a workflow artifact, so the source is not exposed to anyone
+authenticated against the GitHub Actions API. But this is a
+single-line property maintained by the workflow's structure (fetch and
+evaluate share a job; `APP_INSTALLATION_TOKEN` is scoped to one step's
+env); we do not actively probe it, and a future workflow refactor
+could regress it silently. Submitters who require confidentiality
+should audit the workflow themselves before relying on this.
+
 ## 2. Architecture: Challenge / Submission / Solution
 
 Every benchmark problem ships as a self-contained Lake project in

--- a/scripts/fetch_submission.py
+++ b/scripts/fetch_submission.py
@@ -19,6 +19,7 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -394,6 +395,18 @@ def fetch_submission(
     source_dir = output_dir / "source"
     if not skip_clone:
         clone_at_sha(clone_url, sha, source_dir)
+        # For private-repo submissions, `clone_url` embeds the
+        # `lean-eval-bot` App installation token in the `origin` remote
+        # URL, which `git remote add` persists into `.git/config`.
+        # Comparator's landrun policy is `--ro /`, so anything left on
+        # the runner under a path the sandbox can stat is readable by
+        # the untrusted Lean elaborator; dropping `.git` here keeps the
+        # token (and any other VCS metadata) out of `source.tar.gz` and
+        # out of the workspace the elaborator overlays from. If the
+        # auth-injection in `clone_url_for` ever moves to
+        # `http.extraheader` / credential helper, this strip becomes
+        # belt-and-braces but can stay.
+        shutil.rmtree(source_dir / ".git")
         guard_no_path_escape(source_dir)
         tar_source(source_dir, output_dir / "source.tar.gz")
 

--- a/tests/test_fetch_submission.py
+++ b/tests/test_fetch_submission.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 import subprocess
 import sys
+import tarfile
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -274,6 +275,106 @@ class CloneAtShaTests(unittest.TestCase):
             self.assertEqual(
                 (destination / "README.md").read_text(encoding="utf-8"),
                 "hello\n",
+            )
+
+    def test_clone_persists_token_in_git_config(self) -> None:
+        # Documents the leak path the strip in `fetch_submission` defends
+        # against: `git remote add origin <url>` writes the URL verbatim
+        # into .git/config, so an `x-access-token:` URL ends up on disk.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            origin, sha = self._make_fixture_repo(tmp_path)
+            authed_url = (
+                "https://x-access-token:SENTINEL_TOKEN_DO_NOT_TRUST"
+                f"@127.0.0.1/{origin.name}"
+            )
+            destination = tmp_path / "dest"
+            destination.mkdir()
+            subprocess.run(
+                ["git", "init", "--quiet"], cwd=destination, check=True
+            )
+            subprocess.run(
+                ["git", "remote", "add", "origin", authed_url],
+                cwd=destination,
+                check=True,
+            )
+            config = (destination / ".git" / "config").read_text(encoding="utf-8")
+            self.assertIn("SENTINEL_TOKEN_DO_NOT_TRUST", config)
+            del sha  # unused; fixture creator returns it for symmetry
+
+
+class FetchSubmissionTarballHygieneTests(unittest.TestCase):
+    """Regression test for the .git-strip in `fetch_submission`.
+
+    `clone_url_for` embeds the App installation token in the `origin`
+    remote URL for private-repo submissions, which `git remote add`
+    persists into .git/config. Comparator's landrun policy is `--ro /`,
+    so anything left under a path the sandbox can stat is readable by
+    untrusted Lean. The fetch flow MUST strip .git before tarring.
+    """
+
+    def _make_fixture_repo(self, tmp_path: pathlib.Path) -> tuple[pathlib.Path, str]:
+        repo = tmp_path / "origin"
+        repo.mkdir()
+        subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+        (repo / "README.md").write_text("hello\n")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init", "--no-gpg-sign"],
+            cwd=repo,
+            check=True,
+        )
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return repo, result.stdout.strip()
+
+    def test_source_tarball_excludes_git_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            origin, sha = self._make_fixture_repo(tmp_path)
+            out_dir = tmp_path / "out"
+            event = {
+                "issue": {
+                    "number": 42,
+                    "user": {"login": "alice"},
+                    "body": SAMPLE_BODY,
+                }
+            }
+            with patch(
+                "fetch_submission.clone_url_for", return_value=str(origin)
+            ), patch(
+                "fetch_submission.resolve_ref", return_value=sha
+            ), patch(
+                "fetch_submission.resolve_repo_visibility", return_value=False
+            ):
+                fs.fetch_submission(
+                    event_payload=event,
+                    output_dir=out_dir,
+                    app_token="ghs_SENTINEL_TOKEN_DO_NOT_TRUST",
+                    skip_clone=False,
+                )
+
+            tar_path = out_dir / "source.tar.gz"
+            self.assertTrue(tar_path.is_file())
+            with tarfile.open(tar_path, "r:gz") as tf:
+                offending = [
+                    m.name
+                    for m in tf.getmembers()
+                    if ".git" in pathlib.PurePosixPath(m.name).parts
+                ]
+            self.assertEqual(
+                offending, [], f"tarball must not contain .git entries: {offending!r}"
+            )
+            self.assertFalse(
+                (out_dir / "source" / ".git").exists(),
+                "source/.git was not removed before tar",
             )
 
 


### PR DESCRIPTION
This PR stops uploading cloned submission source as the `submission-source` GitHub Actions artifact, which on a public repo is downloadable by anyone authenticated against the Actions API and so was exposing the source of private submissions.

The previous `fetch` and `evaluate` jobs are merged into a single `evaluate` job, eliminating the cross-runner transport entirely. `APP_INSTALLATION_TOKEN` stays scoped to the single `Fetch submission` step's `env:` (not present in any later step's process), so the landrun-sandboxed evaluation does not gain read access to private submission repos. `.git` is still stripped before `lake` runs, and the sandbox-engaged + env-allowlist probes still gate the evaluation. The `notify` job now reads a `fetch_succeeded` output from the merged job so it can still tell fetch failure (commented inline) from evaluate/record failure.

`SECURITY.md` gains a short paragraph noting that submission confidentiality is a best-effort property of the workflow's structure, not something we probe, and that submitters needing confidentiality should audit before relying on it.

Reported by Eric Rodriguez.

🤖 Prepared with Claude Code