### PR TITLE
feat: add Cauchy–Kovalevskaya theorem eval problem

### DIFF
--- a/LeanEval/Analysis/CauchyKovalevskaya.lean
+++ b/LeanEval/Analysis/CauchyKovalevskaya.lean
@@ -1,0 +1,62 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+# Cauchy–Kovalevskaya theorem
+
+§32 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. For
+analytic data `F`, `f`, `u₀`, the quasi-linear scalar Cauchy problem
+
+  `uₜ(x, t) = F(x, t, u(x,t)) · ∇ₓu(x, t) + f(x, t, u(x, t))`,
+  `u(x, 0) = u₀(x)`
+
+has a unique local analytic solution near every point of the initial
+hypersurface `t = 0`.
+
+The statement uses only off-the-shelf mathlib (`AnalyticOnNhd`, `fderiv`,
+`EuclideanSpace`); mathlib has no Cauchy–Kovalevskaya theorem. The PDE is
+encoded through the Fréchet derivative: `fderiv ℝ u p (0, 1)` is `∂u/∂t`
+and `fderiv ℝ u p (v, 0)` is the spatial directional derivative along `v`,
+so `fderiv ℝ u p (F-data, 0)` is `F · ∇ₓu`. Locality and uniqueness are
+folded into a single `∀ x₀, ∃ U …` statement.
+-/
+
+open Set
+
+/-- The model space `ℝᵈ`. -/
+abbrev E (d : ℕ) := EuclideanSpace ℝ (Fin d)
+
+/-- **Cauchy–Kovalevskaya theorem.** For analytic data `F`, `f`, `u₀`, the
+quasi-linear Cauchy problem
+
+  `uₜ(x, t) = F(x, t, u(x,t)) · ∇ₓu(x, t) + f(x, t, u(x, t))`,
+  `u(x, 0) = u₀(x)`
+
+has a unique local analytic solution: for every `x₀ ∈ ℝᵈ` there is an open
+neighborhood `U` of `(x₀, 0)` and an analytic function `u : E d × ℝ → ℝ`
+satisfying the PDE and the initial condition on `U`, and `u` is unique among
+analytic functions on `U` with the same initial data. -/
+@[eval_problem]
+theorem cauchy_kovalevskaya {d : ℕ}
+    (F : E d × ℝ × ℝ → E d) (f : E d × ℝ × ℝ → ℝ) (u₀ : E d → ℝ)
+    (_hF : AnalyticOnNhd ℝ F univ) (_hf : AnalyticOnNhd ℝ f univ)
+    (_hu₀ : AnalyticOnNhd ℝ u₀ univ) (x₀ : E d) :
+    ∃ (U : Set (E d × ℝ)) (u : E d × ℝ → ℝ),
+      (x₀, (0 : ℝ)) ∈ U ∧ IsOpen U ∧ AnalyticOnNhd ℝ u U ∧
+      (∀ x : E d, (x, (0 : ℝ)) ∈ U → u (x, 0) = u₀ x) ∧
+      (∀ p ∈ U,
+        fderiv ℝ u p ((0 : E d), (1 : ℝ)) =
+          fderiv ℝ u p (F (p.1, p.2, u p), (0 : ℝ)) + f (p.1, p.2, u p)) ∧
+      (∀ v : E d × ℝ → ℝ, AnalyticOnNhd ℝ v U →
+        (∀ x : E d, (x, (0 : ℝ)) ∈ U → v (x, 0) = u₀ x) →
+        (∀ p ∈ U,
+          fderiv ℝ v p ((0 : E d), (1 : ℝ)) =
+            fderiv ℝ v p (F (p.1, p.2, v p), (0 : ℝ)) + f (p.1, p.2, v p)) →
+        ∀ p ∈ U, u p = v p) := by
+  sorry
+
+end Analysis
+end LeanEval

--- a/manifests/problems/cauchy_kovalevskaya.toml
+++ b/manifests/problems/cauchy_kovalevskaya.toml
@@ -1,0 +1,9 @@
+id = "cauchy_kovalevskaya"
+title = "Cauchy–Kovalevskaya theorem"
+test = false
+module = "LeanEval.Analysis.CauchyKovalevskaya"
+holes = ["cauchy_kovalevskaya"]
+submitter = "Kim Morrison"
+notes = "§32 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. The quasi-linear scalar Cauchy problem with real-analytic data has a unique local analytic solution. Stated with off-the-shelf mathlib (AnalyticOnNhd, fderiv, EuclideanSpace); the PDE is encoded through the Fréchet derivative, with fderiv u p (0,1) the time derivative and fderiv u p (v,0) the spatial directional derivative. Mathlib has no Cauchy-Kovalevskaya theorem, and no formalization of it was found in any other proof assistant."
+source = "A.-L. Cauchy (1842) and S. Kovalevskaya (1875). Listed as §32 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Construct the solution as a formal power series in (x, t) whose coefficients are determined recursively by differentiating the PDE and using the initial data; prove convergence by the method of majorants — bound the analytic data F, f, u₀ by geometric majorants for which the majorant Cauchy problem has an explicitly convergent closed-form solution, so the formal series converges on a neighborhood and is analytic there. Uniqueness holds because the power-series coefficients of any analytic solution with the given initial data are forced by the equation."


### PR DESCRIPTION
This PR adds the **Cauchy–Kovalevskaya theorem** as a new lean-eval challenge problem — §32 of Oliver Knill's [*Some Fundamental Theorems in Mathematics*](https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf).

For real-analytic data `F`, `f`, `u₀`, the quasi-linear scalar Cauchy problem `uₜ = F·∇ₓu + f`, `u(·,0) = u₀` has a unique local analytic solution near every point of the initial hypersurface.

The statement uses only off-the-shelf mathlib (`AnalyticOnNhd`, `fderiv`, `EuclideanSpace`) — no new definitions. The PDE is encoded through the Fréchet derivative: `fderiv ℝ u p (0,1)` is the time derivative and `fderiv ℝ u p (v,0)` the spatial directional derivative. Locality and uniqueness are folded into one `∀ x₀, ∃ U …` statement. Mathlib has no Cauchy–Kovalevskaya theorem, and a search found no formalization of it in any other proof assistant.

🤖 Prepared with Claude Code