### PR TITLE
feat: add Sturm's theorem eval problem

### DIFF
--- a/LeanEval/Algebra/Sturm.lean
+++ b/LeanEval/Algebra/Sturm.lean
@@ -1,0 +1,63 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Algebra
+
+/-!
+# Sturm's theorem
+
+§97 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. For a
+squarefree real polynomial `p` and an interval `(a, b)` whose endpoints are
+not roots of `p`, the number of distinct roots of `p` in `(a, b)` equals the
+drop in the number of sign variations of the Sturm chain across `[a, b]`.
+
+mathlib has no Sturm chain, no sign-variation counter, and no Sturm's
+theorem. The chain, the sign-change counter, and the variation function are
+defined here. (Sturm's theorem is formalized in Isabelle/HOL — Manuel
+Eberl's AFP entry `Sturm_Sequences` — for the same distinct-root form.)
+
+The Sturm chain uses the negated-remainder convention `pₖ₊₁ = -(pₖ₋₁ mod pₖ)`,
+for which the count is the difference `σ(a) − σ(b)`.
+-/
+
+open Polynomial
+open scoped Classical
+
+/-- Recursive helper for the Sturm chain. `sturmAux a b n` extends the chain
+starting from successive entries `a, b` with fuel `n`: at each step it
+appends `a` and continues with `b` and `-(a % b)`, stopping when the next
+entry is `0` (or the fuel runs out). -/
+noncomputable def sturmAux : ℝ[X] → ℝ[X] → ℕ → List ℝ[X]
+  | a, _, 0       => [a]
+  | a, b, (n + 1) =>
+    if b = 0 then [a] else a :: sturmAux b (-(a % b)) n
+
+/-- The **Sturm chain** of a real polynomial `p`: `p₀ = p`, `p₁ = p'`, and
+each subsequent entry is `-(pₖ₋₁ mod pₖ)`, terminating at the last nonzero
+entry. -/
+noncomputable def sturmChain (p : ℝ[X]) : List ℝ[X] :=
+  sturmAux p (derivative p) (p.natDegree + 2)
+
+/-- Number of sign changes in a list of real numbers, ignoring zeros: filter
+the zeros out, then count adjacent pairs of opposite sign. -/
+noncomputable def signChanges (xs : List ℝ) : ℕ :=
+  let ys := xs.filter (· ≠ 0)
+  ((ys.zip ys.tail).filter (fun q => q.1 * q.2 < 0)).length
+
+/-- The Sturm sign-variation function `σ_p(x)` of a real polynomial `p`. -/
+noncomputable def sigma (p : ℝ[X]) (x : ℝ) : ℕ :=
+  signChanges ((sturmChain p).map fun q => q.eval x)
+
+/-- **Sturm's theorem.** For a squarefree real polynomial `p` and an interval
+`(a, b)` with `a < b` whose endpoints are not roots of `p`, the number of
+distinct roots of `p` in `(a, b)` equals `σ(a) − σ(b)`. -/
+@[eval_problem]
+theorem sturm (p : ℝ[X]) (hp : Squarefree p) {a b : ℝ} (hab : a < b)
+    (ha : p.eval a ≠ 0) (hb : p.eval b ≠ 0) :
+    ((p.roots.toFinset).filter (fun x => a < x ∧ x < b)).card =
+      sigma p a - sigma p b := by
+  sorry
+
+end Algebra
+end LeanEval

--- a/manifests/problems/sturm.toml
+++ b/manifests/problems/sturm.toml
@@ -1,0 +1,9 @@
+id = "sturm"
+title = "Sturm's theorem"
+test = false
+module = "LeanEval.Algebra.Sturm"
+holes = ["sturm"]
+submitter = "Kim Morrison"
+notes = "§97 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. The number of distinct real roots of a squarefree real polynomial in an open interval equals the drop in the number of sign variations of its Sturm chain across the interval. The Sturm chain, the sign-variation counter, and the variation function σ are defined in the problem; mathlib has none of them. The chain uses the negated-remainder convention p_{k+1} = -(p_{k-1} mod p_k), for which the count is σ(a) - σ(b). Sturm's theorem is formalized in Isabelle/HOL (Manuel Eberl, AFP entry Sturm_Sequences) in the same distinct-root form."
+source = "J. C. F. Sturm (1829). Listed as §97 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Formalized in Isabelle/HOL by Manuel Eberl (AFP entry Sturm_Sequences)."
+informal_solution = "As x increases across a simple root of p exactly one sign variation of the Sturm chain is lost and none is gained — the standard sign analysis of consecutive chain entries at a root, using squarefreeness so that p and p' have no common root — while across a root of an interior chain entry the variation count is unchanged. Between roots σ is locally constant. Hence the number of distinct roots of p in (a, b) equals σ(a) - σ(b)."


### PR DESCRIPTION
This PR adds **Sturm's theorem** as a new lean-eval challenge problem — §97 of Oliver Knill's [*Some Fundamental Theorems in Mathematics*](https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf).

For a squarefree real polynomial `p` and an interval `(a, b)` whose endpoints are not roots of `p`, the number of distinct roots of `p` in `(a, b)` equals `σ(a) − σ(b)`, the drop in the number of sign variations of the Sturm chain.

The problem defines the Sturm chain (`p₀ = p`, `p₁ = p'`, `pₖ₊₁ = −(pₖ₋₁ mod pₖ)`), the sign-change counter, and the variation function `σ` — mathlib has none of them. The chain uses the negated-remainder convention, for which the count is `σ(a) − σ(b)`.

Cross-checked against the Isabelle/HOL formalization (Manuel Eberl, AFP entry `Sturm_Sequences`), which proves the same classical distinct-root form; our statement takes `Squarefree p` as an explicit hypothesis (the core case).

🤖 Prepared with Claude Code