### PR TITLE
feat: add Hadwiger's theorem eval problem

### DIFF
--- a/LeanEval/ConvexGeometry/Hadwiger.lean
+++ b/LeanEval/ConvexGeometry/Hadwiger.lean
@@ -1,0 +1,62 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace ConvexGeometry
+
+/-!
+# Hadwiger's theorem
+
+§31 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. The real
+vector space of continuous, rigid-motion-invariant valuations on convex
+bodies in `ℝⁿ` has dimension `n + 1` (a basis being the intrinsic volumes,
+the coefficients of the Steiner polynomial `Vol(K + tB)`).
+
+mathlib has `ConvexBody V` with its Hausdorff `MetricSpace`, but no
+valuations on convex bodies, no intrinsic volumes, and no Hadwiger's
+theorem; a search found no formalization of it in any other proof assistant.
+The problem defines the `IsValuation` predicate and the `valuations`
+submodule.
+
+The additivity clause is stated over four convex bodies `A B C D` with
+`↑A = ↑C ∪ ↑D`, `↑B = ↑C ∩ ↑D`; when `C ∩ D` is empty no body `B` exists
+and that case is dropped (mathlib's `ConvexBody` is nonempty). The
+`Submodule` membership-closure fields of `valuations` are left as `sorry`
+(routine: valuations are closed under sum and scalar multiple).
+-/
+
+open scoped Classical
+
+/-- The model space `ℝⁿ`. -/
+abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin n)
+
+/-- A continuous, rigid-motion-invariant, additive real valuation on the
+convex bodies of `ℝⁿ`: continuity in the Hausdorff metric, inclusion–
+exclusion additivity, and invariance under linear isometries and
+translations. -/
+def IsValuation {n : ℕ} (f : ConvexBody (E n) → ℝ) : Prop :=
+  Continuous f ∧
+  (∀ A B C D : ConvexBody (E n),
+      (A : Set (E n)) = (C : Set (E n)) ∪ (D : Set (E n)) →
+      (B : Set (E n)) = (C : Set (E n)) ∩ (D : Set (E n)) →
+      f A + f B = f C + f D) ∧
+  (∀ A B : ConvexBody (E n), ∀ e : E n ≃ₗᵢ[ℝ] E n,
+      (B : Set (E n)) = e '' (A : Set (E n)) → f B = f A) ∧
+  (∀ A B : ConvexBody (E n), ∀ t : E n,
+      (B : Set (E n)) = (· + t) '' (A : Set (E n)) → f A = f B)
+
+/-- The valuations form an `ℝ`-subspace of `ConvexBody ℝⁿ → ℝ`. -/
+noncomputable def valuations (n : ℕ) : Submodule ℝ (ConvexBody (E n) → ℝ) where
+  carrier := {f | IsValuation f}
+  add_mem' := by sorry
+  zero_mem' := by sorry
+  smul_mem' := by sorry
+
+/-- **Hadwiger's theorem.** The space of continuous rigid-motion-invariant
+valuations on convex bodies in `ℝⁿ` is `(n+1)`-dimensional. -/
+@[eval_problem]
+theorem hadwiger (n : ℕ) : Module.finrank ℝ (valuations n) = n + 1 := by
+  sorry
+
+end ConvexGeometry
+end LeanEval

--- a/manifests/problems/hadwiger.toml
+++ b/manifests/problems/hadwiger.toml
@@ -1,0 +1,9 @@
+id = "hadwiger"
+title = "Hadwiger's theorem"
+test = false
+module = "LeanEval.ConvexGeometry.Hadwiger"
+holes = ["hadwiger"]
+submitter = "Kim Morrison"
+notes = "§31 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. The real vector space of continuous, rigid-motion-invariant valuations on convex bodies in ℝⁿ has dimension n + 1. The problem defines the IsValuation predicate (continuity in the Hausdorff metric, inclusion-exclusion additivity, invariance under linear isometries and translations) and the valuations submodule. mathlib has ConvexBody with its Hausdorff MetricSpace but no valuations, intrinsic volumes, or Hadwiger's theorem; no formalization was found in any other proof assistant. The Submodule membership-closure fields of `valuations` are shipped as sorry (routine: valuations are closed under sum and scalar multiple)."
+source = "H. Hadwiger (1937). Listed as §31 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Hadwiger's classification: every continuous rigid-motion-invariant valuation on convex bodies in ℝⁿ is a linear combination of the n + 1 intrinsic volumes V₀, …, Vₙ (equivalently the coefficients of the Steiner polynomial Vol(K + tB) = ∑ⱼ aⱼ tʲ). The intrinsic volumes are linearly independent valuations, so they form a basis and the space has dimension exactly n + 1. The hard direction (every such valuation is a combination of intrinsic volumes) is Hadwiger's characterization theorem, proved by reduction to the one-dimensional case via the behaviour of valuations on simple convex bodies."


### PR DESCRIPTION
This PR adds **Hadwiger's theorem** as a new lean-eval challenge problem — §31 of Oliver Knill's [*Some Fundamental Theorems in Mathematics*](https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf).

The real vector space of continuous, rigid-motion-invariant valuations on convex bodies in `ℝⁿ` has dimension `n + 1` — a basis being the intrinsic volumes (the coefficients of the Steiner polynomial `Vol(K + tB)`).

mathlib has `ConvexBody` with its Hausdorff `MetricSpace` but no valuations, intrinsic volumes, or Hadwiger's theorem; a search found no formalization in any other proof assistant. The problem defines the `IsValuation` predicate (continuity, inclusion–exclusion additivity, linear-isometry and translation invariance) and the `valuations` submodule.

Two encoding notes: the additivity clause is stated over four convex bodies `A B C D` with `↑A = ↑C ∪ ↑D`, `↑B = ↑C ∩ ↑D` (the empty-intersection case is dropped, since `ConvexBody` is nonempty); and the `Submodule` membership-closure fields of `valuations` are shipped as `sorry` (routine — valuations are closed under sum and scalar multiple).

🤖 Prepared with Claude Code