### PR TITLE
fix: emit variable declarations in single-hole workspaces

### DIFF
--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -773,6 +773,174 @@ def extractContextOpens (problemId : String) (sourcePath : System.FilePath)
   if contextLines.isEmpty then return ""
   return "\n".intercalate contextLines.toList ++ "\n\n"
 
+/-! ## Context variables
+
+Walk the source up to the theorem and collect every `variable` declaration
+that is still in scope at that point. The lidskii regression (issue #276) is
+the canonical example: a theorem can refer to identifiers like `n` that are
+introduced by a preceding `variable {n : Type*} ...` declaration, and the
+elaborated theorem inherits those binders even though they do not appear in
+the source slice between `theorem <name>` and `:= by`. Re-emitting the
+`variable` lines in the generated workspace restores the elaboration context
+needed to type-check the extracted statement.
+
+Multi-line `variable` declarations are kept verbatim: after a `variable`
+header line we keep absorbing lines that begin with whitespace, which matches
+how Lean's parser treats indented continuations of a binder list. -/
+
+private def isLineStartingWithWhitespace (line : String) : Bool :=
+  match line.toList with
+  | [] => false
+  | c :: _ => c.isWhitespace
+
+/-- True iff `s` starts with `kw` and the next character (if any) is not part of
+an identifier — i.e. `kw` is followed by whitespace or end-of-line, not by more
+letters/underscores. Avoids matching `variableFoo` as `variable`. -/
+private def startsWithKeyword (s kw : String) : Bool :=
+  if !(s.startsWith kw) then false
+  else
+    let chars := s.toList.drop kw.length
+    match chars with
+    | [] => true
+    | c :: _ => !(c.isAlphanum || c == '_' || c == '\'')
+
+-- Drop the prefix of length `n` from `s` as a `String`.
+private def stringDrop (s : String) (n : Nat) : String :=
+  String.mk (s.toList.drop n)
+
+-- Find the contents of `s` after the first occurrence of `"-/"`. If the
+-- closer appears, returns `(afterMarker, false)`; otherwise returns
+-- `("", true)` to signal the block comment is still open at end-of-line.
+private def skipToBlockCommentClose (s : String) : String × Bool :=
+  let parts := s.splitOn "-/"
+  match parts with
+  | [] => ("", true)
+  | [_] => ("", true)
+  | _ :: rest => ("-/".intercalate rest, false)
+
+-- Strip a single block comment from the start of `lineRemainder`, returning
+-- `(remainderAfterComment, stillOpen)`. Caller must ensure `lineRemainder`
+-- starts with the block-comment opener `/-`.
+private def consumeBlockCommentStart (lineRemainder : String) : String × Bool :=
+  skipToBlockCommentClose (stringDrop lineRemainder 2)
+
+-- Strip text up to and including the next block-comment closer, returning
+-- what's left on this line and whether the block comment is still open.
+private def consumeBlockCommentContinuation (lineRemainder : String) : String × Bool :=
+  skipToBlockCommentClose lineRemainder
+
+/-- Names introduced by the named (non-instance) leading binders of a
+declaration-like text such as a theorem signature or the body of a
+`variable` declaration. -/
+def binderIntroducedNames (text : String) : Array String := Id.run do
+  let mut names : Array String := #[]
+  for (opener, body) in leadingBinders text do
+    -- Instance-implicit binders are usually anonymous (`[Fintype n]`); skip
+    -- them — the names they reference come from other binders.
+    if opener == '[' then continue
+    let parts := body.splitOn ":"
+    if parts.length < 2 then continue
+    for name in splitWhitespace parts[0]! do
+      names := names.push name
+  return names
+
+/-- True iff every name introduced by `varText` (a `variable ...` line, with
+the `variable` prefix still attached) is already bound by `theoremBinderNames`.
+Such a `variable` is shadowed by the theorem's explicit binders and so
+Lean would emit it as an "unused variable" if we re-emitted it. -/
+private def variableShadowedByTheorem (varText : String)
+    (theoremBinderNames : Array String) : Bool := Id.run do
+  let trimmed := varText.trimAscii.toString
+  if !(startsWithKeyword trimmed "variable") then return false
+  let body := (trimmed.drop "variable".length).toString
+  let varNames := binderIntroducedNames body
+  if varNames.isEmpty then return false
+  for name in varNames do
+    if !theoremBinderNames.contains name then return false
+  return true
+
+def extractContextVariables (source : String) (extracted? : Option ExtractedTheorem)
+    (theoremBinderNames : Array String) : String := Id.run do
+  let lines := source.splitOn "\n"
+  let targetLine? : Option Nat := extracted?.map fun e => e.startLine
+  -- One layer per `section`/`namespace` we are still inside. A `variable`
+  -- declared in a `section`/`namespace` goes out of scope at the matching
+  -- `end`; treating both the same way matches Lean's scoping for `variable`.
+  let mut variableLayers : Array (Array String) := #[#[]]
+  let mut frameDepth : Nat := 0
+  let mut inBlockComment := false
+  let mut idx : Nat := 0
+  while idx < lines.length do
+    let lineNum := idx + 1
+    if let some t := targetLine? then
+      if lineNum ≥ t then break
+    let line := lines[idx]!
+    -- Walk the line tracking block-comment state. We only consider the
+    -- non-comment remainder when classifying the line.
+    let mut work := line
+    if inBlockComment then
+      let (rest, stillOpen) := consumeBlockCommentContinuation work
+      if stillOpen then
+        idx := idx + 1
+        continue
+      inBlockComment := false
+      work := rest
+    -- Strip any further `/- ... -/` segments that close on this line, and
+    -- detect an opener that doesn't.
+    let mut classified := work
+    let mut bail := false
+    while true do
+      let trimmed := classified.trimAsciiStart.toString
+      if trimmed.startsWith "/-" then
+        let (rest', stillOpen) := consumeBlockCommentStart trimmed
+        if stillOpen then
+          inBlockComment := true
+          bail := true
+          break
+        classified := rest'
+      else
+        break
+    if bail then
+      idx := idx + 1
+      continue
+    let stripped := classified.trimAscii.toString
+    if stripped.isEmpty || stripped.startsWith "--" then
+      idx := idx + 1
+      continue
+    if startsWithKeyword stripped "namespace" || startsWithKeyword stripped "section" then
+      frameDepth := frameDepth + 1
+      variableLayers := variableLayers.push #[]
+      idx := idx + 1
+    else if startsWithKeyword stripped "end" then
+      if frameDepth > 0 then
+        frameDepth := frameDepth - 1
+        variableLayers := variableLayers.pop
+      idx := idx + 1
+    else if startsWithKeyword stripped "variable" then
+      let mut block := line
+      idx := idx + 1
+      while idx < lines.length do
+        let lineNum' := idx + 1
+        if let some t := targetLine? then
+          if lineNum' ≥ t then break
+        let next := lines[idx]!
+        if next.trimAscii.toString.isEmpty then break
+        if !isLineStartingWithWhitespace next then break
+        block := block ++ "\n" ++ next
+        idx := idx + 1
+      if !variableShadowedByTheorem block theoremBinderNames then
+        let layerIdx := variableLayers.size - 1
+        let layer := variableLayers[layerIdx]!.push block
+        variableLayers := variableLayers.set! layerIdx layer
+    else
+      idx := idx + 1
+  let mut flat : Array String := #[]
+  for layer in variableLayers do
+    for v in layer do
+      flat := flat.push v
+  if flat.isEmpty then return ""
+  return "\n".intercalate flat.toList ++ "\n\n"
+
 /-! ## Render ChallengeDeps.lean -/
 
 def renderChallengeDeps (root : System.FilePath) (entry : EvalProblemMetadata)
@@ -1168,6 +1336,9 @@ private def renderWorkspaceSingleHole (root : System.FilePath) (entry : EvalProb
   let submissionImports :=
     if hasChallengeDeps then "import ChallengeDeps\nimport Submission.Helpers\n\n"
     else "import Mathlib\nimport Submission.Helpers\n\n"
+  let theoremBinderNames := binderIntroducedNames theoremStatement
+  let contextVariablesBlock :=
+    extractContextVariables sourceText (some extracted) theoremBinderNames
   let includeNamespaces := hasChallengeDeps || !localImports.isEmpty
   let contextOpenBlock ←
     extractContextOpens entry.id sourcePath sourceText (some extracted) includeNamespaces
@@ -1186,13 +1357,13 @@ private def renderWorkspaceSingleHole (root : System.FilePath) (entry : EvalProb
   let readmeLines := renderReadmeLines entry #[extracted] (multiHole := false)
   let readme := "\n".intercalate readmeLines.toList ++ "\n"
   let challengeFile :=
-    challengeImport ++ contextOpenBlock ++
+    challengeImport ++ contextOpenBlock ++ contextVariablesBlock ++
     s!"theorem {theoremName} {theoremStatement} := by\n  sorry\n"
   let solutionFile :=
-    solutionImports ++ contextOpenBlock ++
+    solutionImports ++ contextOpenBlock ++ contextVariablesBlock ++
     s!"theorem {theoremName} {theoremStatement} := by\n  exact {solutionExact}\n"
   let submissionFile :=
-    submissionImports ++ contextOpenBlock ++
+    submissionImports ++ contextOpenBlock ++ contextVariablesBlock ++
     "namespace Submission\n\n" ++
     s!"theorem {theoremName} {theoremStatement} := by\n  sorry\n\n" ++
     "end Submission\n"

--- a/LeanEval/Sandbox/VariableBinderExample.lean
+++ b/LeanEval/Sandbox/VariableBinderExample.lean
@@ -1,0 +1,34 @@
+import Mathlib
+import EvalTools.Markers
+
+/-!
+Regression for https://github.com/leanprover/lean-eval/issues/276.
+
+The theorem below relies on `n` from a preceding `variable` declaration.
+Before the fix, the extractor sliced the theorem source verbatim, dropping
+the `variable {n : Type*} [Fintype n] [DecidableEq n]` line, and the
+generated `Challenge.lean` failed to compile with "Unknown identifier `n`".
+
+A few negative cases are also exercised:
+- a `variable` declared inside a closed `section` must NOT be emitted; if
+  the scanner is buggy it might leak `[DecidableEq m]` into the workspace,
+  which would refer to an out-of-scope `m`;
+- the word `variable` appearing inside this docstring must NOT be picked up
+  by the line scanner.
+-/
+
+namespace LeanEval.Sandbox
+
+section ClosedSection
+variable {m : Type*} [DecidableEq m]
+end ClosedSection
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+@[eval_problem]
+theorem variable_binder_example
+    (A : Matrix n n ℚ) (hA : A.IsHermitian) :
+    A.trace = ∑ i, A i i := by
+  sorry
+
+end LeanEval.Sandbox

--- a/generated/index.json
+++ b/generated/index.json
@@ -418,6 +418,17 @@
     "generated_path": "generated/instance_hole_example"
   },
   {
+    "id": "variable_binder_example",
+    "title": "variable-binder minimal example",
+    "test": true,
+    "submitter": "Kim Morrison",
+    "module": "LeanEval.Sandbox.VariableBinderExample",
+    "holes": [
+      "variable_binder_example"
+    ],
+    "generated_path": "generated/variable_binder_example"
+  },
+  {
     "id": "exists_nonisotopic_link",
     "title": "Existence of a non-isotopic pair of oriented two-component links",
     "test": false,

--- a/generated/variable_binder_example/Challenge.lean
+++ b/generated/variable_binder_example/Challenge.lean
@@ -1,0 +1,7 @@
+import Mathlib
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+theorem variable_binder_example (A : Matrix n n ℚ) (hA : A.IsHermitian) :
+    A.trace = ∑ i, A i i := by
+  sorry

--- a/generated/variable_binder_example/README.md
+++ b/generated/variable_binder_example/README.md
@@ -1,0 +1,23 @@
+# `variable_binder_example`
+
+variable-binder minimal example
+
+- Problem ID: `variable_binder_example`
+- Test Problem: yes
+- Submitter: Kim Morrison
+- Notes: Regression for https://github.com/leanprover/lean-eval/issues/276. The theorem inherits implicit binders from a preceding `variable` declaration, which the extractor must re-emit in the generated workspace.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+Write your solution in `Submission.lean` and any additional local modules under
+`Submission/`.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+Multi-file submissions are allowed through `Submission.lean` and additional local
+modules under `Submission/`.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/variable_binder_example/Solution.lean
+++ b/generated/variable_binder_example/Solution.lean
@@ -1,0 +1,8 @@
+import Mathlib
+import Submission
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+theorem variable_binder_example (A : Matrix n n ℚ) (hA : A.IsHermitian) :
+    A.trace = ∑ i, A i i := by
+  exact Submission.variable_binder_example A hA

--- a/generated/variable_binder_example/Submission.lean
+++ b/generated/variable_binder_example/Submission.lean
@@ -1,0 +1,12 @@
+import Mathlib
+import Submission.Helpers
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+namespace Submission
+
+theorem variable_binder_example (A : Matrix n n ℚ) (hA : A.IsHermitian) :
+    A.trace = ∑ i, A i i := by
+  sorry
+
+end Submission

--- a/generated/variable_binder_example/Submission/Helpers.lean
+++ b/generated/variable_binder_example/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/variable_binder_example/WorkspaceTest.lean
+++ b/generated/variable_binder_example/WorkspaceTest.lean
@@ -1,0 +1,19 @@
+import Lean
+
+open Lean
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  try
+    let child ← IO.Process.spawn {
+      cmd := "lake"
+      args := #["env", comparatorBin, "config.json"]
+    }
+    let exitCode ← child.wait
+    pure exitCode
+  catch err =>
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    IO.eprintln s!"Original error: {err}"
+    pure 1

--- a/generated/variable_binder_example/config.json
+++ b/generated/variable_binder_example/config.json
@@ -1,0 +1,13 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "variable_binder_example"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false
+}

--- a/generated/variable_binder_example/holes.json
+++ b/generated/variable_binder_example/holes.json
@@ -1,0 +1,12 @@
+{
+  "id": "variable_binder_example",
+  "module": "LeanEval.Sandbox.VariableBinderExample",
+  "holes": [
+    {
+      "name": "LeanEval.Sandbox.variable_binder_example",
+      "basename": "variable_binder_example",
+      "kind": "theorem",
+      "body": "theorem variable_binder_example\n    (A : Matrix n n \u211a) (hA : A.IsHermitian) :\n    A.trace = \u2211 i, A i i := by\n  sorry"
+    }
+  ]
+}

--- a/generated/variable_binder_example/lakefile.toml
+++ b/generated/variable_binder_example/lakefile.toml
@@ -1,0 +1,24 @@
+name = "variable_binder_example"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/variable_binder_example/lean-toolchain
+++ b/generated/variable_binder_example/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -414,6 +414,15 @@ submitter = "Kim Morrison"
 notes = "Minimal example exercising instance + theorem holes; instances must be named so the comparator can address them."
 
 [[problem]]
+id = "variable_binder_example"
+title = "variable-binder minimal example"
+test = true
+module = "LeanEval.Sandbox.VariableBinderExample"
+holes = ["variable_binder_example"]
+submitter = "Kim Morrison"
+notes = "Regression for https://github.com/leanprover/lean-eval/issues/276. The theorem inherits implicit binders from a preceding `variable` declaration, which the extractor must re-emit in the generated workspace."
+
+[[problem]]
 id = "exists_nonisotopic_link"
 title = "Existence of a non-isotopic pair of oriented two-component links"
 test = false


### PR DESCRIPTION
This PR makes the extractor re-emit `variable` declarations in generated single-hole workspaces so a theorem that inherits binders from a preceding `variable {n : Type*} [Fintype n] [DecidableEq n]` declaration still type-checks under `autoImplicit = false`.

Closes https://github.com/leanprover/lean-eval/issues/276.

The new `extractContextVariables` walks the source up to the theorem, tracking `section`/`namespace`/`end` frames and block-comment state, and collects every still-in-scope `variable` declaration (multi-line variables are kept by absorbing indented continuation lines). A `variableShadowedByTheorem` filter drops a `variable` whose named binders are all already explicit on the theorem, so existing `@[eval_problem]`s that inline binders (Gleason, etc.) do not pick up a redundant `variable` line that would trigger Lean's unused-variable linter.

There is a sandbox regression problem `variable_binder_example` whose theorem refers to a variable-introduced `n`, plus a closed `section` and a docstring mention of `variable` to exercise the scoping and block-comment handling.

🤖 Prepared with Claude Code
