### PR TITLE
feat: add Szemerédi's theorem eval problem

### DIFF
--- a/LeanEval/Combinatorics/Szemeredi.lean
+++ b/LeanEval/Combinatorics/Szemeredi.lean
@@ -1,0 +1,44 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Combinatorics
+
+/-!
+# Szemerédi's theorem
+
+§37 of Oliver Knill's *Some Fundamental Theorems in Mathematics* (the
+section's first additional statement, generalizing Roth's theorem from
+3-APs to `k`-APs). Every subset of `ℕ` of positive upper density contains
+arbitrarily long arithmetic progressions.
+
+mathlib has Roth's theorem (`roth_3ap_theorem_nat`, the `k = 3` case) but
+**not** the full Szemerédi theorem. As of 2026 it has not been formalized
+in any major proof assistant (a well-known open formalization target).
+-/
+
+open scoped BigOperators
+
+/-- A set `A ⊆ ℕ` contains **arbitrarily long arithmetic progressions** if
+for every length `k` there is an AP `{a + b·j | j < k}` of common
+difference `b ≥ 1` entirely contained in `A`. -/
+def ContainsArbitraryAPs (A : Set ℕ) : Prop :=
+  ∀ k : ℕ, ∃ a b : ℕ, 1 ≤ b ∧ ∀ j : ℕ, j < k → a + b * j ∈ A
+
+/-- The **upper density** of `A ⊆ ℕ`:
+`limsup_{n → ∞} |A ∩ {0,…,n}| / (n+1)`. -/
+noncomputable def upperDensity (A : Set ℕ) : ℝ :=
+  Filter.limsup
+    (fun n : ℕ =>
+      (∑ k ∈ Finset.range (n + 1), A.indicator (fun _ => (1 : ℝ)) k) / (n + 1))
+    Filter.atTop
+
+/-- **Szemerédi's theorem.** Every subset of `ℕ` of positive upper density
+contains arbitrarily long arithmetic progressions. -/
+@[eval_problem]
+theorem szemeredi (A : Set ℕ) (h : 0 < upperDensity A) :
+    ContainsArbitraryAPs A := by
+  sorry
+
+end Combinatorics
+end LeanEval

--- a/manifests/problems/szemeredi.toml
+++ b/manifests/problems/szemeredi.toml
@@ -1,0 +1,9 @@
+id = "szemeredi"
+title = "Szemerédi's theorem"
+test = false
+module = "LeanEval.Combinatorics.Szemeredi"
+holes = ["szemeredi"]
+submitter = "Kim Morrison"
+notes = "§37 of Oliver Knill's 'Some Fundamental Theorems in Mathematics' (first additional statement of the section, generalizing Roth's theorem from 3-APs to k-APs). Every subset of ℕ of positive upper density contains arbitrarily long arithmetic progressions. Mathlib has Roth's theorem (roth_3ap_theorem_nat, the k = 3 case) but not the full Szemerédi theorem. As of 2026 it has not been formalized in any major proof assistant (a well-known open formalization target)."
+source = "E. Szemerédi, On sets of integers containing no k elements in arithmetic progression, Acta Arith. 27 (1975), 199-245. Listed as §37 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Szemerédi's original combinatorial proof relies on the Szemerédi regularity lemma plus a delicate density-increment argument. Furstenberg gave a measure-theoretic proof via multiple recurrence in ergodic theory (every measure-preserving system has the Multiple Recurrence Property for k commuting transformations). Gowers gave a Fourier-analytic proof introducing the Gowers uniformity norms U^k. Any of these formalisations is a major undertaking; all three structures (regularity, ergodic multiple recurrence, U^k norms) are absent from mathlib."


### PR DESCRIPTION
This PR adds **Szemerédi's theorem** as a new lean-eval challenge problem — §37 of Oliver Knill's [*Some Fundamental Theorems in Mathematics*](https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf), the section's first additional statement (generalizing Roth's theorem from 3-APs to `k`-APs).

Every subset of `ℕ` of positive upper density contains arbitrarily long arithmetic progressions.

mathlib has Roth's theorem (`roth_3ap_theorem_nat`, the `k = 3` case) but **not** the full Szemerédi theorem. As of 2026 it has not been formalized in any major proof assistant — a well-known open formalization target.

🤖 Prepared with Claude Code