### PR TITLE
chore: redirect stale submit template links to lean-eval-submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Submit a benchmark solution
+    url: https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml
+    about: Benchmark submissions are filed in leanprover/lean-eval-submissions, not here.
   - name: Discussion on Zulip
     url: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/with/594108910
     about: General questions and discussion about lean-eval happen in the #Model-comparisons-for-Lean > LeanEval topic on the Lean Zulip.

--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -1,5 +1,5 @@
-name: Submit benchmark solution (moved)
-description: Benchmark submissions now live in leanprover/lean-eval-submissions; this template just points you there.
+name: "Moved: submit at lean-eval-submissions"
+description: Benchmark submissions live in leanprover/lean-eval-submissions. This template only exists to catch stale links and redirect you there.
 title: "[wrong repo] please file at leanprover/lean-eval-submissions"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -1,0 +1,26 @@
+name: Submit benchmark solution (moved)
+description: Benchmark submissions now live in leanprover/lean-eval-submissions; this template just points you there.
+title: "[wrong repo] please file at leanprover/lean-eval-submissions"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Benchmark submissions have moved
+
+        The hosted submission pipeline (issue intake, fetch, evaluate, leaderboard
+        recording) is no longer in this repository. It now lives in:
+
+        **https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml**
+
+        Please open your submission there. Nothing filed here will be evaluated or
+        recorded on the leaderboard.
+
+        You can close this draft and follow the link above; there is nothing more
+        to do in this repository.
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Acknowledgement
+      options:
+        - label: I understand this repository no longer accepts submissions and I should file at leanprover/lean-eval-submissions instead.
+          required: true


### PR DESCRIPTION
This PR adds a stub `.github/ISSUE_TEMPLATE/submit.yml` to this repository
that points submitters at `leanprover/lean-eval-submissions`. PR #278
moved the hosted submission pipeline out, but stale
`/issues/new?template=submit.yml` links in old Zulip threads, READMEs,
docs, and browser autocomplete continue to resolve here and now land
users on a blank issue chooser. Two recent submissions
(#281, #282) were misfiled in this repo and never evaluated.

The new template carries no inputs other than a required acknowledgement
checkbox; its body is a single markdown block pointing at
`https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml`
and explaining that nothing filed here will be evaluated or recorded on
the leaderboard. Any issue that does get filed through it is auto-titled
`[wrong repo] please file at leanprover/lean-eval-submissions` so it is
trivial to triage.

🤖 Prepared with Claude Code