### PR TITLE
feat: add Milnor's exotic 7-sphere eval problem

### DIFF
--- a/LeanEval/Topology/MilnorExoticSphereSeven.lean
+++ b/LeanEval/Topology/MilnorExoticSphereSeven.lean
@@ -1,0 +1,47 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Topology
+
+/-!
+# Milnor's exotic 7-sphere
+
+A `proof_wanted` in `Mathlib/Geometry/Manifold/PoincareConjecture.lean`. The
+existence of a smooth 7-manifold `M` that is homeomorphic to the standard
+7-sphere `𝕊⁷` but **not** diffeomorphic to it.
+
+This is John Milnor's 1956 discovery (Milnor, *On manifolds homeomorphic to
+the 7-sphere*, Ann. of Math. 64) — the birth of differential topology as a
+distinct subject from topology. Milnor exhibited his exotic 7-spheres as
+`S³`-bundles over `S⁴` with non-standard smooth structure; their
+non-diffeomorphism to `𝕊⁷` is detected by an invariant (Milnor's λ) built
+from the signature of an 8-manifold bounding the candidate via Hirzebruch's
+signature theorem and an integrality argument that distinguishes the
+smooth structures.
+
+mathlib has `ChartedSpace`, `IsManifold`, `Diffeomorph`, `Homeomorph`, and
+the unit sphere as a smooth manifold (`Geometry/Manifold/Instances/Sphere.lean`),
+but no exotic sphere construction. The statement here is the existential
+form recorded as `proof_wanted exists_homeomorph_isEmpty_diffeomorph_sphere_seven`
+in mathlib (the eval-problem flavour is the same — produce a smooth
+structure on some `M ≃ₜ 𝕊⁷` for which no diffeomorphism `M ≃ₘ⟮𝓡 7, 𝓡 7⟯ 𝕊⁷`
+exists).
+-/
+
+open scoped Manifold ContDiff
+open Metric (sphere)
+
+/-- **Milnor's exotic 7-sphere.** There exists a smooth 7-manifold
+homeomorphic to the standard 7-sphere `𝕊⁷` but not diffeomorphic to it. -/
+@[eval_problem]
+theorem milnor_exotic_sphere_seven :
+    ∃ (M : Type) (_ : TopologicalSpace M)
+      (_ : ChartedSpace (EuclideanSpace ℝ (Fin 7)) M)
+      (_ : IsManifold (𝓡 7) ∞ M)
+      (_homeo : M ≃ₜ sphere (0 : EuclideanSpace ℝ (Fin 8)) 1),
+      IsEmpty (M ≃ₘ⟮𝓡 7, 𝓡 7⟯ sphere (0 : EuclideanSpace ℝ (Fin 8)) 1) := by
+  sorry
+
+end Topology
+end LeanEval

--- a/manifests/problems/milnor_exotic_sphere_seven.toml
+++ b/manifests/problems/milnor_exotic_sphere_seven.toml
@@ -1,0 +1,9 @@
+id = "milnor_exotic_sphere_seven"
+title = "Milnor's exotic 7-sphere"
+test = false
+module = "LeanEval.Topology.MilnorExoticSphereSeven"
+holes = ["milnor_exotic_sphere_seven"]
+submitter = "Kim Morrison"
+notes = "Existence of a smooth 7-manifold homeomorphic but not diffeomorphic to 𝕊⁷. Recorded as `proof_wanted exists_homeomorph_isEmpty_diffeomorph_sphere_seven` in `Mathlib/Geometry/Manifold/PoincareConjecture.lean`. Milnor's 1956 discovery and the birth of differential topology as a distinct subject. The construction uses S³-bundles over S⁴; the non-diffeomorphism is detected by Milnor's λ-invariant built from the signature of an 8-manifold bounding the candidate (Hirzebruch's signature theorem + an integrality / mod-7 argument)."
+source = "J. Milnor, On manifolds homeomorphic to the 7-sphere, Ann. of Math. 64 (1956), 399-405. Recorded as a `proof_wanted` in Mathlib/Geometry/Manifold/PoincareConjecture.lean at rev 5450b53e5ddc."
+informal_solution = "Milnor's construction: for k ∈ ℤ let M_k → S⁴ be the S³-bundle whose Euler number is k+1 and first Pontryagin class is 2(2k+1). Each M_k carries a natural smooth structure and is, by direct construction of a Morse function with two critical points, homeomorphic to S⁷. To detect that M_k is not diffeomorphic to S⁷ for k ≢ 0 (mod 7), Milnor introduced the invariant λ(M) ∈ ℤ/7 by computing λ(M) = (2σ(W) − p₁(W)²) / 7 mod 7 for any smooth 8-manifold W with ∂W = M (Hirzebruch's signature theorem makes 2σ(W) − p₁(W)² divisible by 7); a Mayer-Vietoris / cobordism argument shows λ is well-defined and a diffeomorphism invariant. For the bundles M_k a direct calculation gives λ(M_k) ≡ k(k+1) mod 7, which is nonzero for k = 1 (and many other k); the corresponding M_1 is therefore an exotic 7-sphere."


### PR DESCRIPTION
This PR adds **Milnor's exotic 7-sphere** as a new lean-eval challenge problem — the existence of a smooth 7-manifold homeomorphic to the standard `𝕊⁷` but not diffeomorphic to it.

Recorded in mathlib as `proof_wanted exists_homeomorph_isEmpty_diffeomorph_sphere_seven` in `Mathlib/Geometry/Manifold/PoincareConjecture.lean`. Milnor's 1956 discovery (Ann. of Math. 64) — the birth of differential topology as a distinct subject. The classical construction uses `S³`-bundles over `S⁴`; non-diffeomorphism is detected by Milnor's λ-invariant built from the signature of an 8-manifold bounding the candidate (Hirzebruch's signature theorem + an integrality argument mod 7).

mathlib has `ChartedSpace`, `IsManifold`, `Diffeomorph`, and the unit sphere as a smooth manifold (`Geometry/Manifold/Instances/Sphere.lean`) but no exotic-sphere construction.

🤖 Prepared with Claude Code