### PR TITLE
feat: add Morse inequalities eval problem

### DIFF
--- a/LeanEval/Geometry/MorseInequalities.lean
+++ b/LeanEval/Geometry/MorseInequalities.lean
@@ -1,0 +1,113 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Geometry
+
+/-!
+# Morse inequalities (Marston Morse, 1934)
+
+§40 of Knill's *Some Fundamental Theorems in Mathematics*. For a Morse
+function `f` on a closed smooth finite-dimensional manifold `M`,
+
+`∑_{j≤k} (−1)^{k−j} c_j(f) ≥ ∑_{j≤k} (−1)^{k−j} b_j(M)`
+
+for every `k`, where `c_j` is the number of critical points of `f` of Morse
+index `j` and `b_j` is the `j`-th Betti number of `M`.
+
+mathlib has the smooth-manifold framework, `mfderiv`, higher Fréchet
+derivatives, and `singularHomologyFunctor` — but no Morse functions, Morse
+index, critical-point counts, Betti numbers (as a named definition), or
+the Morse inequalities. The Challenge ships seven helper definitions
+(`IsCriticalPoint`, `localHessian`, `IsNondegenerateCritical`,
+`IsMorseFunction`, `morseIndex`, `morseCount`, `bettiNumber`,
+`alternatingPartialSum`) on top of mathlib.
+-/
+
+open scoped Manifold ContDiff Topology
+open CategoryTheory
+
+
+/-- A point `x ∈ M` is a **critical point** of `f` if `mfderiv f x = 0`. -/
+def IsCriticalPoint
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H]
+    {M : Type} [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) (f : M → ℝ) (x : M) : Prop :=
+  mfderiv I (modelWithCornersSelf ℝ ℝ) f x = 0
+
+/-- **Local Hessian** of `f` at `x`, in the preferred extended chart. -/
+noncomputable def localHessian
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H]
+    {M : Type} [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) (f : M → ℝ) (x : M) :
+    ContinuousMultilinearMap ℝ (fun _ : Fin 2 => E) ℝ :=
+  iteratedFDeriv ℝ 2 (f ∘ (extChartAt I x).symm) (extChartAt I x x)
+
+/-- A critical point `x` is **non-degenerate** when the local Hessian, viewed
+as a symmetric bilinear form on `E`, has trivial radical. -/
+def IsNondegenerateCritical
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H]
+    {M : Type} [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) (f : M → ℝ) (x : M) : Prop :=
+  IsCriticalPoint I f x ∧
+    ∀ v : E, (∀ w : E, localHessian I f x ![v, w] = 0) → v = 0
+
+/-- A **Morse function** on `M` is `C^∞`, has finitely many critical points,
+and every critical point is non-degenerate. -/
+structure IsMorseFunction
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H]
+    {M : Type} [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) [IsManifold I ∞ M] (f : M → ℝ) : Prop where
+  smooth : ContMDiff I (modelWithCornersSelf ℝ ℝ) ∞ f
+  critical_finite : {x : M | IsCriticalPoint I f x}.Finite
+  nondegenerate : ∀ x : M, IsCriticalPoint I f x → IsNondegenerateCritical I f x
+
+/-- The **Morse index** of `f` at `x` — the supremum of dimensions of
+subspaces of `E` on which the local Hessian is negative-definite. -/
+noncomputable def morseIndex
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H]
+    {M : Type} [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) (f : M → ℝ) (x : M) : ℕ :=
+  sSup {k : ℕ | ∃ S : Submodule ℝ E,
+    Module.finrank ℝ S = k ∧
+      ∀ v ∈ S, v ≠ 0 → localHessian I f x ![v, v] < 0}
+
+/-- `morseCount f k` is the number `c_k(f)` of Morse-index-`k` critical points. -/
+noncomputable def morseCount
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H]
+    {M : Type} [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) (f : M → ℝ) (k : ℕ) : ℕ :=
+  {x : M | IsCriticalPoint I f x ∧ morseIndex I f x = k}.ncard
+
+/-- `b_k(M) := dim_ℝ H_k(M; ℝ)`, the `k`-th Betti number with real
+coefficients. -/
+noncomputable def bettiNumber (M : Type) [TopologicalSpace M] (k : ℕ) : ℕ :=
+  Module.finrank ℝ
+    (((AlgebraicTopology.singularHomologyFunctor (ModuleCat ℝ) k).obj
+        (ModuleCat.of ℝ ℝ)).obj (TopCat.of M))
+
+/-- The alternating partial sum `∑_{j=0}^{k} (−1)^{k−j} a_j`. -/
+def alternatingPartialSum (a : ℕ → ℕ) (k : ℕ) : ℤ :=
+  ∑ j ∈ Finset.range (k + 1), (-1 : ℤ) ^ (k - j) * (a j : ℤ)
+
+/-- **Morse inequalities** (Marston Morse, 1934). For a Morse function `f`
+on a closed smooth finite-dimensional manifold `M` and every `k ∈ ℕ`,
+`∑_{j≤k}(−1)^{k−j} c_j(f) ≥ ∑_{j≤k}(−1)^{k−j} b_j(M)`. -/
+@[eval_problem]
+theorem morse_inequality
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H} [I.Boundaryless]
+    {M : Type} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    [CompactSpace M] (f : M → ℝ) (_hf : IsMorseFunction I f) (k : ℕ) :
+    alternatingPartialSum (bettiNumber M) k ≤
+      alternatingPartialSum (morseCount I f) k := by
+  sorry
+
+end Geometry
+end LeanEval

--- a/manifests/problems/morse_inequality.toml
+++ b/manifests/problems/morse_inequality.toml
@@ -1,0 +1,9 @@
+id = "morse_inequality"
+title = "Morse inequalities"
+test = false
+module = "LeanEval.Geometry.MorseInequalities"
+holes = ["morse_inequality"]
+submitter = "Kim Morrison"
+notes = "§40 of Knill's 'Some Fundamental Theorems in Mathematics' (Marston Morse, 1934). For a Morse function f on a closed smooth finite-dimensional manifold M, ∑_{j≤k}(−1)^{k−j} c_j(f) ≥ ∑_{j≤k}(−1)^{k−j} b_j(M) for every k. Mathlib has the smooth-manifold framework, mfderiv, higher Fréchet derivatives, and singularHomologyFunctor but no Morse functions, Morse index, critical-point counts, Betti numbers as a named definition, or the Morse inequalities. The Challenge ships seven helper definitions (IsCriticalPoint, localHessian, IsNondegenerateCritical, IsMorseFunction, morseIndex, morseCount, bettiNumber, alternatingPartialSum)."
+source = "M. Morse, The Calculus of Variations in the Large, AMS Colloq. Publ. 18 (1934). Listed as §40 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Strong Morse inequality via the Morse-Smale complex: order the critical points by increasing critical value t_1 < t_2 < … < t_N and consider the sublevel sets M_t = f⁻¹((−∞,t]). Crossing a critical value attaches a k-cell where k is the Morse index, so M_t is obtained from M_{t−} by attaching one k-cell per index-k critical point at level t (Morse lemma + handle attachment). This gives a CW structure on M with c_k cells in dimension k, hence a chain complex C_k = ℤ^{c_k} computing H_k(M; ℤ). The strong inequality follows from the rank-nullity-style relation rank H_k = c_k − rank ∂_{k+1} − rank ∂_k applied to alternating partial sums, combined with subadditivity of rank under boundary maps."


### PR DESCRIPTION
This PR adds the **Morse inequalities** as a new lean-eval challenge problem — §40 of Oliver Knill's [*Some Fundamental Theorems in Mathematics*](https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf) (Marston Morse, 1934).

For a Morse function `f` on a closed smooth finite-dimensional manifold `M` and every `k ∈ ℕ`:

`∑_{j≤k} (−1)^{k−j} c_j(f) ≥ ∑_{j≤k} (−1)^{k−j} b_j(M)`

where `c_j(f)` is the number of Morse-index-`j` critical points and `b_j(M)` is the `j`-th Betti number.

mathlib has the smooth-manifold framework, `mfderiv`, higher Fréchet derivatives, and `singularHomologyFunctor` — but **no Morse functions, Morse index, critical-point counts, or Betti numbers as a named definition**. The Challenge ships seven auxiliary definitions: `IsCriticalPoint`, `localHessian`, `IsNondegenerateCritical`, `IsMorseFunction`, `morseIndex`, `morseCount`, `bettiNumber`, `alternatingPartialSum`.

🤖 Prepared with Claude Code