### PR TITLE
feat: add Jordan curve theorem eval problem

### DIFF
--- a/LeanEval/Topology/JordanCurve.lean
+++ b/LeanEval/Topology/JordanCurve.lean
@@ -1,0 +1,36 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Topology
+
+/-!
+# Jordan curve theorem (Camille Jordan, 1887)
+
+§48 of Knill's *Some Fundamental Theorems in Mathematics*. A simple
+closed curve in the plane separates it into exactly two regions.
+Formalized as: for every continuous injection
+`r : S¹ → ℝ²`, the complement of its image has exactly two connected
+components.
+
+Mathlib has `Metric.sphere`, `EuclideanSpace`, `ConnectedComponents`,
+`Nat.card`, but **no Jordan curve theorem** (`grep -ri 'jordan curve'
+Mathlib/`: no hits), no Schoenflies theorem, no Jordan–Brouwer
+separation theorem, no winding numbers / invariance of domain in a form
+that would discharge it. Stateable with no new definitions.
+-/
+
+/-- **Jordan curve theorem** (Camille Jordan, 1887). For every
+continuous injection `r : S¹ → ℝ²` from the unit circle to the plane,
+the complement of its image has exactly two connected components. -/
+@[eval_problem]
+theorem jordan_curve
+    (r : Metric.sphere (0 : EuclideanSpace ℝ (Fin 2)) 1 → EuclideanSpace ℝ (Fin 2))
+    (_hcont : Continuous r) (_hinj : Function.Injective r) :
+    Nat.card
+        (ConnectedComponents ((Set.range r)ᶜ : Set (EuclideanSpace ℝ (Fin 2)))) =
+      2 := by
+  sorry
+
+end Topology
+end LeanEval

--- a/manifests/problems/jordan_curve.toml
+++ b/manifests/problems/jordan_curve.toml
@@ -1,0 +1,9 @@
+id = "jordan_curve"
+title = "Jordan curve theorem"
+test = false
+module = "LeanEval.Topology.JordanCurve"
+holes = ["jordan_curve"]
+submitter = "Kim Morrison"
+notes = "§48 of Knill's 'Some Fundamental Theorems in Mathematics'. Every continuous injection r : S¹ → ℝ² has a complement with exactly two connected components. Mathlib has Metric.sphere, EuclideanSpace, ConnectedComponents, and Nat.card, but no Jordan curve theorem (`grep -ri 'jordan curve' Mathlib/`: no hits), no winding numbers / invariance of domain in a form that would discharge it. Stateable with zero new definitions."
+source = "C. Jordan, *Cours d'analyse* (1887, 2nd ed.; first statement and a famously gap-laden proof). The first rigorous proof is by O. Veblen, *Theory on plane curves in non-metrical analysis situs*, Trans. AMS 6 (1905). Listed as §48 in O. Knill, *Some Fundamental Theorems in Mathematics* (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Formalized in Mizar (Korniłowicz et al., 2005) and HOL Light (Hales, 2007); not in Lean or Coq mathlib-equivalents."
+informal_solution = "Modern proofs use either singular homology of the complement (Alexander duality H̃_0(ℝ² ∖ C) ≅ H̃¹(S¹) = ℤ giving exactly two components) or planar combinatorics (approximate by polygonal Jordan curves, use winding-number parity to define inside/outside, transfer to the continuous curve via uniform convergence)."


### PR DESCRIPTION
This PR adds an eval problem for the Jordan curve theorem (Camille
Jordan, 1887): every continuous injection `r : S¹ → ℝ²` has a
complement with exactly two connected components. §48 of Knill's
*Some Fundamental Theorems in Mathematics*.

Mathlib has `Metric.sphere`, `EuclideanSpace`, `ConnectedComponents`,
and `Nat.card`, but no Jordan curve theorem (`grep -ri 'jordan curve'
Mathlib/`: no hits), no winding numbers / invariance of domain in a
form that would discharge it. Stateable with zero new definitions.

Formalized in Mizar (Korniłowicz et al., 2005) and HOL Light
(Hales, 2007); item #14 on Freek Wiedijk's 100-theorems list (not yet
in Lean).

🤖 Prepared with Claude Code