### PR TITLE
feat: add Burnside normal p-complement theorem eval problem

### DIFF
--- a/LeanEval/GroupTheory/BurnsideNormalPComplement.lean
+++ b/LeanEval/GroupTheory/BurnsideNormalPComplement.lean
@@ -1,0 +1,44 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace GroupTheory
+
+/-!
+# Burnside's normal `p`-complement theorem
+
+Let `G` be a finite group, `p` a prime, and `P` a Sylow `p`-subgroup of `G`.
+If `P` is central in its normalizer (equivalently, `N_G(P) ≤ C_G(P)`), then
+`G` has a *normal `p`-complement*: a normal subgroup `N ⊴ G` with `N ⊓ P = 1`,
+`N ⊔ P = ⊤`, and `(|N|, p) = 1`.
+
+Proved by William Burnside (1900) using his transfer homomorphism. The
+result is the foundational example of *transfer*-based local-to-global
+arguments in finite group theory and was the original prototype for the
+modern theory of fusion (Alperin, Stallings, Mislin). Together with the
+focal subgroup theorem and Grün's theorems, it sits at the entry point of
+the CFSG local analysis programme.
+
+Note: Mathlib has the underlying construction — the *kernel of the
+transfer to `P`* is a normal `p`-complement, see
+`MonoidHom.ker_transferSylow_isComplement'`. The eval problem here is to
+recover the named theorem statement (existence of *some* normal subgroup
+witnessing the four conditions) from that machinery.
+
+We add the coprimality condition `(|N|, p) = 1` explicitly, since the
+combination `N.Normal ∧ N ⊓ P = 1 ∧ N ⊔ P = ⊤` alone does not force `N` to
+be the Hall `p'`-complement.
+-/
+
+/-- **Burnside's normal `p`-complement theorem.** -/
+@[eval_problem]
+theorem burnside_normal_p_complement
+    {G : Type*} [Group G] [Finite G]
+    {p : ℕ} [Fact p.Prime] (P : Sylow p G)
+    (h : Subgroup.normalizer (P : Subgroup G) ≤ Subgroup.centralizer (P : Set G)) :
+    ∃ N : Subgroup G, N.Normal ∧ N ⊓ (P : Subgroup G) = ⊥ ∧
+      N ⊔ (P : Subgroup G) = ⊤ ∧ (Nat.card N).Coprime p := by
+  sorry
+
+end GroupTheory
+end LeanEval

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -682,3 +682,14 @@ module = "LeanEval.Geometry.Uniformization"
 holes = ["uniformization"]
 submitter = "Junyan Xu"
 source = "John Hamal Hubbard, *Teichmüller theory and applications to geometry, topology, and dynamics. Vol. 1*, Chapter 1."
+
+[[problem]]
+id = "burnside_normal_p_complement"
+title = "Burnside's normal p-complement theorem"
+test = false
+module = "LeanEval.GroupTheory.BurnsideNormalPComplement"
+holes = ["burnside_normal_p_complement"]
+submitter = "Kim Morrison"
+notes = "If a Sylow p-subgroup P of a finite group G is central in its normalizer, then G has a normal p-complement: a normal subgroup N ⊴ G with N ∩ P = 1, N P = G, and (|N|, p) = 1. W. Burnside, *Theory of groups of finite order*, 2nd ed., Cambridge (1911), §243 (the proof via transfer). The prototype transfer-based local-to-global argument and the historical seed of fusion theory (Alperin, Stallings, Mislin). Mathlib already contains the underlying construction `MonoidHom.ker_transferSylow_isComplement'` (Mathlib/GroupTheory/Transfer.lean); the eval problem is to assemble the named theorem statement from that machinery."
+source = "W. Burnside, *Theory of groups of finite order*, 2nd ed., Cambridge University Press (1911), §243. Modern textbook treatment: I. M. Isaacs, *Finite Group Theory*, AMS Graduate Studies in Math. 92 (2008), §5."
+informal_solution = "Let τ : G → P be the transfer homomorphism (averaging g over coset representatives of P in G). Under the hypothesis N_G(P) ≤ C_G(P), Burnside's transfer evaluation formula gives τ(p) = p for all p ∈ P, so τ restricted to P is the identity. Hence ker τ ⊓ P = 1 and ker τ · P = G; ker τ is normal in G (as the kernel of a homomorphism) and has order coprime to p (since |G : ker τ| = |P| is a p-power and |G| = |P| · |ker τ|). Therefore N := ker τ is the normal p-complement."


### PR DESCRIPTION
This PR adds Burnside's normal `p`-complement theorem (1911): if a Sylow `p`-subgroup `P` of a finite group `G` is central in its normalizer, then `G` has a normal `p`-complement. The prototype transfer-based local-to-global argument and the seed of fusion theory.

Mathlib already contains the underlying construction `MonoidHom.ker_transferSylow_isComplement'`; the eval problem is to assemble the named theorem statement from that machinery.

🤖 Prepared with Claude Code