### PR TITLE
feat: add Gorenstein-Walter theorem eval problem

### DIFF
--- a/LeanEval/GroupTheory/GorensteinWalter.lean
+++ b/LeanEval/GroupTheory/GorensteinWalter.lean
@@ -1,0 +1,45 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace GroupTheory
+
+open scoped MatrixGroups
+
+/-!
+# Gorenstein–Walter theorem (dihedral Sylow 2-subgroup)
+
+Let `G` be a finite nonabelian simple group whose Sylow 2-subgroups are
+dihedral. Then `G` is isomorphic to either:
+
+* `PSL₂(q)` for some odd prime power `q ≥ 5`, or
+* the alternating group `A₇`.
+
+D. Gorenstein and J. H. Walter, "The characterization of finite groups
+with dihedral Sylow 2-subgroups", J. Algebra 2 (1965); a famously long
+paper, the first major application of the Bender method in CFSG.
+
+The conclusion is captured in two clauses:
+* `Nonempty (G ≃* alternatingGroup (Fin 7))`, or
+* an existential over a prime `p`, an exponent `k`, and an isomorphism
+  `G ≃* PSL(2, GaloisField p k)` with `p` odd and `p^k ≥ 5`.
+
+Since `GaloisField p k` requires the typeclass `Fact p.Prime`, we
+existentially bind a `Fact p.Prime` term and use it (via `letI`) to
+reach the `GaloisField`.
+-/
+
+/-- **Gorenstein–Walter theorem.** -/
+@[eval_problem]
+theorem gorenstein_walter
+    (G : Type) [Group G] [Finite G] [IsSimpleGroup G]
+    (hnonab : ∃ a b : G, a * b ≠ b * a)
+    (P : Sylow 2 G)
+    (_hdih : ∃ n : ℕ, Nonempty ((P : Subgroup G) ≃* DihedralGroup n)) :
+    Nonempty (G ≃* alternatingGroup (Fin 7)) ∨
+    ∃ p k : ℕ, ∃ _hp : Fact p.Prime, Odd p ∧ 5 ≤ p ^ k ∧
+      Nonempty (G ≃* PSL(2, GaloisField p k)) := by
+  sorry
+
+end GroupTheory
+end LeanEval

--- a/LeanEval/GroupTheory/GorensteinWalter.lean
+++ b/LeanEval/GroupTheory/GorensteinWalter.lean
@@ -24,9 +24,9 @@ The conclusion is captured in two clauses:
 * an existential over a prime `p`, an exponent `k`, and an isomorphism
   `G ≃* PSL(2, GaloisField p k)` with `p` odd and `p^k ≥ 5`.
 
-Since `GaloisField p k` requires the typeclass `Fact p.Prime`, we
-existentially bind a `Fact p.Prime` term and use it (via `letI`) to
-reach the `GaloisField`.
+Since `GaloisField p k` requires the typeclass `Fact p.Prime`, the
+existential binds a `Fact p.Prime` term directly (rather than the bare
+`p.Prime`), so the typeclass is available where `GaloisField` is used.
 -/
 
 /-- **Gorenstein–Walter theorem.** -/

--- a/manifests/problems/gorenstein_walter.toml
+++ b/manifests/problems/gorenstein_walter.toml
@@ -1,0 +1,9 @@
+id = "gorenstein_walter"
+title = "Gorenstein–Walter theorem (dihedral Sylow 2-subgroup)"
+test = false
+module = "LeanEval.GroupTheory.GorensteinWalter"
+holes = ["gorenstein_walter"]
+submitter = "Kim Morrison"
+notes = "A finite nonabelian simple group with dihedral Sylow 2-subgroups is isomorphic to PSL₂(q) for some odd prime power q ≥ 5, or to A₇. D. Gorenstein and J. H. Walter, 'The characterization of finite groups with dihedral Sylow 2-subgroups', J. Algebra 2 (1965), 85-151, 218-270, 354-393 (in three parts, ~250 pages). The first major application of the Bender method in CFSG and a template for the later Sylow-2-structure papers. No new definitions: uses Mathlib's PSL notation, DihedralGroup, alternatingGroup, GaloisField, and Sylow."
+source = "D. Gorenstein and J. H. Walter, The characterization of finite groups with dihedral Sylow 2-subgroups, J. Algebra 2 (1965), 85-151, 218-270, 354-393. https://doi.org/10.1016/0021-8693(65)90027-X"
+informal_solution = "Three-part argument. Part I (Gorenstein-Walter): if G has dihedral Sylow 2-subgroup, then either G ≅ A₇, or O(G) — the largest normal subgroup of odd order — has G/O(G) of a very specific structure: an extension of PSL₂(q) for some odd q ≥ 5 by an outer automorphism. Part II rules out the outer-automorphism case using Brauer's theory of blocks of defect one and the analysis of involution centralizers (this is where the Bender method first appears). Part III shows O(G) = 1 under the simplicity hypothesis, using the Z*-theorem and signalizer functor methods. Combined, the simple G is isomorphic to PSL₂(q) for some odd q ≥ 5 or to A₇."


### PR DESCRIPTION
This PR adds the Gorenstein-Walter theorem (1965): a finite nonabelian simple group with dihedral Sylow 2-subgroups is isomorphic to `PSL₂(q)` for some odd prime power `q ≥ 5` or to `A₇`. A ~250-page paper across three parts; the first major application of the Bender method in CFSG and a template for later Sylow-2-structure papers.

Uses Mathlib's `PSL`, `DihedralGroup`, `alternatingGroup`, and `GaloisField` — no new definitions.

🤖 Prepared with Claude Code