### PR TITLE
feat: add Schauder fixed-point theorem eval problem

### DIFF
--- a/LeanEval/Topology/Schauder.lean
+++ b/LeanEval/Topology/Schauder.lean
@@ -1,0 +1,55 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Topology
+
+/-!
+# Schauder fixed-point theorem (Juliusz Schauder, 1930)
+
+§60 of Knill's *Some Fundamental Theorems in Mathematics* (additional
+statement). The Banach-space generalization of Brouwer: every continuous
+self-map of a nonempty compact convex subset of a real Banach space has
+a fixed point. Stated with `NormedAddCommGroup` + `NormedSpace ℝ` +
+`CompleteSpace` (the canonical decomposition of "Banach space" in
+mathlib); the `CompleteSpace` hypothesis is what distinguishes this
+from the general normed-space statement.
+
+Mathlib has `NormedAddCommGroup`, `NormedSpace`, `CompleteSpace`,
+`IsCompact`, `Convex ℝ`, `ContinuousOn`, `MapsTo`, and
+`ContractingWith.exists_fixedPoint` (Banach's contraction principle, a
+strictly weaker fixed-point theorem). But **no Schauder fixed-point
+theorem** — `grep -ri 'Schauder.*fixed\|fixed.*Schauder' Mathlib/`
+returns nothing. (`SchauderBasis` / `GeneralSchauderBasis` are present
+but they are different: Schauder bases are about sequences spanning a
+Banach space, not fixed points.)
+
+No open mathlib PR for Schauder (`gh search prs` returns no hits as of
+2026-05-24). The Sperner → Brouwer → Schauder dependency chain is
+partially in motion in mathlib: Sperner foundations partly landed; open
+PR https://github.com/leanprover-community/mathlib4/pull/36770 uses
+Brouwer to prove invariance of domain (so Brouwer itself is in flight).
+Schauder is the next step in that chain and there is active downstream
+demand from the PDE community (cf. Nelson Spence's 2026-03-06 Zulip
+thread requesting Schauder / Schaefer / Leray–Schauder machinery for
+elliptic-existence formalizations).
+
+Stateable with zero new definitions.
+-/
+
+/-- **Schauder fixed-point theorem.** Every continuous self-map of a
+nonempty compact convex subset of a real Banach space has a fixed
+point. -/
+@[eval_problem]
+theorem schauder_fixed_point {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    {K : Set E}
+    (_hK_compact : IsCompact K) (_hK_convex : Convex ℝ K)
+    (_hK_nonempty : K.Nonempty)
+    (f : E → E)
+    (_hf_cont : ContinuousOn f K) (_hf_maps : Set.MapsTo f K K) :
+    ∃ x ∈ K, f x = x := by
+  sorry
+
+end Topology
+end LeanEval

--- a/manifests/problems.toml
+++ b/manifests/problems.toml
@@ -694,3 +694,13 @@ notes = "The order of a finite nonabelian simple group is bounded by a function 
 source = "R. Brauer and K. A. Fowler, On groups of even order, Ann. of Math. (2) 62 (1955), 565-583. https://doi.org/10.2307/1970080"
 informal_solution = "Counting argument. For an involution t in a finite simple group G with C := |C_G(t)|, every pair of involutions a, b generates a dihedral subgroup ⟨a,b⟩ of order 2k for some k ≥ 1; the product ab has order k. Use the class equation and orbit-counting on conjugates of t to show that |G| divides (2C^2)! or a similar explicit factorial of a polynomial in C — any such bound furnishes the required f."
 
+[[problem]]
+id = "schauder_fixed_point"
+title = "Schauder fixed-point theorem"
+test = false
+module = "LeanEval.Topology.Schauder"
+holes = ["schauder_fixed_point"]
+submitter = "Kim Morrison"
+notes = "§60 of Knill's 'Some Fundamental Theorems in Mathematics' (additional statement). The Banach-space generalization of Brouwer: every continuous self-map of a nonempty compact convex subset of a real Banach space has a fixed point. Mathlib has NormedAddCommGroup / NormedSpace / CompleteSpace and the Banach contraction principle (ContractingWith.exists_fixedPoint, strictly weaker), but no Schauder fixed-point theorem. SchauderBasis / GeneralSchauderBasis in mathlib are unrelated (about sequences spanning a Banach space, not fixed points). No open mathlib PR; the Sperner → Brouwer → Schauder dependency chain is partially in motion (Sperner partially landed, Brouwer in flight in #36770). Active downstream demand from the PDE community for Schauder / Schaefer / Leray–Schauder machinery (cf. Nelson Spence's 2026-03-06 Zulip thread). Stateable with zero new definitions."
+source = "J. Schauder, *Der Fixpunktsatz in Funktionalräumen*, Studia Mathematica 2 (1930), 171-180. Listed as §60 (additional statement 2) in O. Knill, *Some Fundamental Theorems in Mathematics* (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). No formalization found in mathlib4 or any open mathlib PR; Brouwer is in flight via https://github.com/leanprover-community/mathlib4/pull/36770."
+informal_solution = "Standard proof: approximate the compact convex K by finite-dimensional convex polytopes K_n via ε-nets and the convex-hull construction; on each K_n apply Brouwer fixed-point to a continuous projection of f to get a fixed point x_n ∈ K_n; pass to a subsequence x_n → x (compactness of K), and verify f x = x using uniform continuity of f on the compact set K. The full argument depends on Brouwer's fixed-point theorem (the main classical input) and Mazur's theorem (the closed convex hull of a compact subset of a Banach space is compact, which uses completeness)."


### PR DESCRIPTION
This PR adds an eval problem for the Schauder fixed-point theorem
(Juliusz Schauder, 1930): every continuous self-map of a nonempty
compact convex subset of a real Banach space has a fixed point. §60
of Knill's *Some Fundamental Theorems in Mathematics* (additional
statement; the boxed main theorem of §60 is Lefschetz–Hopf, classified
(c) and not stated).

Mathlib has `NormedAddCommGroup`, `NormedSpace`, `CompleteSpace`,
`IsCompact`, `Convex ℝ`, `ContinuousOn`, `MapsTo`, and the Banach
contraction principle (`ContractingWith.exists_fixedPoint`, a strictly
weaker fixed-point theorem). But no Schauder fixed-point theorem
(`grep -ri 'Schauder.*fixed\|fixed.*Schauder' Mathlib/` returns
nothing) and no open mathlib PR for it. The Sperner → Brouwer →
Schauder dependency chain is partially in motion in mathlib (Sperner
foundations partly landed; open PR
https://github.com/leanprover-community/mathlib4/pull/36770 uses
Brouwer to prove invariance of domain). Active downstream demand from
PDE formalization efforts (Nelson Spence's 2026-03-06 Zulip thread
requesting Schauder / Schaefer / Leray–Schauder machinery for
elliptic-existence formalizations).

Stateable with zero new definitions.

🤖 Prepared with Claude Code