### PR TITLE
ci: also trigger leaderboard notify on generated/ changes

### DIFF
--- a/.github/workflows/notify-leaderboard.yml
+++ b/.github/workflows/notify-leaderboard.yml
@@ -15,6 +15,7 @@ on:
       - 'EvalTools/**'
       - 'templates/**'
       - 'manifests/problems/**'
+      - 'generated/**'
       - 'lakefile.toml'
       - 'lean-toolchain'
   workflow_dispatch:


### PR DESCRIPTION
This PR makes `notify-leaderboard.yml` also fire on pushes that touch
`generated/**`, so that the regenerator bot's follow-up commit retries
the leaderboard's snapshot bump.

Problem-adding PRs reach `main` in two pushes: the source-only PR
commit, then a `chore: regenerate generated/ workspaces` from the
regenerator app. Previously, only the first push matched `notify`'s
trigger paths. That dispatch raced `regenerate-main.yml`, so the
leaderboard's `bump-benchmark-snapshot.yml` would resolve
`origin/main` to the source-only commit and fail on missing
`generated/<new_problem>/holes.json`. The regenerator's follow-up
commit only touches `generated/**`, which wasn't in the trigger paths,
so no retry ever fired and the leaderboard pin stayed behind.

Concretely: the leaderboard pin has been stuck at `2434b5c` (2026-05-19)
through three subsequent problem additions (Brauer-Fowler #310,
Schauder #316, and the recent split-manifest refactor #317), and the
deploy has been failing because results referenced problem ids absent
from the pinned snapshot catalog.

After this PR, the regenerator's commit fires its own notify, so the
bump retries against a now-consistent main and the snapshot advances on
its own.

🤖 Prepared with Claude Code