### PR TITLE
fix: wrap sibling-problem helpers in per-problem inner namespaces

### DIFF
--- a/LeanEval/Geometry/Darboux.lean
+++ b/LeanEval/Geometry/Darboux.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace Darboux
 
 /-!
 # Darboux's theorem
@@ -82,5 +83,6 @@ theorem darboux {n : ℕ} {U : Set (E n)} (_hU : IsOpen U)
             (fderiv ℝ (φ.symm : E n → E n) z)) := by
   sorry
 
+end Darboux
 end Geometry
 end LeanEval

--- a/LeanEval/Geometry/KoszulFormula.lean
+++ b/LeanEval/Geometry/KoszulFormula.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace KoszulFormula
 
 /-!
 # Koszul formula
@@ -75,5 +76,6 @@ theorem koszul_formula
       + inner ℝ (Z x) (mlieBracket I X Y x) := by
   sorry
 
+end KoszulFormula
 end Geometry
 end LeanEval

--- a/LeanEval/Geometry/LeviCivita.lean
+++ b/LeanEval/Geometry/LeviCivita.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace LeviCivita
 
 /-!
 # Fundamental theorem of Riemannian geometry (Levi-Civita)
@@ -84,5 +85,6 @@ theorem levi_civita_exists_unique
         SameOnSmooth cov cov' := by
   sorry
 
+end LeviCivita
 end Geometry
 end LeanEval

--- a/LeanEval/Geometry/LiouvilleArnold.lean
+++ b/LeanEval/Geometry/LiouvilleArnold.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace LiouvilleArnold
 
 /-!
 # Liouville–Arnold theorem
@@ -84,5 +85,6 @@ theorem liouville_arnold
     Nonempty ((levelSet F c) ≃ₜ (Fin n → AddCircle (1 : ℝ))) := by
   sorry
 
+end LiouvilleArnold
 end Geometry
 end LeanEval

--- a/LeanEval/Geometry/MorseInequalities.lean
+++ b/LeanEval/Geometry/MorseInequalities.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace MorseInequalities
 
 /-!
 # Morse inequalities (Marston Morse, 1934)
@@ -109,5 +110,6 @@ theorem morse_inequality
       alternatingPartialSum (morseCount I f) k := by
   sorry
 
+end MorseInequalities
 end Geometry
 end LeanEval

--- a/LeanEval/Geometry/PlatonicClassification.lean
+++ b/LeanEval/Geometry/PlatonicClassification.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace PlatonicClassification
 
 /-!
 # Platonic classification
@@ -113,5 +114,6 @@ theorem platonic_classification :
           ∀ d, 5 ≤ d → platonicCount d = 3 := by
   sorry
 
+end PlatonicClassification
 end Geometry
 end LeanEval

--- a/LeanEval/Geometry/SchlafliClassification.lean
+++ b/LeanEval/Geometry/SchlafliClassification.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace SchlafliClassification
 
 /-!
 # Schläfli classification
@@ -110,5 +111,6 @@ theorem schlafli_classification :
         ∀ d, 5 ≤ d → platonicCount d = 3 := by
   sorry
 
+end SchlafliClassification
 end Geometry
 end LeanEval

--- a/LeanEval/Geometry/WeakMorseInequality.lean
+++ b/LeanEval/Geometry/WeakMorseInequality.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace Geometry
+namespace WeakMorseInequality
 
 /-!
 # Weak Morse inequalities
@@ -101,5 +102,6 @@ theorem weak_morse_inequality
     bettiNumber M k ≤ morseCount I f k := by
   sorry
 
+end WeakMorseInequality
 end Geometry
 end LeanEval


### PR DESCRIPTION
**Main is broken**: `lake exe lean-eval validate-manifest` and
`lake exe lean-eval generate` both fail with

```
uncaught exception: import LeanEval.Geometry.LeviCivita failed,
environment already contains 'LeanEval.Geometry.IsMetricCompatible'
from LeanEval.Geometry.KoszulFormula
```

after the recent batch of sibling Knill PRs merged.

Cause: Levi-Civita / Koszul, Morse / Weak Morse, Platonic / Schläfli,
and Darboux / Liouville-Arnold each define identical helper-def names
(`IsMetricCompatible`, `IsCriticalPoint`, `ConvexPolytope`, `E`,
`idxP`, `idxQ`, …) at the same `LeanEval.Geometry` namespace path.
Individual PRs were CI-green because `LeanEval.lean` (the lib glob)
doesn't import these modules, but `lake exe lean-eval` loads every
`@[eval_problem]` module together for inventory validation, which
trips the collision. 25 colliding decl names total across 8 files.

Fix: wrap each file's helpers + main theorem in an inner
`namespace <ProblemName>` (e.g. `LeanEval.Geometry.LeviCivita.*`).
The `@[eval_problem]` matching is by `basename`, so
`holes = [\"levi_civita\"]` still resolves correctly. Manifest module
path is by file path — unchanged.

**Verified:**
- `lake build` for all 8 files: success, only expected sorry warnings.
- `lake exe lean-eval validate-manifest`: \"Manifest and @[eval_problem]
  declarations are consistent.\"
- `lake exe lean-eval generate`: produces 92 workspaces.
- Per-problem generated workspaces (spot-checked
  `levi_civita_exists_unique`, `morse_inequality`) build clean.

🤖 Prepared with Claude Code