### PR TITLE
refactor: inline E2 in the unit-distance problem statements

### DIFF
--- a/LeanEval/Combinatorics/UnitDistance.lean
+++ b/LeanEval/Combinatorics/UnitDistance.lean
@@ -30,16 +30,15 @@ constant-factor improvements.
 
 open scoped Classical
 
-/-- The model space `ℝ²` with its Euclidean norm. We use
-`EuclideanSpace ℝ (Fin 2)` rather than `ℝ × ℝ` so that `dist x y`
-denotes the Euclidean distance `√((x₀ - y₀)² + (x₁ - y₁)²)`, not the
-sup-norm distance carried by the product space. -/
-abbrev E2 : Type := EuclideanSpace ℝ (Fin 2)
-
 /-- For a finite planar set `P ⊆ ℝ²`, `unitDist P` is the number of
-unordered pairs `{x, y} ⊆ P` at Euclidean distance exactly `1`. -/
-noncomputable def unitDist (P : Finset E2) : ℕ :=
-  (P.offDiag.filter (fun pq : E2 × E2 => dist pq.1 pq.2 = 1)).card / 2
+unordered pairs `{x, y} ⊆ P` at Euclidean distance exactly `1`.
+
+Points are modelled as `EuclideanSpace ℝ (Fin 2)` rather than `ℝ × ℝ`
+so that `dist x y = √((x₀ - y₀)² + (x₁ - y₁)²)`; the product space
+`ℝ × ℝ` carries the sup-norm and would give the wrong notion of
+unit-distance pair. -/
+noncomputable def unitDist (P : Finset (EuclideanSpace ℝ (Fin 2))) : ℕ :=
+  (P.offDiag.filter (fun pq => dist pq.1 pq.2 = 1)).card / 2
 
 end Combinatorics
 end LeanEval

--- a/LeanEval/Combinatorics/UnitDistanceConjectureFalse.lean
+++ b/LeanEval/Combinatorics/UnitDistanceConjectureFalse.lean
@@ -59,7 +59,7 @@ unit-distance pairs. Concretely: for every threshold `N` there exist
 @[eval_problem]
 theorem erdos_unit_distance_conjecture_false :
     ∃ δ : ℝ, 0 < δ ∧
-      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset E2),
+      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset (EuclideanSpace ℝ (Fin 2))),
         N ≤ n ∧ P.card = n ∧ (n : ℝ) ^ (1 + δ) ≤ (unitDist P : ℝ) := by
   sorry
 

--- a/LeanEval/Combinatorics/UnitDistanceUpperBound.lean
+++ b/LeanEval/Combinatorics/UnitDistanceUpperBound.lean
@@ -30,7 +30,8 @@ constant `C > 0` such that every finite `P ⊆ ℝ²` satisfies
 @[eval_problem]
 theorem unit_distance_upper_bound :
     ∃ C : ℝ, 0 < C ∧
-      ∀ P : Finset E2, (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
+      ∀ P : Finset (EuclideanSpace ℝ (Fin 2)),
+        (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
   sorry
 
 end Combinatorics


### PR DESCRIPTION
This PR inlines `E2 := EuclideanSpace ℝ (Fin 2)` at its four use sites and deletes the abbreviation. With a fixed dimension, the abbrev added a layer of indirection without saving meaningful space, and `abbrev` reduces away in error messages anyway. The sup-norm footgun note (use `EuclideanSpace`, not `ℝ × ℝ`) moves to the docstring of `unitDist` where it belongs.

Follow-up to #321.

🤖 Prepared with Claude Code