### PR TITLE
chore: regenerate generated/ workspaces

### DIFF
--- a/generated/erdos_unit_distance_conjecture_false/Challenge.lean
+++ b/generated/erdos_unit_distance_conjecture_false/Challenge.lean
@@ -4,6 +4,6 @@ open LeanEval.Combinatorics
 
 theorem erdos_unit_distance_conjecture_false :
     ∃ δ : ℝ, 0 < δ ∧
-      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset E2),
+      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset (EuclideanSpace ℝ (Fin 2))),
         N ≤ n ∧ P.card = n ∧ (n : ℝ) ^ (1 + δ) ≤ (unitDist P : ℝ) := by
   sorry

--- a/generated/erdos_unit_distance_conjecture_false/ChallengeDeps.lean
+++ b/generated/erdos_unit_distance_conjecture_false/ChallengeDeps.lean
@@ -30,16 +30,15 @@ constant-factor improvements.
 
 open scoped Classical
 
-/-- The model space `ℝ²` with its Euclidean norm. We use
-`EuclideanSpace ℝ (Fin 2)` rather than `ℝ × ℝ` so that `dist x y`
-denotes the Euclidean distance `√((x₀ - y₀)² + (x₁ - y₁)²)`, not the
-sup-norm distance carried by the product space. -/
-abbrev E2 : Type := EuclideanSpace ℝ (Fin 2)
-
 /-- For a finite planar set `P ⊆ ℝ²`, `unitDist P` is the number of
-unordered pairs `{x, y} ⊆ P` at Euclidean distance exactly `1`. -/
-noncomputable def unitDist (P : Finset E2) : ℕ :=
-  (P.offDiag.filter (fun pq : E2 × E2 => dist pq.1 pq.2 = 1)).card / 2
+unordered pairs `{x, y} ⊆ P` at Euclidean distance exactly `1`.
+
+Points are modelled as `EuclideanSpace ℝ (Fin 2)` rather than `ℝ × ℝ`
+so that `dist x y = √((x₀ - y₀)² + (x₁ - y₁)²)`; the product space
+`ℝ × ℝ` carries the sup-norm and would give the wrong notion of
+unit-distance pair. -/
+noncomputable def unitDist (P : Finset (EuclideanSpace ℝ (Fin 2))) : ℕ :=
+  (P.offDiag.filter (fun pq => dist pq.1 pq.2 = 1)).card / 2
 
 end Combinatorics
 end LeanEval

--- a/generated/erdos_unit_distance_conjecture_false/Solution.lean
+++ b/generated/erdos_unit_distance_conjecture_false/Solution.lean
@@ -5,6 +5,6 @@ open LeanEval.Combinatorics
 
 theorem erdos_unit_distance_conjecture_false :
     ∃ δ : ℝ, 0 < δ ∧
-      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset E2),
+      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset (EuclideanSpace ℝ (Fin 2))),
         N ≤ n ∧ P.card = n ∧ (n : ℝ) ^ (1 + δ) ≤ (unitDist P : ℝ) := by
   exact Submission.erdos_unit_distance_conjecture_false

--- a/generated/erdos_unit_distance_conjecture_false/Submission.lean
+++ b/generated/erdos_unit_distance_conjecture_false/Submission.lean
@@ -7,7 +7,7 @@ namespace Submission
 
 theorem erdos_unit_distance_conjecture_false :
     ∃ δ : ℝ, 0 < δ ∧
-      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset E2),
+      ∀ N : ℕ, ∃ (n : ℕ) (P : Finset (EuclideanSpace ℝ (Fin 2))),
         N ≤ n ∧ P.card = n ∧ (n : ℝ) ^ (1 + δ) ≤ (unitDist P : ℝ) := by
   sorry
 

--- a/generated/erdos_unit_distance_conjecture_false/holes.json
+++ b/generated/erdos_unit_distance_conjecture_false/holes.json
@@ -6,7 +6,7 @@
       "name": "LeanEval.Combinatorics.erdos_unit_distance_conjecture_false",
       "basename": "erdos_unit_distance_conjecture_false",
       "kind": "theorem",
-      "body": "/-- **OpenAI (2026), Theorem 1.1: Erd\u0151s's unit-distance conjecture is\nfalse.**\n\nThere is an absolute `\u03b4 > 0` and infinitely many positive integers `n`\nfor which some `n`-point set `P \u2286 \u211d\u00b2` has at least `n^{1+\u03b4}`\nunit-distance pairs. Concretely: for every threshold `N` there exist\n`n \u2265 N` and a finite `P \u2286 \u211d\u00b2` with `|P| = n` and\n`n^{1+\u03b4} \u2264 unitDist P`. -/\ntheorem erdos_unit_distance_conjecture_false :\n    \u2203 \u03b4 : \u211d, 0 < \u03b4 \u2227\n      \u2200 N : \u2115, \u2203 (n : \u2115) (P : Finset E2),\n        N \u2264 n \u2227 P.card = n \u2227 (n : \u211d) ^ (1 + \u03b4) \u2264 (unitDist P : \u211d) := by\n  sorry"
+      "body": "/-- **OpenAI (2026), Theorem 1.1: Erd\u0151s's unit-distance conjecture is\nfalse.**\n\nThere is an absolute `\u03b4 > 0` and infinitely many positive integers `n`\nfor which some `n`-point set `P \u2286 \u211d\u00b2` has at least `n^{1+\u03b4}`\nunit-distance pairs. Concretely: for every threshold `N` there exist\n`n \u2265 N` and a finite `P \u2286 \u211d\u00b2` with `|P| = n` and\n`n^{1+\u03b4} \u2264 unitDist P`. -/\ntheorem erdos_unit_distance_conjecture_false :\n    \u2203 \u03b4 : \u211d, 0 < \u03b4 \u2227\n      \u2200 N : \u2115, \u2203 (n : \u2115) (P : Finset (EuclideanSpace \u211d (Fin 2))),\n        N \u2264 n \u2227 P.card = n \u2227 (n : \u211d) ^ (1 + \u03b4) \u2264 (unitDist P : \u211d) := by\n  sorry"
     }
   ]
 }

--- a/generated/unit_distance_upper_bound/Challenge.lean
+++ b/generated/unit_distance_upper_bound/Challenge.lean
@@ -5,5 +5,6 @@ open scoped Classical
 
 theorem unit_distance_upper_bound :
     ∃ C : ℝ, 0 < C ∧
-      ∀ P : Finset E2, (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
+      ∀ P : Finset (EuclideanSpace ℝ (Fin 2)),
+        (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
   sorry

--- a/generated/unit_distance_upper_bound/ChallengeDeps.lean
+++ b/generated/unit_distance_upper_bound/ChallengeDeps.lean
@@ -30,16 +30,15 @@ constant-factor improvements.
 
 open scoped Classical
 
-/-- The model space `ℝ²` with its Euclidean norm. We use
-`EuclideanSpace ℝ (Fin 2)` rather than `ℝ × ℝ` so that `dist x y`
-denotes the Euclidean distance `√((x₀ - y₀)² + (x₁ - y₁)²)`, not the
-sup-norm distance carried by the product space. -/
-abbrev E2 : Type := EuclideanSpace ℝ (Fin 2)
-
 /-- For a finite planar set `P ⊆ ℝ²`, `unitDist P` is the number of
-unordered pairs `{x, y} ⊆ P` at Euclidean distance exactly `1`. -/
-noncomputable def unitDist (P : Finset E2) : ℕ :=
-  (P.offDiag.filter (fun pq : E2 × E2 => dist pq.1 pq.2 = 1)).card / 2
+unordered pairs `{x, y} ⊆ P` at Euclidean distance exactly `1`.
+
+Points are modelled as `EuclideanSpace ℝ (Fin 2)` rather than `ℝ × ℝ`
+so that `dist x y = √((x₀ - y₀)² + (x₁ - y₁)²)`; the product space
+`ℝ × ℝ` carries the sup-norm and would give the wrong notion of
+unit-distance pair. -/
+noncomputable def unitDist (P : Finset (EuclideanSpace ℝ (Fin 2))) : ℕ :=
+  (P.offDiag.filter (fun pq => dist pq.1 pq.2 = 1)).card / 2
 
 end Combinatorics
 end LeanEval

--- a/generated/unit_distance_upper_bound/Solution.lean
+++ b/generated/unit_distance_upper_bound/Solution.lean
@@ -6,5 +6,6 @@ open scoped Classical
 
 theorem unit_distance_upper_bound :
     ∃ C : ℝ, 0 < C ∧
-      ∀ P : Finset E2, (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
+      ∀ P : Finset (EuclideanSpace ℝ (Fin 2)),
+        (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
   exact Submission.unit_distance_upper_bound

--- a/generated/unit_distance_upper_bound/Submission.lean
+++ b/generated/unit_distance_upper_bound/Submission.lean
@@ -8,7 +8,8 @@ namespace Submission
 
 theorem unit_distance_upper_bound :
     ∃ C : ℝ, 0 < C ∧
-      ∀ P : Finset E2, (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
+      ∀ P : Finset (EuclideanSpace ℝ (Fin 2)),
+        (unitDist P : ℝ) ≤ C * (P.card : ℝ) ^ ((4 : ℝ) / 3) := by
   sorry
 
 end Submission

--- a/generated/unit_distance_upper_bound/holes.json
+++ b/generated/unit_distance_upper_bound/holes.json
@@ -6,7 +6,7 @@
       "name": "LeanEval.Combinatorics.unit_distance_upper_bound",
       "basename": "unit_distance_upper_bound",
       "kind": "theorem",
-      "body": "/-- **Spencer\u2013Szemer\u00e9di\u2013Trotter (1984).** The number of unit-distance\npairs in any finite planar set is `O(n^{4/3})`: there is an absolute\nconstant `C > 0` such that every finite `P \u2286 \u211d\u00b2` satisfies\n\n  `unitDist P \u2264 C \u00b7 |P|^{4/3}`. -/\ntheorem unit_distance_upper_bound :\n    \u2203 C : \u211d, 0 < C \u2227\n      \u2200 P : Finset E2, (unitDist P : \u211d) \u2264 C * (P.card : \u211d) ^ ((4 : \u211d) / 3) := by\n  sorry"
+      "body": "/-- **Spencer\u2013Szemer\u00e9di\u2013Trotter (1984).** The number of unit-distance\npairs in any finite planar set is `O(n^{4/3})`: there is an absolute\nconstant `C > 0` such that every finite `P \u2286 \u211d\u00b2` satisfies\n\n  `unitDist P \u2264 C \u00b7 |P|^{4/3}`. -/\ntheorem unit_distance_upper_bound :\n    \u2203 C : \u211d, 0 < C \u2227\n      \u2200 P : Finset (EuclideanSpace \u211d (Fin 2)),\n        (unitDist P : \u211d) \u2264 C * (P.card : \u211d) ^ ((4 : \u211d) / 3) := by\n  sorry"
     }
   ]
 }


### PR DESCRIPTION
This PR regenerates the `generated/` workspaces for the two unit-distance problems after #323 inlined `E2` in the source statements but did not refresh the generated workspaces. CI is currently failing on every PR (e.g. #324) with `Repository is not in a clean generated state` listing exactly these ten files.

Produced by `lake exe lean-eval generate`; no source changes.

🤖 Prepared with Claude Code