### PR TITLE
feat: add brauer_splitting_field problem

### DIFF
--- a/LeanEval/RepresentationTheory/BrauerCharacterInCyclotomic.lean
+++ b/LeanEval/RepresentationTheory/BrauerCharacterInCyclotomic.lean
@@ -1,0 +1,39 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace RepresentationTheory
+
+/-!
+Brauer's theorem on character values.
+
+For a finite group `G` of exponent `n`, every value of every complex
+character of `G` lies in (the image of) the cyclotomic field `ℚ(ζₙ)`.
+Concretely: there is a ring embedding `φ : ℚ(ζₙ) →+* ℂ` whose range
+contains `tr ρ(g)` for every finite-dimensional complex representation
+`ρ` of `G` and every `g ∈ G`.
+
+This is a consequence of Brauer's induction theorem (every character is a
+ℤ-combination of characters induced from elementary subgroups, whose values
+are visibly cyclotomic).
+
+The full Brauer "splitting field" theorem says more — that `ℚ(ζₙ)` is in fact
+a *splitting field* for the group algebra, i.e. every irreducible complex
+representation admits a `ℚ(ζₙ)`-form. The character-value statement below
+is implied by the splitting-field statement and is the part most cleanly
+expressible in Mathlib's current API; the full splitting-field statement
+would additionally require scalar-extension scaffolding around
+`CyclotomicField n ℚ → ℂ`.
+-/
+
+@[eval_problem]
+theorem brauer_character_in_cyclotomic
+    (G : Type) [Group G] [Fintype G] :
+    ∃ φ : CyclotomicField (Monoid.exponent G) ℚ →+* ℂ,
+      ∀ (V : Type) (_ : AddCommGroup V) (_ : Module ℂ V) (_ : FiniteDimensional ℂ V)
+        (ρ : Representation ℂ G V) (g : G),
+        LinearMap.trace ℂ V (ρ g) ∈ φ.range := by
+  sorry
+
+end RepresentationTheory
+end LeanEval

--- a/LeanEval/RepresentationTheory/BrauerSplittingField.lean
+++ b/LeanEval/RepresentationTheory/BrauerSplittingField.lean
@@ -33,7 +33,6 @@ theorem brauer_splitting_field
     ∃ (φ : CyclotomicField (Monoid.exponent G) ℚ →+* ℂ)
       (W : Type) (_ : AddCommGroup W)
       (_ : Module (CyclotomicField (Monoid.exponent G) ℚ) W)
-      (_ : FiniteDimensional (CyclotomicField (Monoid.exponent G) ℚ) W)
       (σ : Representation (CyclotomicField (Monoid.exponent G) ℚ) G W),
       letI : Algebra (CyclotomicField (Monoid.exponent G) ℚ) ℂ := φ.toAlgebra
       ∃ (f : (ℂ ⊗[CyclotomicField (Monoid.exponent G) ℚ] W) ≃ₗ[ℂ] V),

--- a/LeanEval/RepresentationTheory/BrauerSplittingField.lean
+++ b/LeanEval/RepresentationTheory/BrauerSplittingField.lean
@@ -4,35 +4,41 @@ import EvalTools.Markers
 namespace LeanEval
 namespace RepresentationTheory
 
+open scoped TensorProduct
+
 /-!
-Brauer's theorem on character values.
+Brauer's splitting field theorem.
 
-For a finite group `G` of exponent `n`, every value of every complex
-character of `G` lies in (the image of) the cyclotomic field `ℚ(ζₙ)`.
-Concretely: there is a ring embedding `φ : ℚ(ζₙ) →+* ℂ` whose range
-contains `tr ρ(g)` for every finite-dimensional complex representation
-`ρ` of `G` and every `g ∈ G`.
+For a finite group `G` of exponent `n`, every finite-dimensional complex
+representation of `G` descends to `ℚ(ζₙ)`. Concretely: there is a ring
+embedding `φ : CyclotomicField n ℚ →+* ℂ`, a `ℚ(ζₙ)`-representation
+`(W, σ)` of `G`, and a `ℂ`-linear, `G`-equivariant isomorphism
+`ℂ ⊗[ℚ(ζₙ)] W ≃ V`, where ℂ is regarded as a `ℚ(ζₙ)`-algebra via `φ`.
 
-This is a consequence of Brauer's induction theorem (every character is a
-ℤ-combination of characters induced from elementary subgroups, whose values
-are visibly cyclotomic).
+Brauer (1945) proved this using his induction theorem.
 
-The full Brauer "splitting field" theorem says more — that `ℚ(ζₙ)` is in fact
-a *splitting field* for the group algebra, i.e. every irreducible complex
-representation admits a `ℚ(ζₙ)`-form. The character-value statement below
-is implied by the splitting-field statement and is the part most cleanly
-expressible in Mathlib's current API; the full splitting-field statement
-would additionally require scalar-extension scaffolding around
-`CyclotomicField n ℚ → ℂ`.
+The weaker "character values lie in `φ.range`" statement
+(`brauer_character_in_cyclotomic`) is a corollary, and is in fact
+elementary: `ρ g ^ n = 1` makes `ρ g` diagonalisable with `n`-th-root-of-
+unity eigenvalues, so its trace is already a sum of `n`-th roots of unity.
+The descent statement here is the deep content (Schur index 1 over
+`ℚ(ζₙ)` for every irreducible complex representation of `G`).
 -/
 
 @[eval_problem]
-theorem brauer_character_in_cyclotomic
-    (G : Type) [Group G] [Fintype G] :
-    ∃ φ : CyclotomicField (Monoid.exponent G) ℚ →+* ℂ,
-      ∀ (V : Type) (_ : AddCommGroup V) (_ : Module ℂ V) (_ : FiniteDimensional ℂ V)
-        (ρ : Representation ℂ G V) (g : G),
-        LinearMap.trace ℂ V (ρ g) ∈ φ.range := by
+theorem brauer_splitting_field
+    (G : Type) [Group G] [Fintype G]
+    (V : Type) [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
+    (ρ : Representation ℂ G V) :
+    ∃ (φ : CyclotomicField (Monoid.exponent G) ℚ →+* ℂ)
+      (W : Type) (_ : AddCommGroup W)
+      (_ : Module (CyclotomicField (Monoid.exponent G) ℚ) W)
+      (_ : FiniteDimensional (CyclotomicField (Monoid.exponent G) ℚ) W)
+      (σ : Representation (CyclotomicField (Monoid.exponent G) ℚ) G W),
+      letI : Algebra (CyclotomicField (Monoid.exponent G) ℚ) ℂ := φ.toAlgebra
+      ∃ (f : (ℂ ⊗[CyclotomicField (Monoid.exponent G) ℚ] W) ≃ₗ[ℂ] V),
+        ∀ (g : G) (x : ℂ ⊗[CyclotomicField (Monoid.exponent G) ℚ] W),
+          f ((σ g).baseChange ℂ x) = ρ g (f x) := by
   sorry
 
 end RepresentationTheory

--- a/manifests/problems/brauer_character_in_cyclotomic.toml
+++ b/manifests/problems/brauer_character_in_cyclotomic.toml
@@ -1,7 +1,7 @@
 id = "brauer_character_in_cyclotomic"
 title = "Character values of finite groups lie in cyclotomic fields"
 test = false
-module = "LeanEval.RepresentationTheory.BrauerSplittingField"
+module = "LeanEval.RepresentationTheory.BrauerCharacterInCyclotomic"
 holes = ["brauer_character_in_cyclotomic"]
 submitter = "Kim Morrison"
 notes = "For a finite group G of exponent n, every value of every complex character of G lies in (the image of) the cyclotomic field ℚ(ζₙ). Stated uniformly for the fixed group G: there is a ring embedding φ : CyclotomicField (Monoid.exponent G) ℚ →+* ℂ whose range contains tr(ρ(g)) for every finite-dimensional complex representation ρ of G and every g. This is a corollary of Brauer's induction theorem; the full splitting-field statement (every irreducible representation has a ℚ(ζₙ)-form) is strictly stronger and requires more scalar-extension scaffolding than mathlib currently exposes cleanly."

--- a/manifests/problems/brauer_splitting_field.toml
+++ b/manifests/problems/brauer_splitting_field.toml
@@ -1,0 +1,9 @@
+id = "brauer_splitting_field"
+title = "Brauer's splitting field theorem"
+test = false
+module = "LeanEval.RepresentationTheory.BrauerSplittingField"
+holes = ["brauer_splitting_field"]
+submitter = "Kim Morrison"
+notes = "For a finite group G of exponent n, the cyclotomic field ℚ(ζₙ) is a splitting field for G: every finite-dimensional complex representation ρ of G descends to ℚ(ζₙ). Concretely, there exists an embedding φ : CyclotomicField n ℚ →+* ℂ, a ℚ(ζₙ)-representation (W, σ) of G, and a ℂ-linear G-equivariant isomorphism ℂ ⊗[ℚ(ζₙ)] W ≃ V (with ℂ viewed as a ℚ(ζₙ)-algebra via φ). The G-equivariance is expressed against the base-changed action `(σ g).baseChange ℂ`. Strictly stronger than the character-value statement `brauer_character_in_cyclotomic`, which follows by taking traces and is in fact elementary."
+source = "R. Brauer, On the representation of a group of order g in the field of g-th roots of unity, Amer. J. Math. 67 (1945), 461–471."
+informal_solution = "Pick any embedding φ : ℚ(ζₙ) ↪ ℂ. By Maschke's theorem ρ decomposes as a direct sum of irreducible complex representations, so it suffices to descend each irreducible ρᵢ separately. Brauer's induction theorem expresses the character of each ρᵢ as a ℤ-combination of characters induced from one-dimensional characters of elementary subgroups; these one-dimensional characters take values in ℚ(ζₙ), so each induced representation is realised on a ℚ(ζₙ)-module. The Schur index of each ρᵢ over ℚ(ζₙ) is therefore 1, meaning ρᵢ itself descends to ℚ(ζₙ): there exists a ℚ(ζₙ)[G]-module Wᵢ with ℂ ⊗_{ℚ(ζₙ)} Wᵢ ≃ Vᵢ as ℂ[G]-modules. Assemble the Wᵢ into W and the isomorphisms into f to conclude."


### PR DESCRIPTION
This PR adds `brauer_splitting_field`, stating Brauer's splitting field theorem: for a finite group `G` of exponent `n`, every finite-dimensional complex representation `(V, ρ)` of `G` descends to `ℚ(ζₙ)`. Concretely, there exists a ring embedding `φ : CyclotomicField n ℚ →+* ℂ`, a `ℚ(ζₙ)`-representation `(W, σ)` of `G`, and a `ℂ`-linear, `G`-equivariant isomorphism `ℂ ⊗[ℚ(ζₙ)] W ≃ V` (with `ℂ` viewed as a `ℚ(ζₙ)`-algebra via `φ`, and `G`-equivariance against `(σ g).baseChange ℂ`).

This is the genuine content of Brauer (1945), proved via his induction theorem. The previously stated `brauer_character_in_cyclotomic` (every complex character value lies in `φ.range`) is strictly weaker — and in fact elementary, since `ρ g ^ n = 1` makes `ρ g` diagonalisable with `n`-th-root-of-unity eigenvalues. Thanks to Kevin Buzzard for flagging the gap.

The existing `LeanEval/RepresentationTheory/BrauerSplittingField.lean` file (which despite the name held the weaker character-value statement) is renamed to `BrauerCharacterInCyclotomic.lean` so its name matches its theorem, freeing the original path for the new problem. The old manifest's `module` field is updated to match. No other change to the old problem in this PR — the question of what to do about it (delete vs retire) is separate.

🤖 Prepared with Claude Code