### PR TITLE
fix: namespace Mandelbrot.lean and FatouJulia.lean to avoid Tc/Mandelbrot collision

### DIFF
--- a/LeanEval/ComplexAnalysis/FatouJulia.lean
+++ b/LeanEval/ComplexAnalysis/FatouJulia.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace ComplexAnalysis
+namespace FatouJuliaProblem
 
 /-!
 # Fatou–Julia / Cantor dichotomy
@@ -42,5 +43,6 @@ theorem julia_cantor_dichotomy (c : ℂ) :
     (c ∉ Mandelbrot → Nonempty ((FilledJulia c) ≃ₜ (ℕ → Bool))) := by
   sorry
 
+end FatouJuliaProblem
 end ComplexAnalysis
 end LeanEval

--- a/LeanEval/ComplexAnalysis/Mandelbrot.lean
+++ b/LeanEval/ComplexAnalysis/Mandelbrot.lean
@@ -3,6 +3,7 @@ import EvalTools.Markers
 
 namespace LeanEval
 namespace ComplexAnalysis
+namespace MandelbrotProblem
 
 /-!
 # Mandelbrot set is connected (Douady–Hubbard)
@@ -27,5 +28,6 @@ def Mandelbrot : Set ℂ :=
 theorem mandelbrot_connected : IsConnected Mandelbrot := by
   sorry
 
+end MandelbrotProblem
 end ComplexAnalysis
 end LeanEval


### PR DESCRIPTION
Hotfix for `regenerate-main` failures on `origin/main`. Both `LeanEval/ComplexAnalysis/Mandelbrot.lean` and `LeanEval/ComplexAnalysis/FatouJulia.lean` defined `Tc` and `Mandelbrot` under the same `LeanEval.ComplexAnalysis` namespace, so the `eval_inventory` step fails with:

```
import LeanEval.ComplexAnalysis.Mandelbrot failed, environment already contains
'LeanEval.ComplexAnalysis.Tc' from LeanEval.ComplexAnalysis.FatouJulia
```

This breaks the `regenerate-main` workflow and the leaderboard's `Advance benchmark-snapshot` workflow, so the live site at https://lean-lang.org/eval is not deploying recent merges.

Fix: move each file's declarations into a sub-namespace (`MandelbrotProblem` and `FatouJuliaProblem` respectively). The `@[eval_problem]`-tagged theorems retain their basenames (`mandelbrot_connected`, `julia_cantor_dichotomy`), so the existing manifests resolve them correctly via `eval_inventory`'s basename match.

Verified locally with `lake env .lake/build/bin/eval_inventory LeanEval.ComplexAnalysis.Mandelbrot LeanEval.ComplexAnalysis.FatouJulia LeanEval.ComplexAnalysis.Mandelbar`:
- `mandelbrot_connected` → `LeanEval.ComplexAnalysis.MandelbrotProblem.mandelbrot_connected`
- `julia_cantor_dichotomy` → `LeanEval.ComplexAnalysis.FatouJuliaProblem.julia_cantor_dichotomy`
- `mandelbar_not_path_connected` → `LeanEval.ComplexAnalysis.mandelbar_not_path_connected` (unchanged)

Mandelbar.lean does not need namespacing because its declarations (`Tantibar`, `Mandelbar`) do not collide with the other two files.

🤖 Prepared with Claude