### PR TITLE
feat: add §84 Pell-solutions-are-convergents problem

### DIFF
--- a/LeanEval/NumberTheory/PellConvergent.lean
+++ b/LeanEval/NumberTheory/PellConvergent.lean
@@ -1,0 +1,46 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace NumberTheory
+
+/-!
+# Pell solutions are convergents of `√d`
+
+§84 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. Lagrange's
+theorem: if `d` is a positive squarefree integer and `(x, y)` is a positive
+solution of Pell's equation `x² − d y² = 1`, then `x / y` occurs as a
+convergent `pₙ / qₙ` of the regular continued fraction of `√d`, connecting the
+arithmetic of Pell solutions with the continued-fraction expansion of a
+quadratic irrational.
+
+mathlib has the Pell solution group (`Pell.Solution₁`, `Pell.IsFundamental`)
+and the continued-fraction algorithm `GenContFract.of` with its convergent
+stream `GenContFract.convs`, but no link between the two: there is no
+quadratic-irrational / eventually-periodic continued-fraction theory of `√d`,
+and nothing relating Pell solutions to convergents.
+
+Since `x² − d y² = 1` forces `gcd x y = 1`, and `convs n` is `pₙ / qₙ` in
+lowest terms, `convs n = x / y` is the faithful reading of "`(x, y)` is of the
+form `(pₙ, qₙ)`". For `d = 1` the hypotheses `0 < x`, `0 < y`, `x² − y² = 1`
+are unsatisfiable; the content lives at squarefree `d ≥ 2`, where `√d` is
+irrational and the continued fraction is infinite.
+-/
+
+open scoped Real
+
+/-- **Pell solutions are convergents of `√d`** (§84). Let `d` be a positive
+squarefree integer and let `(x, y)` be a positive solution of Pell's equation
+`x² − d y² = 1`. Then the ratio `x / y` is one of the convergents of the
+regular continued fraction of `√d`: there is an index `n` with
+`(GenContFract.of √d).convs n = x / y`. -/
+@[eval_problem]
+theorem pell_solution_is_convergent
+    (d : ℤ) (_hd : Squarefree d) (_hd0 : 0 < d)
+    (x y : ℤ) (_hx : 0 < x) (_hy : 0 < y)
+    (_hsol : x ^ 2 - d * y ^ 2 = 1) :
+    ∃ n : ℕ, (GenContFract.of (Real.sqrt (d : ℝ))).convs n = (x : ℝ) / (y : ℝ) := by
+  sorry
+
+end NumberTheory
+end LeanEval

--- a/manifests/problems/pell_solution_convergent.toml
+++ b/manifests/problems/pell_solution_convergent.toml
@@ -1,0 +1,9 @@
+id = "pell_solution_convergent"
+title = "Pell solutions are convergents of √d"
+test = false
+module = "LeanEval.NumberTheory.PellConvergent"
+holes = ["pell_solution_is_convergent"]
+submitter = "Kim Morrison"
+notes = "§84 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. Lagrange's theorem: if d is a positive squarefree integer and (x, y) is a positive solution of Pell's equation x² − d y² = 1, then x/y occurs as a convergent of the regular continued fraction of √d, connecting the arithmetic of Pell solutions with the continued-fraction expansion of a quadratic irrational. Mathlib has APIs for Pell solutions (Pell.Solution₁) and for continued fractions (GenContFract.of, GenContFract.convs) but currently lacks any theorem relating positive Pell solutions to convergents of √d."
+source = "J.-L. Lagrange (1770). Listed as §84 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Expand √d as a regular continued fraction; for squarefree d ≥ 2 this is infinite with convergents pₙ/qₙ satisfying |pₙ² − d qₙ²| < 1 + 2√d, so the values pₙ² − d qₙ² are bounded and some value v is attained infinitely often. A positive Pell solution (x, y) with x² − d y² = 1 is a best rational approximation of √d from the relevant side: |x/y − √d| < 1/(2y²), and by Legendre's theorem (mathlib's Real.exists_convs_eq_rat-style best-approximation criterion) any rational p/q in lowest terms with |p/q − √d| < 1/(2q²) is a convergent of √d. Since x² − d y² = 1 gives gcd x y = 1 and the required approximation bound, x/y = convs n for some n."


### PR DESCRIPTION
This PR adds a benchmark problem for §84 of Knill's *Some Fundamental Theorems in Mathematics*: Lagrange's theorem that for a positive squarefree integer `d`, every positive solution `(x, y)` of Pell's equation `x² − d y² = 1` has ratio `x / y` equal to a convergent of the regular continued fraction of `√d`. The statement uses only off-the-shelf mathlib (`Pell.Solution₁`, `GenContFract.of`, `GenContFract.convs`); since `x² − d y² = 1` forces `gcd x y = 1`, equality of the convergent with `x / y` is the faithful reading. mathlib has the Pell solution group and the continued-fraction algorithm but no theorem linking the two.

The formalization was independently reviewed for faithfulness (quantifier scope, hypothesis strength, degenerate cases) before submission.

🤖 Prepared with Claude Code