### PR TITLE
feat: add §137 Bourbaki locally-convex Banach–Alaoglu problem

### DIFF
--- a/LeanEval/Analysis/BanachAlaoglu.lean
+++ b/LeanEval/Analysis/BanachAlaoglu.lean
@@ -1,0 +1,42 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+# Bourbaki's locally convex extension of Banach–Alaoglu
+
+§137 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. The classical
+Banach–Alaoglu theorem — the closed unit ball of the dual of a Banach space is
+weak-star compact — is already in mathlib (`WeakDual.isCompact_closedBall`).
+Bourbaki's extension drops the norm: for any real locally convex topological
+vector space `E`, the weak-star polar of a neighbourhood of `0` is compact in
+the weak dual, extending the statement from closed dual balls to polars of
+zero-neighbourhoods in arbitrary locally convex spaces.
+
+mathlib has the normed-space results `WeakDual.isCompact_closedBall` and
+`WeakDual.isCompact_polar`, but no corresponding compactness theorem for general
+locally convex spaces.
+-/
+
+open Set Topology
+
+/-- The weak-star polar of a subset `s` of a real locally convex space `E`:
+the continuous functionals `φ` with `‖φ x‖ ≤ 1` for every `x ∈ s`. -/
+def weakStarPolar (E : Type*) [AddCommGroup E] [Module ℝ E] [TopologicalSpace E]
+    [ContinuousAdd E] [ContinuousSMul ℝ E] (s : Set E) : Set (WeakDual ℝ E) :=
+  {φ | ∀ x ∈ s, ‖φ x‖ ≤ 1}
+
+/-- **Bourbaki's locally convex extension of Banach–Alaoglu** (§137). The
+weak-star polar of a zero-neighbourhood `U` in a real locally convex space `E`
+is weak-star compact. -/
+@[eval_problem]
+theorem banach_alaoglu_bourbaki (E : Type*) [AddCommGroup E] [Module ℝ E]
+    [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E]
+    [LocallyConvexSpace ℝ E] (U : Set E) (_hU : U ∈ 𝓝 (0 : E)) :
+    IsCompact (weakStarPolar E U) := by
+  sorry
+
+end Analysis
+end LeanEval

--- a/manifests/problems/banach_alaoglu_bourbaki.toml
+++ b/manifests/problems/banach_alaoglu_bourbaki.toml
@@ -1,0 +1,9 @@
+id = "banach_alaoglu_bourbaki"
+title = "Bourbaki's locally convex extension of Banach–Alaoglu"
+test = false
+module = "LeanEval.Analysis.BanachAlaoglu"
+holes = ["banach_alaoglu_bourbaki"]
+submitter = "Kim Morrison"
+notes = "§137 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. Bourbaki's locally convex Banach–Alaoglu theorem states that, for any real locally convex topological vector space E, the weak-star polar of a neighbourhood of 0 is compact in the weak dual. This extends the familiar normed-space Banach–Alaoglu theorem from closed dual balls to polars of zero-neighbourhoods in arbitrary locally convex spaces. Mathlib currently has the normed-space results WeakDual.isCompact_closedBall and WeakDual.isCompact_polar, but no corresponding compactness theorem for general locally convex spaces."
+source = "N. Bourbaki, Espaces vectoriels topologiques; the normed case is L. Alaoglu, Ann. of Math. 41 (1940). Listed as §137 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Realise each functional φ ∈ WeakDual ℝ E by its restriction to the neighbourhood U, embedding the polar into the product ∏_{x ∈ U} [−1, 1] (φ ↦ (φ x)). The polar maps into this product because |φ x| ≤ 1 on U; by Tychonoff the product is compact. The image is closed: the conditions ‖φ x‖ ≤ 1 (closed) and linearity/continuity of φ (preserved under pointwise limits, using that U absorbs E so a pointwise limit of equicontinuous functionals is again continuous and linear) are closed in the product topology, which coincides with the weak-star topology on the polar. Hence the polar is a closed subset of a compact space, so compact."


### PR DESCRIPTION
This PR adds a benchmark problem for §137 of Knill's *Some Fundamental Theorems in Mathematics*: Bourbaki's locally convex extension of Banach–Alaoglu. For any real locally convex topological vector space `E`, the weak-star polar of a neighbourhood of `0` is compact in the weak dual — extending the classical normed-space statement from closed dual balls to polars of zero-neighbourhoods. mathlib has the normed-space results `WeakDual.isCompact_closedBall` and `WeakDual.isCompact_polar`, but no compactness theorem for general locally convex spaces. The polar is provided as a small helper definition `weakStarPolar`, which matches mathlib's `WeakDual.polar` over real scalars.

The formalization was independently reviewed for faithfulness (the polar definition, hypothesis choice, degenerate cases) before submission.

🤖 Prepared with Claude Code