### PR TITLE
feat: add §44 Euler–Lagrange equation problem

### DIFF
--- a/LeanEval/Analysis/EulerLagrange.lean
+++ b/LeanEval/Analysis/EulerLagrange.lean
@@ -1,0 +1,67 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+# Euler–Lagrange equation
+
+§44 of Oliver Knill's *Some Fundamental Theorems in Mathematics* (the additional
+statement of the calculus-of-variations section). A sufficiently regular
+stationary path `x` of the action `I(y) = ∫_a^b L(t, y(t), y'(t)) dt` satisfies
+the Euler–Lagrange equation `∂L/∂x = (d/dt)(∂L/∂x')` pointwise on `(a, b)`.
+
+mathlib has the fundamental lemma of the calculus of variations
+(`IsOpen.ae_eq_zero_of_integral_contDiff_smul_eq_zero` and neighbours), but it
+has no notion of a variational extremum of an action functional and no
+Euler–Lagrange theorem (`grep -i 'euler.*lagrange'` in mathlib finds nothing in
+the analytic sense). Here a path is a variational extremum when the first
+variation of the action vanishes against every smooth compactly supported
+perturbation, and the conclusion is the classical pointwise equation for `C²`
+data.
+-/
+
+open MeasureTheory Set
+open scoped ContDiff
+
+/-- `∂L/∂x` along the path `x` at time `t`: the derivative of the partial map
+`y ↦ L t y (x' t)` at `y = x t`. -/
+noncomputable def lagrangianPartialX
+    (L : ℝ → ℝ → ℝ → ℝ) (x : ℝ → ℝ) (t : ℝ) : ℝ :=
+  deriv (fun y => L t y (deriv x t)) (x t)
+
+/-- `∂L/∂x'` along the path `x` at time `t`: the derivative of the partial map
+`z ↦ L t (x t) z` at `z = x' t`. -/
+noncomputable def lagrangianPartialV
+    (L : ℝ → ℝ → ℝ → ℝ) (x : ℝ → ℝ) (t : ℝ) : ℝ :=
+  deriv (fun z => L t (x t) z) (deriv x t)
+
+/-- A `C¹` path `x : ℝ → ℝ` is a **variational extremum** of the action
+`I(y) := ∫_a^b L(t, y(t), y'(t)) dt` on `(a, b)` if for every smooth compactly
+supported variation `h` with `tsupport h ⊆ (a, b)`, the first variation
+`d/dε|_{ε=0} ∫_a^b L(t, x(t) + ε h(t), x'(t) + ε h'(t)) dt` vanishes. -/
+def IsVariationalExtremum
+    (a b : ℝ) (L : ℝ → ℝ → ℝ → ℝ) (x : ℝ → ℝ) : Prop :=
+  ContDiff ℝ 1 x ∧
+  ∀ h : ℝ → ℝ, ContDiff ℝ ∞ h → HasCompactSupport h →
+    tsupport h ⊆ Set.Ioo a b →
+    deriv (fun ε : ℝ => ∫ t in Set.Ioo a b,
+        L t (x t + ε * h t) (deriv x t + ε * deriv h t)) 0 = 0
+
+/-- **Euler–Lagrange equation** (§44). On an interval `a < b`, every `C²`
+variational extremum `x` of the action `I(y) = ∫_a^b L(t, y(t), y'(t)) dt`, with
+`C²` Lagrangian `L`, satisfies the pointwise equation
+`∂L/∂x (t, x(t), x'(t)) = (d/dt)(∂L/∂x' (t, x(t), x'(t)))` on `(a, b)`. -/
+@[eval_problem]
+theorem euler_lagrange_equation
+    {a b : ℝ} (L : ℝ → ℝ → ℝ → ℝ) (x : ℝ → ℝ) (_hab : a < b)
+    (_hL : ContDiff ℝ 2 (fun p : ℝ × ℝ × ℝ => L p.1 p.2.1 p.2.2))
+    (_hx : ContDiff ℝ 2 x)
+    (_hxe : IsVariationalExtremum a b L x) :
+    ∀ t ∈ Set.Ioo a b,
+      lagrangianPartialX L x t = deriv (lagrangianPartialV L x) t := by
+  sorry
+
+end Analysis
+end LeanEval

--- a/manifests/problems/euler_lagrange_equation.toml
+++ b/manifests/problems/euler_lagrange_equation.toml
@@ -1,0 +1,9 @@
+id = "euler_lagrange_equation"
+title = "Euler–Lagrange equation"
+test = false
+module = "LeanEval.Analysis.EulerLagrange"
+holes = ["euler_lagrange_equation"]
+submitter = "Kim Morrison"
+notes = "§44 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. The Euler–Lagrange equation: a sufficiently regular stationary path x of the action I(y) = ∫_a^b L(t, y(t), y'(t)) dt satisfies ∂L/∂x = (d/dt)(∂L/∂x') pointwise on the open interval (a, b). Stationarity is expressed as the first variation of the action vanishing against every smooth compactly supported perturbation inside (a, b). It is the central necessary condition of the calculus of variations. mathlib has related ingredients such as the fundamental lemma of the calculus of variations, but no bundled action-functional extremum notion and no Euler–Lagrange theorem."
+source = "L. Euler (1744) and J.-L. Lagrange (1755). Listed as §44 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Let h be a smooth variation with compact support in (a, b). Differentiating I(x + ε h) under the integral at ε = 0 gives the first variation ∫_a^b (∂L/∂x · h + ∂L/∂x' · h') dt, which vanishes for all such h since x is a variational extremum. Integrate the second term by parts; the boundary terms vanish because h is compactly supported in (a, b), leaving ∫_a^b (∂L/∂x − d/dt(∂L/∂x')) h dt = 0 for all h. By the fundamental lemma of the calculus of variations the continuous factor ∂L/∂x − d/dt(∂L/∂x') is identically zero on (a, b), which is the Euler–Lagrange equation. C² regularity of L and x makes ∂L/∂x' differentiable in t so the integration by parts and the d/dt term are justified."


### PR DESCRIPTION
This PR adds a benchmark problem for §44 of Knill's *Some Fundamental Theorems in Mathematics*: the Euler–Lagrange equation. On an interval `a < b`, a `C²` stationary path `x` of the action `I(y) = ∫_a^b L(t, y(t), y'(t)) dt` satisfies `∂L/∂x = (d/dt)(∂L/∂x')` pointwise on `(a, b)`. Stationarity is expressed as the first variation of the action vanishing against every smooth compactly supported perturbation inside the interval. mathlib has the fundamental lemma of the calculus of variations but no bundled action-functional extremum notion and no Euler–Lagrange theorem. The supporting notions are provided as small helper definitions (`lagrangianPartialX`, `lagrangianPartialV`, `IsVariationalExtremum`).

The formalization was independently reviewed for faithfulness; the review prompted adding `a < b` to exclude the empty-interval degenerate case and clarifying the "stationary/critical path" reading of the extremum hypothesis.

🤖 Prepared with Claude Code