### PR TITLE
feat: add §66 Wiener atom-detection problem

### DIFF
--- a/LeanEval/Analysis/WienerAtom.lean
+++ b/LeanEval/Analysis/WienerAtom.lean
@@ -1,0 +1,52 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+# Wiener's atom-detection formula
+
+§66 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. For a
+probability measure `μ` on the circle `𝕋 = ℝ/2πℤ` with Fourier coefficients
+`μ̂_k = ∫ e^{ikx} dμ(x)`, the Cesàro average of `|μ̂_k|²` converges to the sum of
+the squared masses of the atoms of `μ`:
+`lim_{N→∞} (1/N) ∑_{k=1}^{N} |μ̂_k|² = ∑_{x} μ({x})²`.
+The Cesàro average of squared Fourier moduli detects exactly the pure-point part
+of `μ`.
+
+mathlib provides `AddCircle`, the Fourier characters `fourier`, and related
+Fourier theory for functions, but it does not package Fourier coefficients of
+measures or this Wiener atom-detection theorem (`grep -rn 'Wiener' Mathlib/`
+finds no result on `lim (1/N) ∑ |μ̂_k|²` for measures on the circle). The
+one-line measure coefficient `fourierCoeffMeasure μ k := ∫ x, fourier k x ∂μ` is
+supplied here.
+-/
+
+open MeasureTheory Filter Topology Real Complex
+
+/-- The `k`-th Fourier coefficient of a Borel measure `μ` on the circle
+`AddCircle (2π)`: `μ̂_k := ∫ exp(i k x) dμ(x)`. With mathlib's normalisation
+`fourier k x = exp(2π i k x / T)`, taking `T = 2π` gives `exp(i k x)`. -/
+noncomputable def fourierCoeffMeasure (μ : Measure (AddCircle (2 * Real.pi)))
+    (k : ℤ) : ℂ :=
+  ∫ x, fourier k x ∂μ
+
+/-- **Wiener's atom-detection formula** (§66). For a probability measure `μ` on
+the circle `𝕋 = ℝ/2πℤ`, the Cesàro average of `|μ̂_k|²` for `k = 1, …, N`
+converges to the sum of the squared masses of the atoms of `μ`. The right-hand
+side is automatically summable: the atoms of a finite measure are at most
+countable and their masses are bounded by `μ(𝕋) = 1`. -/
+@[eval_problem]
+theorem wiener_atom_detection
+    (μ : Measure (AddCircle (2 * Real.pi))) [IsProbabilityMeasure μ] :
+    Tendsto
+      (fun N : ℕ =>
+        (1 / (N : ℝ)) *
+          ∑ k ∈ Finset.Icc (1 : ℤ) N, ‖fourierCoeffMeasure μ k‖ ^ 2)
+      atTop
+      (𝓝 (∑' x : AddCircle (2 * Real.pi), ((μ {x}).toReal) ^ 2)) := by
+  sorry
+
+end Analysis
+end LeanEval

--- a/manifests/problems/wiener_atom_detection.toml
+++ b/manifests/problems/wiener_atom_detection.toml
@@ -1,0 +1,9 @@
+id = "wiener_atom_detection"
+title = "Wiener's atom-detection formula"
+test = false
+module = "LeanEval.Analysis.WienerAtom"
+holes = ["wiener_atom_detection"]
+submitter = "Kim Morrison"
+notes = "§66 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. Wiener's atom-detection formula states that for a probability measure μ on the circle ℝ/2πℤ, the Cesàro averages (1/N) ∑_{k=1}^N |μ̂_k|² of the squared Fourier coefficients converge to ∑_x μ({x})², the total squared mass of the atoms. Thus the asymptotic behavior of the Fourier coefficients detects exactly the pure-point part of the measure. Mathlib provides AddCircle, the Fourier characters fourier, and related Fourier theory for functions, but it does not currently package Fourier coefficients of measures or this Wiener atom-detection theorem."
+source = "N. Wiener, The Fourier Integral and Certain of its Applications (1933). Listed as §66 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Expand |μ̂_k|² = μ̂_k · conj(μ̂_k) = ∫∫ e^{ik(x−y)} dμ(x) dμ(y) by Fubini. Averaging over k = 1, …, N gives (1/N) ∑_{k=1}^N |μ̂_k|² = ∫∫ D_N(x−y) dμ(x) dμ(y), where D_N(t) = (1/N) ∑_{k=1}^N e^{ikt} is a Cesàro/Fejér-type kernel with |D_N| ≤ 1 and D_N(t) → 1 if t = 0 and → 0 if t ≠ 0. By dominated convergence (against the finite product measure μ × μ) the double integral converges to (μ × μ){(x, y) : x = y} = ∑_x μ({x})², the mass the diagonal carries, which is exactly the sum of squared atomic masses. The right-hand side is summable because the atoms of a finite measure are at most countable with masses bounded by μ(𝕋) = 1."


### PR DESCRIPTION
This PR adds a benchmark problem for §66 of Knill's *Some Fundamental Theorems in Mathematics*: Wiener's atom-detection formula. For a probability measure `μ` on the circle `ℝ/2πℤ`, the Cesàro averages `(1/N) ∑_{k=1}^N |μ̂_k|²` of the squared Fourier coefficients converge to `∑_x μ({x})²`, the total squared mass of the atoms — so the asymptotics of the Fourier coefficients detect exactly the pure-point part of `μ`. mathlib has `AddCircle`, the Fourier characters, and Fourier theory for functions, but does not package Fourier coefficients of measures or this theorem; the one-line coefficient `fourierCoeffMeasure μ k := ∫ x, fourier k x ∂μ` is supplied as a helper.

The formalization was independently reviewed for faithfulness (the measure-coefficient convention, frequency range, and atom-mass target) before submission.

🤖 Prepared with Claude Code