### PR TITLE
feat: add §46 Fourier convergence problem (Dirichlet, Fejér)

### DIFF
--- a/LeanEval/Analysis/FourierConvergence.lean
+++ b/LeanEval/Analysis/FourierConvergence.lean
@@ -1,0 +1,63 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+# Pointwise and Cesàro convergence of Fourier series
+
+§46 of Oliver Knill's *Some Fundamental Theorems in Mathematics*.
+
+* **Dirichlet's pointwise convergence theorem** (main): for a `C¹` 2π-periodic
+  complex function `f`, the symmetric Fourier partial sums
+  `S_N(f)(x) = ∑_{n = -N}^{N} f̂_n e^{inx}` converge to `f(x)` at every `x ∈ ℝ`.
+* **Fejér's theorem** (additional): for a merely *continuous* 2π-periodic `f`,
+  the Cesàro means `σ_N(f) = (S_0 + ⋯ + S_N)/(N+1)` of the partial sums converge
+  to `f` uniformly on `ℝ`.
+
+mathlib has the circle, the Fourier characters, `fourierCoeffOn`, the `L²`
+Fourier series, and uniform convergence under `ℓ¹`-summability
+(`hasSum_fourier_series_of_summable`). It has neither the Dirichlet kernel nor
+the statement that `C¹` forces pointwise convergence of the symmetric partial
+sums — the `C¹` bound `|f̂_n| ≤ C/n` is not `ℓ¹`-summable, so the summable case
+does not apply — and it has no Fejér kernel, Cesàro means, or Fejér theorem. The
+symmetric partial-sum order `Finset.Icc (-N) N` is essential, since the Fourier
+series of a `C¹` function need not converge absolutely.
+-/
+
+open Filter Topology
+
+/-- The symmetric Fourier partial sum of `f : ℝ → ℂ` on the period `[0, 2π]`:
+`S_N(f)(x) = ∑_{n = -N}^{N} f̂_n · e^{inx}`, with `f̂_n = fourierCoeffOn _ f n`. -/
+noncomputable def fourierPartialSum (f : ℝ → ℂ) (N : ℕ) (x : ℝ) : ℂ :=
+  ∑ n ∈ Finset.Icc (-(N : ℤ)) N,
+    fourierCoeffOn Real.two_pi_pos f n * Complex.exp (Complex.I * (n : ℂ) * (x : ℂ))
+
+/-- The Cesàro mean of the first `N + 1` Fourier partial sums:
+`σ_N(f)(x) = (S_0(f)(x) + S_1(f)(x) + ⋯ + S_N(f)(x)) / (N + 1)`. -/
+noncomputable def fourierCesaroMean (f : ℝ → ℂ) (N : ℕ) (x : ℝ) : ℂ :=
+  (∑ k ∈ Finset.range (N + 1), fourierPartialSum f k x) / (N + 1 : ℂ)
+
+/-- **Dirichlet's pointwise convergence theorem** (§46). For every `C¹`
+2π-periodic complex function `f`, the symmetric Fourier partial sums `S_N(f)(x)`
+converge to `f(x)` at every point `x ∈ ℝ`. -/
+@[eval_problem]
+theorem dirichlet_pointwise
+    {f : ℝ → ℂ} (_hperiod : Function.Periodic f (2 * Real.pi)) (_hC1 : ContDiff ℝ 1 f)
+    (x : ℝ) :
+    Tendsto (fun N : ℕ => fourierPartialSum f N x) atTop (𝓝 (f x)) := by
+  sorry
+
+/-- **Fejér's theorem** (§46). For every *continuous* 2π-periodic complex
+function `f` — without the `C¹` hypothesis of Dirichlet's theorem — the Cesàro
+means `σ_N(f)` of the symmetric Fourier partial sums converge to `f` uniformly
+on `ℝ`. -/
+@[eval_problem]
+theorem fejer
+    {f : ℝ → ℂ} (_hperiod : Function.Periodic f (2 * Real.pi)) (_hcont : Continuous f) :
+    TendstoUniformly (fun N : ℕ => fourierCesaroMean f N) f atTop := by
+  sorry
+
+end Analysis
+end LeanEval

--- a/manifests/problems/fourier_dirichlet_fejer.toml
+++ b/manifests/problems/fourier_dirichlet_fejer.toml
@@ -1,0 +1,9 @@
+id = "fourier_dirichlet_fejer"
+title = "Pointwise and Cesàro convergence of Fourier series (Dirichlet, Fejér)"
+test = false
+module = "LeanEval.Analysis.FourierConvergence"
+holes = ["dirichlet_pointwise", "fejer"]
+submitter = "Kim Morrison"
+notes = "§46 of Oliver Knill's 'Some Fundamental Theorems in Mathematics' records two Fourier convergence theorems for complex-valued 2π-periodic functions. Dirichlet's theorem says that if f is C¹, the symmetric Fourier partial sums S_N(f)(x) = ∑_{n=-N}^N f̂_n e^{inx} converge pointwise to f(x). Fejér's theorem says that if f is merely continuous, the Cesàro means (S_0 + ⋯ + S_N)/(N+1) converge uniformly to f. Mathlib has Fourier coefficients, Fourier characters, L² Fourier theory, and uniform convergence from summable coefficients (the C¹ bound |f̂_n| ≤ C/n is not ℓ¹-summable, so that route does not apply), but not the Dirichlet-kernel pointwise theorem, Fejér kernels/Cesàro means, or Fejér's theorem."
+source = "P. G. L. Dirichlet (1829) and L. Fejér (1900). Listed as §46 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "Dirichlet: write S_N(f)(x) = (1/2π) ∫ f(x−t) D_N(t) dt with the Dirichlet kernel D_N(t) = ∑_{n=−N}^N e^{int} = sin((N+½)t)/sin(t/2). Then S_N(f)(x) − f(x) = (1/2π) ∫ (f(x−t) − f(x)) D_N(t) dt; for C¹ f the difference quotient (f(x−t)−f(x))/sin(t/2) is bounded and integrable, so by the Riemann–Lebesgue lemma the integral against sin((N+½)t) tends to 0. Fejér: the Cesàro means satisfy σ_N(f)(x) = (1/2π) ∫ f(x−t) F_N(t) dt with the Fejér kernel F_N(t) = (1/(N+1)) (sin((N+1)t/2)/sin(t/2))², which is a nonnegative approximate identity (F_N ≥ 0, total mass 1, mass concentrating at 0). Convolution of a continuous (hence uniformly continuous) periodic f with an approximate identity converges uniformly, giving σ_N(f) → f uniformly."


### PR DESCRIPTION
This PR adds a benchmark problem for §46 of Knill's *Some Fundamental Theorems in Mathematics*, bundling two Fourier convergence theorems for `2π`-periodic complex functions. Dirichlet's theorem: for `C¹` `f`, the symmetric Fourier partial sums `S_N(f)(x) = ∑_{n=-N}^N f̂_n e^{inx}` converge pointwise to `f(x)`. Fejér's theorem: for merely continuous `f`, the Cesàro means `(S_0 + ⋯ + S_N)/(N+1)` converge uniformly to `f`. mathlib has Fourier coefficients, the `L²` Fourier series, and uniform convergence from `ℓ¹`-summable coefficients (which the `C¹` bound `|f̂_n| ≤ C/n` does not provide), but neither the Dirichlet-kernel pointwise theorem nor any Fejér kernel, Cesàro means, or Fejér theorem. The symmetric partial sum and Cesàro mean are supplied as helper definitions.

This is based on the extractor fix in #368 (its `noncomputable` summation helpers need that fix to generate a buildable workspace); it will retarget to `main` once #368 merges.

The formalization was independently reviewed for faithfulness (the symmetric partial-sum convention, the dropped `C¹` hypothesis in Fejér, uniform vs pointwise convergence) before submission.

🤖 Prepared with Claude Code