### PR TITLE
feat: add §73 Monge–Kantorovich existence problem

### DIFF
--- a/LeanEval/Analysis/OptimalTransport.lean
+++ b/LeanEval/Analysis/OptimalTransport.lean
@@ -1,0 +1,56 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+# Monge–Kantorovich existence theorem
+
+§73 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. Given Polish
+probability spaces `(X, P)` and `(Y, Q)` and a continuous cost
+`c : X × Y → [0, ∞]`, the Kantorovich functional `I(π) = ∫ c dπ` attains its
+infimum on the set of couplings `Π(P, Q)` — the probability measures on `X × Y`
+with marginals `P` and `Q` (Kantorovich 1942, after Monge 1781).
+
+mathlib has Polish spaces, marginals (`Measure.fst`, `Measure.snd`), the
+weak-convergence topology, Prokhorov's theorem, lower semicontinuity, and the
+extreme-value theorem, but no optimal-transport content: no couplings, no
+Kantorovich functional, and no existence of an optimal coupling
+(`grep -ri "kantorovich\|monge\|wasserstein\|coupling"` in mathlib returns no
+algorithmic content). The couplings and the functional are supplied as helper
+definitions here.
+-/
+
+open MeasureTheory Set
+
+/-- `Couplings P Q`: the probability measures on `X × Y` whose marginals are `P`
+on `X` and `Q` on `Y`. -/
+def Couplings {X Y : Type*} [MeasurableSpace X] [MeasurableSpace Y]
+    (P : Measure X) (Q : Measure Y) : Set (Measure (X × Y)) :=
+  {π | IsProbabilityMeasure π ∧ π.fst = P ∧ π.snd = Q}
+
+/-- The Kantorovich functional `I(π) = ∫ c dπ` on measures over `X × Y`. -/
+noncomputable def kantorovichCost {X Y : Type*}
+    [MeasurableSpace X] [MeasurableSpace Y]
+    (c : X × Y → ENNReal) (π : Measure (X × Y)) : ENNReal :=
+  ∫⁻ p, c p ∂π
+
+/-- **Monge–Kantorovich existence theorem** (§73). For Polish probability spaces
+`(X, P)` and `(Y, Q)` and a continuous cost `c : X × Y → [0, ∞]`, the Kantorovich
+functional `I(π) = ∫ c dπ` attains its infimum on the set of couplings `Π(P, Q)`
+of `P` and `Q`. -/
+@[eval_problem]
+theorem monge_kantorovich_exists
+    {X Y : Type*}
+    [TopologicalSpace X] [PolishSpace X] [MeasurableSpace X] [BorelSpace X]
+    [TopologicalSpace Y] [PolishSpace Y] [MeasurableSpace Y] [BorelSpace Y]
+    (P : Measure X) (Q : Measure Y)
+    [IsProbabilityMeasure P] [IsProbabilityMeasure Q]
+    (c : X × Y → ENNReal) (_hc : Continuous c) :
+    ∃ π ∈ Couplings P Q,
+      ∀ π' ∈ Couplings P Q, kantorovichCost c π ≤ kantorovichCost c π' := by
+  sorry
+
+end Analysis
+end LeanEval

--- a/manifests/problems/monge_kantorovich.toml
+++ b/manifests/problems/monge_kantorovich.toml
@@ -1,0 +1,9 @@
+id = "monge_kantorovich"
+title = "Monge–Kantorovich existence theorem"
+test = false
+module = "LeanEval.Analysis.OptimalTransport"
+holes = ["monge_kantorovich_exists"]
+submitter = "Kim Morrison"
+notes = "§73 of Oliver Knill's 'Some Fundamental Theorems in Mathematics'. The Monge–Kantorovich existence theorem states that for Polish probability spaces (X, P) and (Y, Q) and a continuous cost c : X × Y → [0, ∞], the functional π ↦ ∫ c dπ attains its minimum over all couplings of P and Q (the probability measures on X × Y with marginals P and Q). This is the basic existence result for optimal transport plans. Mathlib has the surrounding measure-theoretic and topological infrastructure — marginals, probability measures, weak convergence, Prokhorov-type compactness — but no dedicated coupling or Kantorovich-cost API and no theorem asserting existence of an optimal coupling."
+source = "L. V. Kantorovich (1942), after G. Monge (1781). Listed as §73 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf)."
+informal_solution = "The set of couplings Π(P, Q) is nonempty (the product measure P ⊗ Q is a coupling), and it is tight and weakly closed: each marginal P, Q is tight by Prokhorov on a Polish space, tightness of the marginals gives tightness of the couplings, and the marginal constraints π.fst = P, π.snd = Q are preserved under weak limits, so by Prokhorov's theorem Π(P, Q) is weakly compact. The Kantorovich functional π ↦ ∫ c dπ is weakly lower semicontinuous because c is continuous and nonnegative (write c as an increasing limit of bounded continuous functions and use the portmanteau characterisation). A lower semicontinuous function on a (nonempty) compact set attains its infimum, giving an optimal coupling."


### PR DESCRIPTION
This PR adds a benchmark problem for §73 of Knill's *Some Fundamental Theorems in Mathematics*: the Monge–Kantorovich existence theorem. For Polish probability spaces `(X, P)` and `(Y, Q)` and a continuous cost `c : X × Y → [0, ∞]`, the functional `π ↦ ∫ c dπ` attains its minimum over all couplings of `P` and `Q` — the basic existence result for optimal transport plans. mathlib has the surrounding measure-theoretic and topological infrastructure (marginals, probability measures, weak convergence, Prokhorov-type compactness) but no dedicated coupling or Kantorovich-cost API and no existence theorem for an optimal coupling. The couplings and the cost functional are supplied as helper definitions.

The formalization was independently reviewed for faithfulness (the marginal constraints, genuine attainment of the minimum, and non-vacuity of the coupling set) before submission.

🤖 Prepared with Claude Code