### PR TITLE
feat: add Martinet totally real towers eval problem

### DIFF
--- a/LeanEval/NumberTheory/MartinetTotallyRealTowers.lean
+++ b/LeanEval/NumberTheory/MartinetTotallyRealTowers.lean
@@ -1,0 +1,47 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace NumberTheory
+
+/-!
+# Martinet's asymptotically-good totally real towers
+
+`exists_totallyReal_discr_le` is Theorem 3.2 of
+
+> T. F. Bloom, W. Sawin, C. Schildkraut, D. Zhelezov,
+> *The sum-product conjecture is false for real numbers*, `arXiv:2605.28781`,
+
+which is the sole classical input their formalization takes as an axiom (see
+`SumProduct.exists_totallyReal_discr_le` in
+<https://github.com/mathlib-initiative/sum_product>). The underlying result is
+Martinet's construction (1978) of asymptotically-good totally real towers — a
+family of totally real number fields of growing degree with bounded root
+discriminant — obtained from class field theory (Golod–Shafarevich towers).
+It is not currently available in Mathlib.
+
+A bounded root discriminant `rd_K = |Δ_K|^{1/d} ≤ C` is exactly the statement
+that `|Δ_K| ≤ C ^ d`, so the bound below captures Martinet's theorem in the
+form used by the sum-product argument. "Infinitely many degrees `d`" is the
+cofinal form `∀ N, ∃ d ≥ N`.
+-/
+
+open NumberField
+
+/-- **Theorem 3.2 (Martinet).**
+
+There is an absolute constant `C > 0` such that for infinitely many degrees `d`
+there is a totally real number field `K` of degree `d` over `ℚ` whose
+discriminant satisfies `|Δ_K| ≤ C ^ d`.
+
+"Infinitely many `d`" is expressed as: for every `N` there is a degree `d ≥ N`
+that works. -/
+@[eval_problem]
+theorem exists_totallyReal_discr_le :
+    ∃ C : ℝ, 0 < C ∧ ∀ N : ℕ, ∃ d : ℕ, N ≤ d ∧
+      ∃ (K : Type) (_ : Field K) (_ : NumberField K) (_ : NumberField.IsTotallyReal K),
+        Module.finrank ℚ K = d ∧ |(NumberField.discr K : ℝ)| ≤ C ^ d := by
+  sorry
+
+end NumberTheory
+end LeanEval

--- a/manifests/problems/martinet_totally_real_towers.toml
+++ b/manifests/problems/martinet_totally_real_towers.toml
@@ -1,0 +1,9 @@
+id = "martinet_totally_real_towers"
+title = "Martinet's asymptotically-good totally real towers"
+test = false
+module = "LeanEval.NumberTheory.MartinetTotallyRealTowers"
+holes = ["exists_totallyReal_discr_le"]
+submitter = "Kim Morrison"
+notes = "There is an absolute C > 0 such that for infinitely many degrees d there is a totally real number field K of degree d over ℚ with |Δ_K| ≤ C^d, i.e. a family of totally real fields of growing degree with bounded root discriminant rd_K = |Δ_K|^{1/d} ≤ C. This is the sole classical input taken as an axiom in the sum_product formalization of Bloom–Sawin–Schildkraut–Zhelezov's refutation of the sum-product conjecture over ℝ (SumProduct.exists_totallyReal_discr_le). Removing it would require formalizing Martinet's tower construction (asymptotically-good totally real towers from class field theory / Golod–Shafarevich), not currently in Mathlib. The statement was reviewed for faithfulness against arXiv:2605.28781 Theorem 3.2."
+source = "Theorem 3.2 of T. F. Bloom, W. Sawin, C. Schildkraut, D. Zhelezov, *The sum-product conjecture is false for real numbers*, arXiv:2605.28781. Lean axiom: https://github.com/mathlib-initiative/sum_product (SumProduct.exists_totallyReal_discr_le). Underlying result: J. Martinet, *Tours de corps de classes et estimations de discriminants*, Invent. Math. 44 (1978), 65–73."
+informal_solution = "Build asymptotically-good totally real towers via class field theory. Following Hajir–Maire / Martinet: start from a totally real base field admitting an infinite unramified pro-p tower (kept infinite by Golod–Shafarevich, r(G) > d(G)²/4 forcing the maximal unramified pro-p Galois group to be infinite), so the tower fields have constant root discriminant; pick a cofinal sequence of degrees d and take K to be the corresponding tower field, whose discriminant satisfies |Δ_K| = rd^d ≤ C^d for the absolute constant C = rd."


### PR DESCRIPTION
This PR adds Theorem 3.2 of Bloom–Sawin–Schildkraut–Zhelezov, *The sum-product conjecture is false for real numbers* ([arXiv:2605.28781](https://arxiv.org/abs/2605.28781)), as an eval problem: there is an absolute constant `C > 0` such that for infinitely many degrees `d` there is a totally real number field `K` of degree `d` over `ℚ` with `|Δ_K| ≤ C^d` (asymptotically-good totally real towers with bounded root discriminant). This is the sole classical input taken as an axiom in the [sum_product](https://github.com/mathlib-initiative/sum_product) formalization (`SumProduct.exists_totallyReal_discr_le`); it rests on Martinet's class field theory tower construction (Golod–Shafarevich), which is not yet in Mathlib, so it is a genuine known-hard gap rather than a project-invented one.

The statement is a closed existential in pure Mathlib vocabulary (no trusted helper definitions). It was checked for faithfulness against the paper's Theorem 3.2 by an independent review (matched verbatim to the arXiv text), and the module builds with only the expected `sorry`.

🤖 Prepared with Claude Code