### PR TITLE
feat: add Vlasov pushforward eval problem

### DIFF
--- a/LeanEval/Dynamics/Vlasov.lean
+++ b/LeanEval/Dynamics/Vlasov.lean
@@ -1,0 +1,86 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Dynamics
+
+/-!
+# The Vlasov pushforward theorem
+
+`vlasov_pushforward_solves` is the kinetic-theory method-of-characteristics
+identity (Knill attributes it to Maxwell; existence of the flow in the
+mean-field limit is Brown–Hepp 1977): if `X_t : M → T*N` solves the Vlasov
+Hamiltonian system with initial probability measure `m`, then the pushforward
+`P^t := (X_t)_* m` is a weak (Lagrangian) solution of the Vlasov
+integro-differential equation.
+
+It is stated on the model phase space `Phase d = ℝᵈ × ℝᵈ`. The trusted helper
+definitions (`Phase`, `IsVlasovHamiltonianFlow`, `vlasovMeanField`,
+`IsVlasovWeakSolution`) are non-holes. Mathlib has gradients, pushforward
+measures, Picard–Lindelöf, and integral curves, but nothing Vlasov-shaped
+(no kinetic equation, no weak/distributional transport PDE, no mean-field
+limit).
+
+This is a category-(b) candidate from §78 of the Knill survey
+(`sections/078-hamiltonian-dynamics.md`).
+-/
+
+open MeasureTheory
+open scoped Gradient ContDiff
+
+/-- The model phase space `T*N = N × N` for `N = ℝᵈ`. -/
+abbrev Phase (d : ℕ) :=
+  EuclideanSpace ℝ (Fin d) × EuclideanSpace ℝ (Fin d)
+
+variable {d : ℕ}
+
+/-- The **Vlasov Hamiltonian system** on `X : ℝ → Phase d → Phase d`,
+pointwise in `x` and `t`: `f' = g` and
+`g' = ∫ y, ∇V((X t x).1 − (X t y).1) ∂m`. -/
+def IsVlasovHamiltonianFlow
+    (V : EuclideanSpace ℝ (Fin d) → ℝ)
+    (m : Measure (Phase d))
+    (X : ℝ → Phase d → Phase d) : Prop :=
+  ∀ (x : Phase d) (t : ℝ),
+    HasDerivAt (fun s => (X s x).1) (X t x).2 t ∧
+    HasDerivAt (fun s => (X s x).2)
+      (∫ y, ∇ V ((X t x).1 - (X t y).1) ∂m) t
+
+/-- The **Vlasov mean field** `W(x) = ∫ ∇V(x − x') dP(x', y')`. -/
+noncomputable def vlasovMeanField
+    (V : EuclideanSpace ℝ (Fin d) → ℝ)
+    (P : Measure (Phase d))
+    (x : EuclideanSpace ℝ (Fin d)) :
+    EuclideanSpace ℝ (Fin d) :=
+  ∫ z, ∇ V (x - z.1) ∂P
+
+/-- `P : ℝ → Measure (T*N)` is a **weak (Lagrangian) solution** of the Vlasov
+integro-differential equation: for every smooth compactly supported test
+function `φ` and time `t`,
+`(d/dt) ∫ φ dP_t = ∫ (y · ∇_x φ + W(x) · ∇_y φ) dP_t`. -/
+def IsVlasovWeakSolution
+    (V : EuclideanSpace ℝ (Fin d) → ℝ)
+    (P : ℝ → Measure (Phase d)) : Prop :=
+  ∀ φ : Phase d → ℝ, ContDiff ℝ ∞ φ → HasCompactSupport φ →
+    ∀ t : ℝ,
+      HasDerivAt (fun s => ∫ z, φ z ∂(P s))
+        (∫ z, (fderiv ℝ (fun x' => φ (x', z.2)) z.1) z.2
+            + (fderiv ℝ (fun y' => φ (z.1, y')) z.2)
+                (vlasovMeanField V (P t) z.1) ∂(P t)) t
+
+/-- **Vlasov pushforward theorem.** If `X_t` solves the Vlasov Hamiltonian
+system with initial probability measure `m`, then `P^t := (X_t)_* m` is a weak
+(Lagrangian) solution of the Vlasov integro-differential equation. -/
+@[eval_problem]
+theorem vlasov_pushforward_solves
+    (V : EuclideanSpace ℝ (Fin d) → ℝ)
+    (_hV : ContDiff ℝ ∞ V)
+    (m : Measure (Phase d)) [IsProbabilityMeasure m]
+    (X : ℝ → Phase d → Phase d)
+    (_hX : IsVlasovHamiltonianFlow V m X)
+    (_hXMeas : ∀ t, Measurable (X t)) :
+    IsVlasovWeakSolution V (fun t => Measure.map (X t) m) := by
+  sorry
+
+end Dynamics
+end LeanEval

--- a/manifests/problems/vlasov_pushforward.toml
+++ b/manifests/problems/vlasov_pushforward.toml
@@ -1,0 +1,9 @@
+id = "vlasov_pushforward"
+title = "The Vlasov pushforward theorem"
+test = false
+module = "LeanEval.Dynamics.Vlasov"
+holes = ["vlasov_pushforward_solves"]
+submitter = "Kim Morrison"
+notes = "If X_t solves the Vlasov Hamiltonian system with initial probability measure m, then the pushforward P^t := (X_t)_* m is a weak (Lagrangian) solution of the Vlasov integro-differential equation — the kinetic-theory method of characteristics. Stated on the model phase space ℝᵈ × ℝᵈ. The trusted helpers (Phase, IsVlasovHamiltonianFlow, vlasovMeanField, IsVlasovWeakSolution) are non-holes. Mathlib has gradients, pushforward measures, Picard–Lindelöf, and integral curves, but nothing Vlasov-shaped (no kinetic equation, no weak transport PDE, no mean-field limit). Candidate from §78 of the Knill survey."
+source = "Knill attributes the identity to Maxwell; the underlying mean-field flow is W. Braun and K. Hepp, *The Vlasov dynamics and its fluctuations in the 1/N limit of interacting classical particles*, Comm. Math. Phys. 56 (1977). Knill, *Some fundamental theorems in mathematics*, §78."
+informal_solution = "Method of characteristics in kinetic theory. For a smooth compactly supported test function φ, the pushforward formula gives ∫ φ dP_t = ∫ φ(X_t z) dm(z). Differentiate in t under the integral (dominated convergence, using smoothness/compact support of φ and the Hamiltonian ODE for X), apply the chain rule with the Vlasov vector field (d/dt)(X_t z) = (g, ∫∇V(f(x)−f(y))dm) = (y, W(x)) along the flow, and recognize the result as ∫ (y·∇_x φ + W(x)·∇_y φ) dP_t after pushing the mean field through the pushforward (Fubini). This yields the weak Vlasov identity."


### PR DESCRIPTION
This PR adds the Vlasov pushforward theorem (§78 of the Knill survey) as a category-(b) eval problem: if `X_t` solves the Vlasov Hamiltonian system with initial probability measure `m`, then the pushforward `P^t := (X_t)_* m` is a weak (Lagrangian) solution of the Vlasov integro-differential equation — the kinetic-theory analogue of the method of characteristics. It is stated on the model phase space `ℝᵈ × ℝᵈ`. The trusted helper definitions (`Phase`, `IsVlasovHamiltonianFlow`, `vlasovMeanField`, `IsVlasovWeakSolution`) are non-holes. Mathlib has gradients, pushforward measures, Picard–Lindelöf, and integral curves, but nothing Vlasov-shaped — no kinetic equation, no weak/distributional transport PDE, no mean-field limit.

🤖 Prepared with Claude Code