### PR TITLE
feat: add Moran equality for affine-symmetric IFS eval problem

### DIFF
--- a/LeanEval/Dynamics/MoranDimension.lean
+++ b/LeanEval/Dynamics/MoranDimension.lean
@@ -1,0 +1,70 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Dynamics
+
+/-!
+# Moran's equality for affine-symmetric iterated function systems
+
+`moran_equality_affine` is the equality case of the Moran–Hutchinson dimension
+theorem (Moran 1946, Hutchinson 1981): for an iterated function system on `ℝᵈ`
+whose maps are affine with a common contraction factor `λ ∈ (0,1)` and
+orthogonal linear parts, satisfying the open set condition, the Hausdorff
+dimension of the attractor equals the similarity dimension — here
+`−log n / log λ`.
+
+The trusted helper definitions (`IsAttractor`, `IsAffineSymmetricIFS`,
+`OpenSetCondition`) are non-holes. Mathlib has `dimH`, `μH[d]`,
+`ContractingWith`, and the Hausdorff (e)metric on compacts, but no iterated
+function systems, Hutchinson operator, attractor, or similarity dimension.
+
+This is a category-(b) candidate from §105 of the Knill survey
+(`sections/105-fractals.md`). (The general Moran–Hutchinson *inequality* and the
+Cantor-set example, the section's other statements, are not included here.)
+-/
+
+open scoped Topology ENNReal NNReal
+open MeasureTheory
+
+/-- A set `S ⊆ X` is an **attractor** of the IFS `f : Fin n → X → X` if it is
+nonempty compact and fixed by the Hutchinson operator `H(A) = ⋃ᵢ fᵢ(A)`. -/
+def IsAttractor {X : Type*} [TopologicalSpace X] {n : ℕ}
+    (f : Fin n → X → X) (S : Set X) : Prop :=
+  IsCompact S ∧ S.Nonempty ∧ S = ⋃ i, f i '' S
+
+/-- An IFS on `ℝᵈ` is **affine-symmetric** with common contraction factor
+`λ ∈ (0,1)` if each map is `fᵢ(x) = λ · Aᵢ(x) + βᵢ` with `Aᵢ` a linear isometry
+(orthogonal transformation) and `βᵢ` a translation. -/
+def IsAffineSymmetricIFS {d n : ℕ}
+    (f : Fin n → EuclideanSpace ℝ (Fin d) → EuclideanSpace ℝ (Fin d)) (lam : ℝ) :
+    Prop :=
+  0 < lam ∧ lam < 1 ∧
+  ∃ A : Fin n → (EuclideanSpace ℝ (Fin d) →ₗᵢ[ℝ] EuclideanSpace ℝ (Fin d)),
+    ∃ β : Fin n → EuclideanSpace ℝ (Fin d),
+      ∀ i x, f i x = lam • A i x + β i
+
+/-- The **open set condition**: a nonempty open `G` with `fᵢ(G) ⊆ G` for all `i`
+and the images `fᵢ(G)` pairwise disjoint. -/
+def OpenSetCondition {d n : ℕ}
+    (f : Fin n → EuclideanSpace ℝ (Fin d) → EuclideanSpace ℝ (Fin d)) : Prop :=
+  ∃ G : Set (EuclideanSpace ℝ (Fin d)), IsOpen G ∧ G.Nonempty ∧
+    (∀ i, f i '' G ⊆ G) ∧
+    (∀ i j : Fin n, i ≠ j → Disjoint (f i '' G) (f j '' G))
+
+/-- **Moran's equality for affine-symmetric IFS.** For an affine-symmetric IFS
+on `ℝᵈ` with common contraction factor `λ ∈ (0,1)`, orthogonal linear parts, and
+the open set condition, the Hausdorff dimension of the attractor is
+`−log n / log λ` (positive since `λ < 1`). -/
+@[eval_problem]
+theorem moran_equality_affine
+    {d n : ℕ} (hn : 1 ≤ n)
+    (f : Fin n → EuclideanSpace ℝ (Fin d) → EuclideanSpace ℝ (Fin d)) (lam : ℝ)
+    (h_aff : IsAffineSymmetricIFS f lam)
+    (h_osc : OpenSetCondition f)
+    {S : Set (EuclideanSpace ℝ (Fin d))} (hS : IsAttractor f S) :
+    dimH S = ENNReal.ofReal (- Real.log n / Real.log lam) := by
+  sorry
+
+end Dynamics
+end LeanEval

--- a/manifests/problems/moran_equality_affine.toml
+++ b/manifests/problems/moran_equality_affine.toml
@@ -1,0 +1,9 @@
+id = "moran_equality_affine"
+title = "Moran's equality for affine-symmetric iterated function systems"
+test = false
+module = "LeanEval.Dynamics.MoranDimension"
+holes = ["moran_equality_affine"]
+submitter = "Kim Morrison"
+notes = "For an iterated function system on ℝᵈ whose maps are affine with a common contraction factor λ ∈ (0,1) and orthogonal linear parts, satisfying the open set condition, the Hausdorff dimension of the attractor equals the similarity dimension −log n / log λ. The trusted helpers (IsAttractor, IsAffineSymmetricIFS, OpenSetCondition) are non-holes. Mathlib has dimH, μH[d], and ContractingWith but no iterated function systems / Hutchinson operator / attractor / similarity dimension. Candidate from §105 of the Knill survey."
+source = "P. A. P. Moran, *Additive functions of intervals and Hausdorff measure*, Proc. Cambridge Philos. Soc. 42 (1946); J. E. Hutchinson, *Fractals and self similarity*, Indiana Univ. Math. J. 30 (1981). Knill, *Some fundamental theorems in mathematics*, §105."
+informal_solution = "Two inequalities. Upper bound (dimH S ≤ s with ∑ λˢ = n·λˢ = 1, i.e. s = −log n/log λ): cover S by the n^k cylinder images of diameter λᵏ·diam(S) under length-k words, giving ∑ diam^s = n^k·(λᵏ diam)^s = (n λˢ)^k diam^s = diam^s bounded, so the s-dimensional Hausdorff measure is finite and dimH S ≤ s. Lower bound (the open set condition): use the OSC to build a mass distribution (the natural self-similar measure giving each length-k cylinder mass n^{-k}) and apply the mass distribution principle — bounded overlap from the disjoint open sets fᵢ(G) gives μ(B_r) ≤ C r^s, forcing μH^s(S) > 0 and dimH S ≥ s. Hence equality."


### PR DESCRIPTION
This PR adds Moran's equality (Moran 1946, Hutchinson 1981; §105 of the Knill survey) as a category-(b) eval problem: for an iterated function system on `ℝᵈ` whose maps are affine with a common contraction factor `λ ∈ (0,1)` and orthogonal linear parts, satisfying the open set condition, the Hausdorff dimension of the attractor equals the similarity dimension `−log n / log λ`. The trusted helper definitions (`IsAttractor`, `IsAffineSymmetricIFS`, `OpenSetCondition`) are non-holes. Mathlib has `dimH`, `μH[d]`, and `ContractingWith` but no iterated function systems, Hutchinson operator, attractor, or similarity dimension. The general Moran–Hutchinson inequality and the Cantor-set example are not included.

🤖 Prepared with Claude Code