### PR TITLE
feat: add KAM invariant-curve eval problem

### DIFF
--- a/LeanEval/Dynamics/KAM.lean
+++ b/LeanEval/Dynamics/KAM.lean
@@ -1,0 +1,58 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Dynamics
+
+/-!
+# KAM persistence of an invariant curve of a twist map
+
+`kam_invariant_curve` is the Kolmogorov–Arnold–Moser theorem in the
+twist-map setting: for Diophantine rotation number `α` and a real-analytic,
+`1`-periodic, non-constant, mean-zero `f`, the invariant curve `q₀(t) = t` of
+the integrable case `c = 0` persists, for small `|c|`, as a smooth strictly
+increasing solution `q` (with `q − id` periodic) of the functional equation
+`q(t+α) − 2q(t) + q(t−α) = c·f(q(t))`.
+
+The linearisation at `c = 0` is not invertible (`L̂₀ = 0`), so the implicit
+function theorem fails and one faces small divisors `[2cos(2πnα)−2]⁻¹`; the
+Diophantine condition makes the Newton/Nash–Moser scheme converge. The trusted
+helper `IsDiophantine` (a non-hole) fixes the arithmetic condition. Mathlib has
+no KAM theory (no twist maps, invariant curves, small divisors, or Nash–Moser).
+
+This is a category-(b) candidate from §83 of the Knill survey
+(`sections/083-kam.md`). (The Poincaré–Siegel linearisation companion is not
+included here.)
+-/
+
+open scoped ContDiff
+
+/-- A real `α` is **Diophantine** (KAM exponent `2`): there is `C > 0` with
+`C / q² ≤ |α − p/q|` for all integers `p, q` with `q ≠ 0`. -/
+def IsDiophantine (α : ℝ) : Prop :=
+  ∃ C : ℝ, 0 < C ∧ ∀ p q : ℤ, q ≠ 0 →
+    C / (q : ℝ) ^ 2 ≤ |α - (p : ℝ) / (q : ℝ)|
+
+/-- **KAM theorem (persistence of an invariant curve).** For real-analytic,
+`1`-periodic, non-constant, mean-zero `f` and Diophantine `α`, for all small
+`|c|` the twist-map functional equation
+`q(t+α) − 2q(t) + q(t−α) = c·f(q(t))` has a smooth strictly increasing solution
+`q` with `q − id` periodic — the `c = 0` curve `q₀(t) = t` persists as a smooth
+invariant curve of rotation number `α`. -/
+@[eval_problem]
+theorem kam_invariant_curve
+    (α : ℝ) (_hα : IsDiophantine α)
+    (f : ℝ → ℝ)
+    (_hf_analytic : AnalyticOnNhd ℝ f Set.univ)
+    (_hf_per : Function.Periodic f 1)
+    (_hf_nonconst : ¬ ∃ k : ℝ, ∀ x, f x = k)
+    (_hf_mean : ∫ x in (0 : ℝ)..1, f x = 0) :
+    ∃ c₀ : ℝ, 0 < c₀ ∧ ∀ c : ℝ, |c| < c₀ →
+      ∃ q : ℝ → ℝ,
+        ContDiff ℝ ∞ q ∧ StrictMono q ∧
+        Function.Periodic (fun t => q t - t) 1 ∧
+        ∀ t : ℝ, q (t + α) - 2 * q t + q (t - α) = c * f (q t) := by
+  sorry
+
+end Dynamics
+end LeanEval

--- a/manifests/problems/kam_invariant_curve.toml
+++ b/manifests/problems/kam_invariant_curve.toml
@@ -1,0 +1,9 @@
+id = "kam_invariant_curve"
+title = "KAM persistence of an invariant curve"
+test = false
+module = "LeanEval.Dynamics.KAM"
+holes = ["kam_invariant_curve"]
+submitter = "Kim Morrison"
+notes = "Kolmogorov–Arnold–Moser for a twist map: for Diophantine α and real-analytic, 1-periodic, non-constant, mean-zero f, for small |c| the functional equation q(t+α)−2q(t)+q(t−α) = c·f(q(t)) has a smooth strictly increasing solution with q−id periodic — the c=0 invariant curve persists. The linearisation is non-invertible (small divisors), so the IFT fails and the Diophantine condition drives a Newton/Nash–Moser scheme. The trusted helper IsDiophantine is a non-hole. Mathlib has no KAM theory (no twist maps, invariant curves, small divisors, Nash–Moser). Candidate from §83 of the Knill survey."
+source = "A. N. Kolmogorov (1954); V. I. Arnold (1963); J. Moser, *On invariant curves of area-preserving mappings of an annulus*, Nachr. Akad. Wiss. Göttingen (1962). Knill, *Some fundamental theorems in mathematics*, §83."
+informal_solution = "KAM via a Newton/Nash–Moser iteration with small-divisor control. Linearise the functional operator F(q) = q(·+α) − 2q + q(·−α) − c·f∘q at the approximate solution; the constant-coefficient part L u = u(·+α) − 2u + u(·−α) is diagonal in Fourier with symbol 2cos(2πnα) − 2, invertible off n = 0 with inverse bounded by the Diophantine estimate |2cos(2πnα)−2|⁻¹ ≲ |n|²/C. Run a quadratically-convergent Newton scheme on a scale of analyticity-shrinking norms (Cauchy estimates absorb the polynomial small-divisor loss), solving the cohomological equation at each step after projecting out the mean (using f mean-zero), and control the analyticity-width loss so the iteration converges for |c| < c₀ to a real-analytic q with q−id periodic and StrictMono."


### PR DESCRIPTION
This PR adds the Kolmogorov–Arnold–Moser persistence theorem for a twist map (§83 of the Knill survey) as a category-(b) eval problem: for Diophantine `α` and a real-analytic, `1`-periodic, non-constant, mean-zero `f`, the invariant curve `q₀(t) = t` of the integrable case `c = 0` persists, for small `|c|`, as a smooth strictly increasing solution `q` (with `q − id` periodic) of `q(t+α) − 2q(t) + q(t−α) = c·f(q(t))`. The linearisation at `c = 0` is non-invertible (small divisors), so the implicit function theorem fails and the Diophantine condition drives a Newton/Nash–Moser scheme. The trusted helper `IsDiophantine` is a non-hole. Mathlib has no KAM theory — no twist maps, invariant curves, small divisors, or Nash–Moser.

🤖 Prepared with Claude Code