### PR TITLE
feat: add fundamental theorem of topos theory eval problem

### DIFF
--- a/LeanEval/CategoryTheory/FundamentalTopos.lean
+++ b/LeanEval/CategoryTheory/FundamentalTopos.lean
@@ -1,0 +1,39 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.ToposTheory
+
+/-!
+# The fundamental theorem of topos theory
+
+`fundamental_topos_theory`: the slice category `E/X` of an elementary topos `E`
+is again an elementary topos. The trusted helper `IsTopos` (a non-hole) bundles
+the four Mathlib classes that make up "elementary topos". Mathlib has finite
+limits and cartesian-monoidal structure on `Over X` and a subobject-classifier
+class, but neither `MonoidalClosed (Over X)` (the locally-cartesian-closed
+upgrade) nor `HasSubobjectClassifier (Over X)` — so no fundamental theorem.
+
+Category-(b) candidate from §54 of the Knill survey.
+-/
+
+universe v u
+
+open _root_.CategoryTheory _root_.CategoryTheory.Limits
+
+/-- An **elementary topos**: finite limits, a cartesian closed structure
+(cartesian-monoidal with internal homs), and a subobject classifier. -/
+def IsTopos (E : Type u) [Category.{v} E] : Prop :=
+  HasFiniteLimits E ∧
+  ∃ cm : CartesianMonoidalCategory E,
+    (letI : MonoidalCategory E := cm.toMonoidalCategory
+     Nonempty (MonoidalClosed E)) ∧
+    HasSubobjectClassifier E
+
+/-- **Fundamental theorem of topos theory.** The slice category `E/X` of an
+elementary topos `E` is again an elementary topos. -/
+@[eval_problem]
+theorem fundamental_topos_theory {E : Type u} [Category.{v} E]
+    (hE : IsTopos E) (X : E) : IsTopos (Over X) := by
+  sorry
+
+end LeanEval.ToposTheory

--- a/LeanEval/CategoryTheory/FundamentalTopos.lean
+++ b/LeanEval/CategoryTheory/FundamentalTopos.lean
@@ -16,13 +16,12 @@ upgrade) nor `HasSubobjectClassifier (Over X)` — so no fundamental theorem.
 Category-(b) candidate from §54 of the Knill survey.
 -/
 
-universe v u
 
 open _root_.CategoryTheory _root_.CategoryTheory.Limits
 
 /-- An **elementary topos**: finite limits, a cartesian closed structure
 (cartesian-monoidal with internal homs), and a subobject classifier. -/
-def IsTopos (E : Type u) [Category.{v} E] : Prop :=
+def IsTopos (E : Type*) [Category E] : Prop :=
   HasFiniteLimits E ∧
   ∃ cm : CartesianMonoidalCategory E,
     (letI : MonoidalCategory E := cm.toMonoidalCategory
@@ -32,7 +31,7 @@ def IsTopos (E : Type u) [Category.{v} E] : Prop :=
 /-- **Fundamental theorem of topos theory.** The slice category `E/X` of an
 elementary topos `E` is again an elementary topos. -/
 @[eval_problem]
-theorem fundamental_topos_theory {E : Type u} [Category.{v} E]
+theorem fundamental_topos_theory {E : Type*} [Category E]
     (hE : IsTopos E) (X : E) : IsTopos (Over X) := by
   sorry
 

--- a/manifests/problems/fundamental_topos_theory.toml
+++ b/manifests/problems/fundamental_topos_theory.toml
@@ -1,0 +1,9 @@
+id = "fundamental_topos_theory"
+title = "Fundamental theorem of topos theory"
+test = false
+module = "LeanEval.CategoryTheory.FundamentalTopos"
+holes = ["fundamental_topos_theory"]
+submitter = "Kim Morrison"
+notes = "The slice category E/X of an elementary topos E is again an elementary topos. The trusted helper IsTopos (non-hole) bundles finite limits + cartesian-closed (CartesianMonoidalCategory + MonoidalClosed) + a subobject classifier. Mathlib has finite limits and cartesian-monoidal structure on Over X and a HasSubobjectClassifier class, but neither MonoidalClosed (Over X) (the locally-cartesian-closed upgrade) nor HasSubobjectClassifier (Over X). Candidate from §54 of the Knill survey."
+source = "F. W. Lawvere & M. Tierney (elementary topos, 1970); see S. Mac Lane & I. Moerdijk, *Sheaves in Geometry and Logic*, IV.7. Knill, *Some fundamental theorems in mathematics*, §54."
+informal_solution = "Reconstruct the three topos structures on E/X from those on E. Finite limits in the slice come from the comma-category construction (already in Mathlib). Cartesian closedness is the locally-cartesian-closed upgrade: the pullback functor f* : E/Y → E/X has a right adjoint Π_f (dependent product), built from exponentials in E; this gives internal homs in E/X. The subobject classifier of E/X is (Ω × X → X): a subobject of (A → X) is classified by composing A's characteristic map with the projection. Verifying the pullback/universal properties (Mac Lane–Moerdijk IV.7) is the substantive work."


### PR DESCRIPTION
This PR adds the fundamental theorem of topos theory (§54 of the Knill survey): the slice category `E/X` of an elementary topos `E` is again an elementary topos. The trusted helper `IsTopos` (a non-hole) bundles the four Mathlib classes that make up "elementary topos". Mathlib has finite limits and cartesian-monoidal structure on `Over X` and a subobject-classifier class, but neither `MonoidalClosed (Over X)` (the locally-cartesian-closed upgrade) nor `HasSubobjectClassifier (Over X)`.
🤖 Prepared with Claude Code