### PR TITLE
feat: add Radon transform diagonalization/inversion eval problem

### DIFF
--- a/LeanEval/Analysis/RadonTransform.lean
+++ b/LeanEval/Analysis/RadonTransform.lean
@@ -1,0 +1,49 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.RadonTransform
+
+/-!
+# The Radon transform: Fourier-slice diagonalization and pseudo-inversion
+
+`radon_can_be_diagonalized_and_pseudo_inverted`: the Fourier slice theorem
+(`fourier1` of `radon φ(·,θ)` equals a 2D-Fourier slice of `φ`), together with
+the existence of a left inverse of the Radon transform on Schwartz functions.
+The trusted helpers (`radon`, `fourier1`, `fourier2`) are non-holes. Mathlib
+has the 1D/2D Fourier transforms and Schwartz space but no Radon transform,
+Fourier slice theorem, or filtered back-projection.
+
+Category-(b) candidate from §100 of the Knill survey.
+-/
+
+open MeasureTheory Real Complex
+
+/-- The **Radon transform** of `f : ℝ × ℝ → ℂ` at `(p, θ)`: the integral of `f`
+along the line `x cos θ + y sin θ = p`. -/
+noncomputable def radon (f : ℝ × ℝ → ℂ) (pθ : ℝ × ℝ) : ℂ :=
+  ∫ t : ℝ, f (pθ.1 * Real.cos pθ.2 - t * Real.sin pθ.2,
+              pθ.1 * Real.sin pθ.2 + t * Real.cos pθ.2)
+
+/-- 1D Fourier transform (mathlib's `2π i` convention). -/
+noncomputable def fourier1 (g : ℝ → ℂ) (k : ℝ) : ℂ :=
+  ∫ p : ℝ, Complex.exp (-(2 * Real.pi * p * k) * Complex.I) * g p
+
+/-- 2D Fourier transform of `f : ℝ × ℝ → ℂ` at `(k₁, k₂)`. -/
+noncomputable def fourier2 (f : ℝ × ℝ → ℂ) (k : ℝ × ℝ) : ℂ :=
+  ∫ x : ℝ × ℝ,
+    Complex.exp (-(2 * Real.pi * (x.1 * k.1 + x.2 * k.2)) * Complex.I) * f x
+
+/-- **Radon's theorem (diagonalization + pseudo-inversion).** The Fourier slice
+theorem diagonalizes the Radon transform, and the transform admits a left
+inverse on the Schwartz space. -/
+@[eval_problem]
+theorem radon_can_be_diagonalized_and_pseudo_inverted :
+    (∀ φ : SchwartzMap (ℝ × ℝ) ℂ, ∀ θ k : ℝ,
+        fourier1 (fun p => radon (φ : ℝ × ℝ → ℂ) (p, θ)) k =
+          fourier2 (φ : ℝ × ℝ → ℂ) (k * Real.cos θ, k * Real.sin θ)) ∧
+    (∃ Rinv : (ℝ × ℝ → ℂ) → (ℝ × ℝ → ℂ),
+        ∀ φ : SchwartzMap (ℝ × ℝ) ℂ,
+          Rinv (radon (φ : ℝ × ℝ → ℂ)) = (φ : ℝ × ℝ → ℂ)) := by
+  sorry
+
+end LeanEval.Analysis.RadonTransform

--- a/manifests/problems/radon_transform_inversion.toml
+++ b/manifests/problems/radon_transform_inversion.toml
@@ -1,0 +1,9 @@
+id = "radon_transform_inversion"
+title = "Radon transform: Fourier-slice diagonalization and pseudo-inversion"
+test = false
+module = "LeanEval.Analysis.RadonTransform"
+holes = ["radon_can_be_diagonalized_and_pseudo_inverted"]
+submitter = "Kim Morrison"
+notes = "The Fourier slice theorem diagonalizes the Radon transform (1D Fourier of a projection = a 2D-Fourier slice), and the transform has a left inverse on Schwartz functions. Trusted helpers radon, fourier1, fourier2 (non-holes). Mathlib has the 1D/2D Fourier transforms and Schwartz space but no Radon transform, Fourier slice theorem, or filtered back-projection. The pseudo-inverse is stated existentially (the explicit filtered-back-projection form would need the Hilbert transform / Riesz potential). Candidate from §100 of the Knill survey."
+source = "J. Radon (1917); R. N. Bracewell (Fourier slice theorem, 1956). Knill, *Some fundamental theorems in mathematics*, §100."
+informal_solution = "Fourier slice theorem: writing the Radon projection R f(p,θ) and taking its 1D Fourier transform in p, interchange integrals (Fubini) and change variables so the line-integral-then-Fourier becomes the 2D Fourier transform of f restricted to the line through the origin at angle θ: F₁[Rf(·,θ)](k) = F₂[f](k cos θ, k sin θ). This diagonalizes R (it becomes a slice/multiplication operator). Pseudo-inversion: the slice identity plus 2D Fourier inversion on Schwartz functions makes R injective on 𝓢, so a left inverse exists; the canonical one is filtered back-projection u ↦ backproject(Hilbert-filter(u)). Mathlib lacks the slice theorem and the filter."


### PR DESCRIPTION
This PR adds the Radon transform diagonalization + pseudo-inversion result (§100 of the Knill survey): the Fourier slice theorem diagonalizes the Radon transform, and the transform admits a left inverse on Schwartz functions. The trusted helpers (`radon`, `fourier1`, `fourier2`) are non-holes. Mathlib has the 1D/2D Fourier transforms and Schwartz space but no Radon transform, Fourier slice theorem, or filtered back-projection; the pseudo-inverse is stated existentially.
🤖 Prepared with Claude Code