### PR TITLE
feat: add Lax approximation eval problem

### DIFF
--- a/LeanEval/Dynamics/LaxApproximation.lean
+++ b/LeanEval/Dynamics/LaxApproximation.lean
@@ -34,14 +34,11 @@ structure VolumePreservingEquiv (d : ℕ) where
   measurePreserving :
     MeasurePreserving toMeasurableEquiv (volume : Measure (Torus d)) volume
 
-instance instCoeFunVPE (d : ℕ) :
-    CoeFun (VolumePreservingEquiv d) (fun _ => Torus d → Torus d) where
-  coe T := T.toMeasurableEquiv
 
 /-- Knill's metric `δ`: the essential supremum of the pointwise torus-distance
 `d(T x, S x)`. -/
 noncomputable def deltaDist {d : ℕ} (T S : VolumePreservingEquiv d) : ℝ≥0∞ :=
-  essSup (fun x => edist (T x) (S x)) (volume : Measure (Torus d))
+  essSup (fun x => edist (T.toMeasurableEquiv x) (S.toMeasurableEquiv x)) (volume : Measure (Torus d))
 
 /-- A **toral dynamical system**: a volume-preserving homeomorphism of `𝕋^d`. -/
 structure ToralDynamicalSystem (d : ℕ) where
@@ -72,7 +69,7 @@ def IsCyclicCubeExchange {d : ℕ} (T : VolumePreservingEquiv d) (n : ℕ) : Pro
   ∃ σ : Equiv.Perm (Fin d → Fin n),
     σ.IsCycle ∧ σ.support = Finset.univ ∧
     ∀ k : Fin d → Fin n, ∀ x ∈ cube n k, ∀ i,
-      T x i = x i + cubeShift n σ k i
+      T.toMeasurableEquiv x i = x i + cubeShift n σ k i
 
 /-- **Lax's approximation theorem.** Every toral dynamical system on `𝕋^d`
 (`d ≥ 1`) is approximated arbitrarily well in the metric `δ` by cyclic cube

--- a/LeanEval/Dynamics/LaxApproximation.lean
+++ b/LeanEval/Dynamics/LaxApproximation.lean
@@ -1,0 +1,87 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Dynamics.LaxApproximation
+
+/-!
+# Lax's approximation theorem for toral homeomorphisms
+
+`lax_approximation` (Peter Lax 1971): every volume-preserving homeomorphism of
+the `d`-torus (`d ≥ 1`) can be approximated arbitrarily well, in the
+`L∞`-metric `δ`, by cyclic cube exchange transformations. The trusted helpers
+(`Torus`, `VolumePreservingEquiv`, `deltaDist`, `ToralDynamicalSystem`, `cube`,
+`cubeShift`, `IsCyclicCubeExchange`, …) are non-holes. Mathlib has the torus,
+measure-preserving maps, and Hall's marriage theorem (the combinatorial
+ingredient) but not Lax's theorem, cube exchanges, or the metric `δ`.
+
+Category-(b) candidate from §110 of the Knill survey. "Cyclic" is encoded as a
+single full `nᵈ`-cycle (`σ.IsCycle ∧ σ.support = univ`), and `0 < d` is required
+(for `d = 0` no non-identity cycle exists).
+-/
+
+open MeasureTheory
+open scoped ENNReal
+
+instance : Fact (0 < (1 : ℝ)) := ⟨zero_lt_one⟩
+
+/-- The standard `d`-dimensional torus `𝕋^d = (ℝ/ℤ)^d`. -/
+abbrev Torus (d : ℕ) : Type := Fin d → AddCircle (1 : ℝ)
+
+/-- The group of measurable, invertible, volume-preserving transformations of
+the `d`-torus. -/
+structure VolumePreservingEquiv (d : ℕ) where
+  toMeasurableEquiv : Torus d ≃ᵐ Torus d
+  measurePreserving :
+    MeasurePreserving toMeasurableEquiv (volume : Measure (Torus d)) volume
+
+instance instCoeFunVPE (d : ℕ) :
+    CoeFun (VolumePreservingEquiv d) (fun _ => Torus d → Torus d) where
+  coe T := T.toMeasurableEquiv
+
+/-- Knill's metric `δ`: the essential supremum of the pointwise torus-distance
+`d(T x, S x)`. -/
+noncomputable def deltaDist {d : ℕ} (T S : VolumePreservingEquiv d) : ℝ≥0∞ :=
+  essSup (fun x => edist (T x) (S x)) (volume : Measure (Torus d))
+
+/-- A **toral dynamical system**: a volume-preserving homeomorphism of `𝕋^d`. -/
+structure ToralDynamicalSystem (d : ℕ) where
+  toHomeomorph : Torus d ≃ₜ Torus d
+  measurePreserving :
+    MeasurePreserving toHomeomorph (volume : Measure (Torus d)) volume
+
+/-- A toral dynamical system as an element of `𝒳`. -/
+noncomputable def ToralDynamicalSystem.toVolumePreservingEquiv {d : ℕ}
+    (T : ToralDynamicalSystem d) : VolumePreservingEquiv d where
+  toMeasurableEquiv := T.toHomeomorph.toMeasurableEquiv
+  measurePreserving := T.measurePreserving
+
+/-- The half-open cube `cube n k ⊆ 𝕋^d` for `k : Fin d → Fin n`. -/
+def cube (n : ℕ) {d : ℕ} (k : Fin d → Fin n) : Set (Torus d) :=
+  { x | ∀ i, ∃ r : ℝ, (k i : ℝ) / n ≤ r ∧ r < ((k i : ℝ) + 1) / n ∧
+        x i = ((r : ℝ) : AddCircle (1 : ℝ)) }
+
+/-- The axis-`i` shift carrying cube `k` onto cube `σ k`. -/
+noncomputable def cubeShift (n : ℕ) {d : ℕ}
+    (σ : Equiv.Perm (Fin d → Fin n))
+    (k : Fin d → Fin n) (i : Fin d) : AddCircle (1 : ℝ) :=
+  ((((((σ k) i : ℤ) - (k i : ℤ) : ℝ) / (n : ℝ)) : ℝ) : AddCircle (1 : ℝ))
+
+/-- A **cyclic cube exchange**: a single full `nᵈ`-cycle `σ` acting on each
+cube `k` by the rigid translation carrying it to cube `σ k`. -/
+def IsCyclicCubeExchange {d : ℕ} (T : VolumePreservingEquiv d) (n : ℕ) : Prop :=
+  ∃ σ : Equiv.Perm (Fin d → Fin n),
+    σ.IsCycle ∧ σ.support = Finset.univ ∧
+    ∀ k : Fin d → Fin n, ∀ x ∈ cube n k, ∀ i,
+      T x i = x i + cubeShift n σ k i
+
+/-- **Lax's approximation theorem.** Every toral dynamical system on `𝕋^d`
+(`d ≥ 1`) is approximated arbitrarily well in the metric `δ` by cyclic cube
+exchange transformations. -/
+@[eval_problem]
+theorem lax_approximation {d : ℕ} (hd : 0 < d) (T : ToralDynamicalSystem d)
+    {ε : ℝ≥0∞} (hε : 0 < ε) :
+    ∃ (n : ℕ) (S : VolumePreservingEquiv d),
+      IsCyclicCubeExchange S n ∧ deltaDist T.toVolumePreservingEquiv S < ε := by
+  sorry
+
+end LeanEval.Dynamics.LaxApproximation

--- a/manifests/problems/lax_approximation.toml
+++ b/manifests/problems/lax_approximation.toml
@@ -1,0 +1,9 @@
+id = "lax_approximation"
+title = "Lax's approximation theorem for toral homeomorphisms"
+test = false
+module = "LeanEval.Dynamics.LaxApproximation"
+holes = ["lax_approximation"]
+submitter = "Kim Morrison"
+notes = "Peter Lax (1971): every volume-preserving homeomorphism of the d-torus (d ≥ 1) is approximated arbitrarily well, in the L∞-metric δ(T,S) = ess sup d(Tx,Sx), by cyclic cube exchange transformations (a single full nᵈ-cycle rigidly permuting the 1/n-grid cubes). Trusted helpers (Torus, VolumePreservingEquiv, deltaDist, ToralDynamicalSystem, cube, cubeShift, IsCyclicCubeExchange) are non-holes. 'Cyclic' = σ.IsCycle ∧ σ.support = univ; 0 < d required. Mathlib has the torus, measure-preserving maps, and Hall's marriage theorem but not Lax's theorem or cube exchanges. Candidate from §110 of the Knill survey."
+source = "P. D. Lax, *Approximation of measure preserving transformations*, Comm. Pure Appl. Math. 24 (1971). Knill, *Some fundamental theorems in mathematics*, §110."
+informal_solution = "Lax's grid argument. Fix a fine mesh n with 1/n < ε-scale. Partition 𝕋ᵈ into nᵈ cubes; since T is volume-preserving, the images T(cube k) and the cubes match up in measure, so by Hall's marriage theorem there is a bijection σ of cube-indices with T(cube k) ∩ cube(σ k) of positive measure (each target within ε of the source), giving a cube exchange S₀ with δ(T,S₀) small. Upgrade σ to a single full cycle: any permutation is a product of cycles, and one can perturb/relabel within the ε-tolerance (concatenating the cycles through shared boundary cubes) to make it one nᵈ-cycle without increasing δ beyond ε. Requires the measure-matching (Hall) and the cyclic upgrade, neither packaged in Mathlib."


### PR DESCRIPTION
This PR adds Lax's approximation theorem (Peter Lax 1971; §110 of the Knill survey): every volume-preserving homeomorphism of the `d`-torus (`d ≥ 1`) is approximated arbitrarily well, in the `L∞`-metric `δ`, by cyclic cube exchange transformations (a single full `nᵈ`-cycle rigidly permuting the `1/n`-grid cubes). The trusted helpers (`Torus`, `VolumePreservingEquiv`, `deltaDist`, `cube`, `IsCyclicCubeExchange`, …) are non-holes. Mathlib has the torus, measure-preserving maps, and Hall's marriage theorem but not Lax's theorem or cube exchanges.
🤖 Prepared with Claude Code