### PR TITLE
feat: add Landsberg-Schaar relation eval problem

### DIFF
--- a/LeanEval/NumberTheory/LandsbergSchaar.lean
+++ b/LeanEval/NumberTheory/LandsbergSchaar.lean
@@ -1,0 +1,36 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.NumberTheory.LandsbergSchaar
+
+/-!
+# The Landsberg–Schaar relation
+
+`landsberg_schaar`: for positive odd integers `p, q`,
+`S(2q, p) = e^{iπ/4} · S(−p, 2q)`, where `S(q,p) = (1/√p) ∑_{x<p} e^{iπ x² q/p}`
+is the normalized quadratic Gauss sum (the trusted helper `gaussS`, a non-hole).
+Mathlib has the character-theoretic `gaussSum` (giving `|g|² = p`) and the
+Jacobi-theta machinery, but neither the quadratic Gauss-sum value nor the
+Landsberg–Schaar relation.
+
+Category-(b) candidate from §120 of the Knill survey.
+-/
+
+open Complex Finset
+
+/-- Knill's normalized finite quadratic exponential sum
+`S(q, p) = (1/√p) ∑_{x=0}^{p−1} exp(i π x² q / p)`. -/
+noncomputable def gaussS (q : ℤ) (p : ℕ) : ℂ :=
+  (Real.sqrt p : ℂ)⁻¹ *
+    ∑ x ∈ Finset.range p,
+      Complex.exp ((Real.pi : ℂ) * Complex.I * ((x : ℂ) ^ 2 * (q : ℂ) / (p : ℂ)))
+
+/-- **Landsberg–Schaar relation.** For positive odd integers `p, q`,
+`S(2q, p) = e^{iπ/4} · S(−p, 2q)`. -/
+@[eval_problem]
+theorem landsberg_schaar (p q : ℕ) (hp : Odd p) (hq : Odd q) :
+    gaussS (2 * q : ℕ) p
+      = Complex.exp ((Real.pi : ℂ) * Complex.I / 4) * gaussS (-(p : ℤ)) (2 * q) := by
+  sorry
+
+end LeanEval.NumberTheory.LandsbergSchaar

--- a/manifests/problems/landsberg_schaar.toml
+++ b/manifests/problems/landsberg_schaar.toml
@@ -1,0 +1,9 @@
+id = "landsberg_schaar"
+title = "The Landsberg–Schaar relation"
+test = false
+module = "LeanEval.NumberTheory.LandsbergSchaar"
+holes = ["landsberg_schaar"]
+submitter = "Kim Morrison"
+notes = "For positive odd integers p, q, S(2q,p) = e^{iπ/4}·S(−p,2q), where S(q,p) = (1/√p) ∑_{x<p} e^{iπ x² q/p} is the normalized quadratic Gauss sum (trusted helper gaussS, a non-hole). Mathlib has the character-theoretic gaussSum (giving |g|²=p) and Jacobi-theta machinery, but neither the quadratic Gauss-sum value nor the Landsberg–Schaar relation. Candidate from §120 of the Knill survey."
+source = "G. Landsberg (1893); M. Schaar (1848). Knill, *Some fundamental theorems in mathematics*, §120."
+informal_solution = "Landsberg–Schaar via theta-function reciprocity. Apply the Jacobi theta transformation θ(−1/τ) = √(−iτ) θ(τ) (Poisson summation for the Gaussian) along a path where the modular parameter degenerates to the rationals p/q: take τ → it with the finite quadratic sums appearing as the boundary values of θ at rational points. The modular transformation relates the sum at modulus p (argument 2q) to the sum at modulus 2q (argument −p), and the automorphy factor √(−iτ) contributes the e^{iπ/4} phase. Mathlib has jacobiTheta₂ and its functional equation; assembling the rational-degeneration limit into the finite-sum identity is the missing step."


### PR DESCRIPTION
This PR adds the Landsberg–Schaar relation (§120 of the Knill survey): for positive odd integers `p, q`, `S(2q,p) = e^{iπ/4}·S(−p,2q)` for the normalized quadratic Gauss sum `S` (the trusted helper `gaussS`, a non-hole). Mathlib has the character-theoretic `gaussSum` (giving `|g|² = p`) and the Jacobi-theta machinery, but neither the quadratic Gauss-sum value nor the Landsberg–Schaar relation.
🤖 Prepared with Claude Code