### PR TITLE
feat: add topological and differentiable sphere theorems eval problems

### DIFF
--- a/LeanEval/Geometry/SphereTheorem.lean
+++ b/LeanEval/Geometry/SphereTheorem.lean
@@ -1,0 +1,95 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Geometry.SphereTheorem
+
+/-!
+# The sphere theorems (Berger–Klingenberg–Rauch; Brendle–Schoen)
+
+`sphere_theorem`: a closed, simply-connected, strictly quarter-pinched Riemannian
+manifold is homeomorphic to the standard sphere (Berger–Klingenberg–Rauch 1960).
+`differentiable_sphere_theorem`: under the same hypotheses it is diffeomorphic to
+the sphere (Brendle–Schoen 2007, via Ricci flow). The trusted helpers
+(`IsMetricCompatible`, `curv`, `QuarterPinched`) are non-holes; following §38,
+the Levi-Civita connection is hypothesized as a smooth torsion-free
+metric-compatible covariant derivative (Mathlib has the covariant-derivative
+interface but does not yet construct Levi-Civita). Mathlib has no Riemann
+curvature tensor, sectional curvature, pinching, or Ricci flow.
+
+Category-(b) candidates from §121 of the Knill survey.
+-/
+
+open scoped Manifold ContDiff Bundle Topology
+open Bundle ContDiff Set VectorField CovariantDerivative Metric
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [FiniteDimensional ℝ E] [CompleteSpace E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+    [IsManifold I ∞ M]
+  [RiemannianBundle (fun (x : M) ↦ TangentSpace I x)]
+  [IsContMDiffRiemannianBundle I ∞ E (fun (x : M) ↦ TangentSpace I x)]
+
+/-- A covariant derivative `cov` is **compatible with the Riemannian metric**:
+`v · ⟨Y, Z⟩ = ⟨∇_v Y, Z⟩ + ⟨Y, ∇_v Z⟩`. -/
+def IsMetricCompatible
+    (cov : CovariantDerivative I E (TangentSpace I (M := M))) : Prop :=
+  ∀ (Y Z : Π x : M, TangentSpace I x),
+    CMDiff ∞ (T% Y) → CMDiff ∞ (T% Z) →
+    ∀ (x : M) (v : TangentSpace I x),
+      extDerivFun (fun y : M => inner ℝ (Y y) (Z y)) x v =
+        inner ℝ (cov Y x v) (Z x) + inner ℝ (Y x) (cov Z x v)
+
+/-- The **Riemann curvature tensor** of `cov` on smooth vector fields:
+`R(X,Y)Z = ∇_X ∇_Y Z − ∇_Y ∇_X Z − ∇_{[X,Y]} Z`. -/
+noncomputable def curv (cov : CovariantDerivative I E (TangentSpace I (M := M)))
+    (X Y Z : Π x : M, TangentSpace I x) : Π x : M, TangentSpace I x :=
+  fun x =>
+    cov (fun y => cov Z y (Y y)) x (X x)
+      - cov (fun y => cov Z y (X y)) x (Y x)
+      - cov Z x (mlieBracket I X Y x)
+
+/-- The manifold is **strictly quarter-pinched**: every sectional curvature
+`K = ⟨R(X,Y)Y, X⟩` at an orthonormal pair lies in Knill's interval `(1, 4]`. -/
+def QuarterPinched
+    (cov : CovariantDerivative I E (TangentSpace I (M := M))) : Prop :=
+  ∀ (X Y : Π x : M, TangentSpace I x),
+    CMDiff ∞ (T% X) → CMDiff ∞ (T% Y) →
+    ∀ x : M,
+      inner ℝ (X x) (X x) = (1 : ℝ) → inner ℝ (Y x) (Y x) = (1 : ℝ) →
+      inner ℝ (X x) (Y x) = (0 : ℝ) →
+      (1 : ℝ) < inner ℝ (curv cov X Y Y x) (X x) ∧
+        inner ℝ (curv cov X Y Y x) (X x) ≤ (4 : ℝ)
+
+/-- **Topological sphere theorem** (Berger–Klingenberg–Rauch 1960). A closed,
+simply-connected, smooth `d`-manifold (`d ≥ 2`) whose Levi-Civita connection is
+strictly quarter-pinched is homeomorphic to the standard `d`-sphere. -/
+@[eval_problem]
+theorem sphere_theorem
+    [I.Boundaryless] [T2Space M] [CompactSpace M] [SimplyConnectedSpace M]
+    (hdim : 2 ≤ Module.finrank ℝ E)
+    (cov : CovariantDerivative I E (TangentSpace I (M := M)))
+    [ContMDiffCovariantDerivative cov ∞]
+    (_htor : cov.torsion = 0) (_hmet : IsMetricCompatible cov)
+    (_hpinch : QuarterPinched cov) :
+    Nonempty
+      (M ≃ₜ sphere (0 : EuclideanSpace ℝ (Fin (Module.finrank ℝ E + 1))) 1) := by
+  sorry
+
+/-- **Differentiable sphere theorem** (Brendle–Schoen 2007). Under the same
+hypotheses, `M` is diffeomorphic to the standard `d`-sphere. -/
+@[eval_problem]
+theorem differentiable_sphere_theorem
+    [I.Boundaryless] [T2Space M] [CompactSpace M] [SimplyConnectedSpace M]
+    (hdim : 2 ≤ Module.finrank ℝ E)
+    (cov : CovariantDerivative I E (TangentSpace I (M := M)))
+    [ContMDiffCovariantDerivative cov ∞]
+    (_htor : cov.torsion = 0) (_hmet : IsMetricCompatible cov)
+    (_hpinch : QuarterPinched cov) :
+    Nonempty
+      (M ≃ₘ⟮I, 𝓡 (Module.finrank ℝ E)⟯
+        (sphere (0 : EuclideanSpace ℝ (Fin (Module.finrank ℝ E + 1))) 1)) := by
+  sorry
+
+end LeanEval.Geometry.SphereTheorem

--- a/manifests/problems/sphere_theorem_differentiable.toml
+++ b/manifests/problems/sphere_theorem_differentiable.toml
@@ -1,0 +1,9 @@
+id = "sphere_theorem_differentiable"
+title = "Differentiable sphere theorem (Brendle–Schoen)"
+test = false
+module = "LeanEval.Geometry.SphereTheorem"
+holes = ["differentiable_sphere_theorem"]
+submitter = "Kim Morrison"
+notes = "Under the same hypotheses as the topological sphere theorem (closed, simply-connected, strictly quarter-pinched, d ≥ 2), the manifold is diffeomorphic to the standard d-sphere (Brendle–Schoen 2007, via Ricci flow). Shares the §121 trusted helpers (IsMetricCompatible, curv, QuarterPinched). Mathlib has no Ricci flow or curvature. Candidate from §121 of the Knill survey (additional 1)."
+source = "S. Brendle & R. Schoen, *Manifolds with 1/4-pinched curvature are space forms*, J. AMS 22 (2009). Knill, *Some fundamental theorems in mathematics*, §121."
+informal_solution = "Brendle–Schoen via Hamilton's Ricci flow. Run the normalized Ricci flow ġ = −2Ric(g) + (2/d)r̄ g from the quarter-pinched metric. The key analytic input is that the strict quarter-pinching condition (more precisely, nonnegative isotropic curvature on M × ℝ²) is preserved by the flow (Brendle–Schoen's curvature-pinching estimates via the maximum principle for the curvature-tensor reaction–diffusion equation), and the flow converges, after rescaling, to a constant-curvature round metric. Hence M is diffeomorphic to the round sphere. Requires Ricci flow and the pinching-preservation estimates, none in Mathlib."

--- a/manifests/problems/sphere_theorem_topological.toml
+++ b/manifests/problems/sphere_theorem_topological.toml
@@ -1,0 +1,9 @@
+id = "sphere_theorem_topological"
+title = "Topological sphere theorem (Berger–Klingenberg–Rauch)"
+test = false
+module = "LeanEval.Geometry.SphereTheorem"
+holes = ["sphere_theorem"]
+submitter = "Kim Morrison"
+notes = "A closed, simply-connected, strictly quarter-pinched (sectional curvature in (1,4]) smooth Riemannian d-manifold (d ≥ 2) is homeomorphic to the standard d-sphere. Trusted helpers IsMetricCompatible, curv (Riemann curvature tensor), QuarterPinched (non-holes); following §38 the Levi-Civita connection is hypothesized as a smooth torsion-free metric-compatible covariant derivative (Mathlib has the interface but does not construct Levi-Civita). Mathlib has no Riemann/sectional curvature or pinching. Candidate from §121 of the Knill survey."
+source = "M. Berger; W. Klingenberg; H. E. Rauch (topological sphere theorem, 1951–1961). Knill, *Some fundamental theorems in mathematics*, §121."
+informal_solution = "Classical sphere theorem via Toponogov/Klingenberg. From strict quarter-pinching, Klingenberg's injectivity-radius estimate gives inj(M) ≥ π/√(max K). Cover M by two metric balls around a point and its farthest point; Toponogov's triangle comparison shows each is a disk and they glue along a sphere, exhibiting M as a twisted sphere, hence homeomorphic to Sᵈ (Brown's theorem / Reeb). Needs the curvature comparison geometry (Toponogov, Rauch, Klingenberg injectivity radius) absent from Mathlib."


### PR DESCRIPTION
This PR adds two category-(b) problems from §121 of the Knill survey: the topological sphere theorem (Berger–Klingenberg–Rauch 1960 — a closed simply-connected strictly quarter-pinched manifold is homeomorphic to the sphere) and the differentiable sphere theorem (Brendle–Schoen 2007 — diffeomorphic, via Ricci flow). The trusted helpers (`IsMetricCompatible`, `curv` the Riemann curvature tensor, `QuarterPinched`) are non-holes; following §38 the Levi-Civita connection is hypothesized as a smooth torsion-free metric-compatible covariant derivative (Mathlib has the covariant-derivative interface but does not yet construct Levi-Civita). Mathlib has no Riemann/sectional curvature, pinching, or Ricci flow.
🤖 Prepared with Claude Code