### PR TITLE
feat: add Mazur torsion theorem eval problem

### DIFF
--- a/LeanEval/NumberTheory/MazurTorsion.lean
+++ b/LeanEval/NumberTheory/MazurTorsion.lean
@@ -1,0 +1,34 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.NumberTheory.MazurTorsion
+
+/-!
+# Mazur's torsion theorem
+
+`mazur_torsion` (Mazur 1977): the torsion subgroup of `E(ℚ)` for an elliptic
+curve over `ℚ` is one of the fifteen groups `ℤ/n` (`n ∈ {1,…,10,12}`) or
+`ℤ/2 × ℤ/2m` (`m ∈ {1,2,3,4}`). Trusted helper `IsInMazurClass` (non-hole).
+Mathlib has Weierstrass curves and their point groups but not Mazur's theorem
+(which rests on the geometry of the modular curves `X₁(N)`).
+Category-(b) candidate from §139 of the Knill survey.
+-/
+
+open scoped WeierstrassCurve
+
+/-- The **Mazur class**: isomorphic to `ℤ/n` (`n ∈ {1,…,10,12}`) or
+`ℤ/2 × ℤ/2m` (`m ∈ {1,2,3,4}`). -/
+def IsInMazurClass (T : Type*) [AddCommGroup T] : Prop :=
+  (∃ n ∈ ({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12} : Finset ℕ),
+      Nonempty (T ≃+ ZMod n)) ∨
+  (∃ m ∈ ({2, 4, 6, 8} : Finset ℕ),
+      Nonempty (T ≃+ (ZMod 2 × ZMod m)))
+
+/-- **Mazur's torsion theorem.** The torsion subgroup of `E(ℚ)` lies in the
+Mazur class. -/
+@[eval_problem]
+theorem mazur_torsion (E : WeierstrassCurve ℚ) [E.IsElliptic] :
+    IsInMazurClass ↥(AddCommGroup.torsion (WeierstrassCurve.Affine.Point E)) := by
+  sorry
+
+end LeanEval.NumberTheory.MazurTorsion

--- a/manifests/problems/mazur_torsion.toml
+++ b/manifests/problems/mazur_torsion.toml
@@ -1,0 +1,9 @@
+id = "mazur_torsion"
+title = "Mazur's torsion theorem"
+test = false
+module = "LeanEval.NumberTheory.MazurTorsion"
+holes = ["mazur_torsion"]
+submitter = "Kim Morrison"
+notes = "The torsion subgroup of E(ℚ) for an elliptic curve over ℚ is one of fifteen groups: ℤ/n (n ∈ {1,…,10,12}) or ℤ/2 × ℤ/2m (m ∈ {1,2,3,4}). Trusted helper IsInMazurClass (non-hole). Mathlib has Weierstrass curves and point groups but not Mazur's theorem (which uses the modular curves X₁(N)). Candidate from §139 of the Knill survey."
+source = "B. Mazur, *Modular curves and the Eisenstein ideal*, Publ. IHÉS 47 (1977). Knill, *Some fundamental theorems in mathematics*, §139."
+informal_solution = "Mazur's deep theorem. A point of order N on E/ℚ gives a rational point on the modular curve X₁(N); Mazur showed X₁(N) has no non-cuspidal rational points for N = 11 or N ≥ 13 (via the Eisenstein-ideal analysis of J₀(N) and the formal-immersion method), and handled the ℤ/2×ℤ/2m families similarly with X₁(2,2m). Hence only the fifteen listed torsion structures occur. Far beyond current Mathlib."


### PR DESCRIPTION
This PR adds Mazur's torsion theorem (§139 of the Knill survey): the torsion subgroup of `E(ℚ)` for an elliptic curve over `ℚ` is one of the fifteen groups `ℤ/n` (`n ∈ {1,…,10,12}`) or `ℤ/2 × ℤ/2m` (`m ∈ {1,2,3,4}`). The trusted helper `IsInMazurClass` is a non-hole. Mathlib has Weierstrass curves and their point groups but not Mazur's theorem (which rests on the geometry of the modular curves `X₁(N)`).
🤖 Prepared with Claude Code