### PR TITLE
feat: add Dehn-Sommerville equations eval problem

### DIFF
--- a/LeanEval/Combinatorics/DehnSommerville.lean
+++ b/LeanEval/Combinatorics/DehnSommerville.lean
@@ -1,0 +1,46 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Combinatorics.DehnSommerville
+
+/-!
+# The Dehn–Sommerville equations for simplicial spheres
+
+`dehn_sommerville`: the h-vector of a finite simplicial `(d-1)`-sphere is
+symmetric, `h_j = h_{d-j}`. Trusted helpers (`FiniteSimplicialSphere`,
+`faceCount`, `extendedFaceCount`, `hVector`) are non-holes. Mathlib has
+simplicial complexes but no f- or h-vector or Dehn–Sommerville theory. (The
+companion upper-bound theorem for simplicial spheres is already in lean-eval.)
+Category-(b) candidate from §142 of the Knill survey.
+-/
+
+/-- A finite geometric simplicial complex homeomorphic to the `(d-1)`-sphere. -/
+structure FiniteSimplicialSphere (d : ℕ) where
+  K : Geometry.SimplicialComplex ℝ (EuclideanSpace ℝ (Fin d))
+  finite_faces : K.faces.Finite
+  sphere_homeomorph :
+    Nonempty (K.space ≃ₜ Metric.sphere (0 : EuclideanSpace ℝ (Fin d)) 1)
+
+/-- Number of `k`-dimensional faces (faces with `k+1` vertices). -/
+noncomputable def faceCount {d : ℕ} (X : FiniteSimplicialSphere d) (k : ℕ) : ℕ :=
+  {s : Finset (EuclideanSpace ℝ (Fin d)) | s ∈ X.K.faces ∧ s.card = k + 1}.ncard
+
+/-- Extended f-vector entry: `f_{-1} = 1`, then `f_{i-1}`. -/
+noncomputable def extendedFaceCount {d : ℕ} (X : FiniteSimplicialSphere d) (i : ℕ) : ℕ :=
+  if i = 0 then 1 else faceCount X (i - 1)
+
+/-- The h-vector via the alternating binomial transform of the f-vector. -/
+noncomputable def hVector {d : ℕ} (X : FiniteSimplicialSphere d) (j : ℕ) : ℤ :=
+  ∑ i ∈ Finset.range (j + 1),
+    (-1 : ℤ) ^ (j - i) * (Nat.choose (d - i) (j - i) : ℤ) *
+      (extendedFaceCount X i : ℤ)
+
+/-- **Dehn–Sommerville equations.** The h-vector of a finite simplicial sphere
+is symmetric: `h_j = h_{d-j}`. -/
+@[eval_problem]
+theorem dehn_sommerville
+    {d j : ℕ} (X : FiniteSimplicialSphere d) (hj : j ≤ d) :
+    hVector X j = hVector X (d - j) := by
+  sorry
+
+end LeanEval.Combinatorics.DehnSommerville

--- a/manifests/problems/dehn_sommerville.toml
+++ b/manifests/problems/dehn_sommerville.toml
@@ -1,0 +1,9 @@
+id = "dehn_sommerville"
+title = "Dehn–Sommerville equations for simplicial spheres"
+test = false
+module = "LeanEval.Combinatorics.DehnSommerville"
+holes = ["dehn_sommerville"]
+submitter = "Kim Morrison"
+notes = "The h-vector of a finite simplicial (d-1)-sphere is symmetric: h_j = h_{d-j}. Trusted helpers (FiniteSimplicialSphere, faceCount, extendedFaceCount, hVector) are non-holes. Mathlib has simplicial complexes but no f/h-vector or Dehn–Sommerville theory. The companion upper-bound theorem for simplicial spheres is already in lean-eval. Candidate from §142 of the Knill survey."
+source = "M. Dehn (1905); D. M. Y. Sommerville (1927); see Stanley, *Combinatorics and Commutative Algebra*. Knill, *Some fundamental theorems in mathematics*, §142."
+informal_solution = "The Dehn–Sommerville relations follow from Poincaré duality / the Euler relations on the face lattice of a simplicial sphere. Encode the f-vector in the h-polynomial h(t) = ∑ h_j t^j defined by ∑ f_{i-1}(t-1)^{d-i} = ∑ h_i t^{d-i}; the Euler–Poincaré relation for a (d-1)-sphere (each face's link is a sphere, χ matches) translates into the functional equation h(t) = t^d h(1/t), i.e. h_j = h_{d-j}. Requires the face-ring/Euler-relation machinery absent from Mathlib."


### PR DESCRIPTION
This PR adds the Dehn–Sommerville equations (§142 of the Knill survey): the h-vector of a finite simplicial `(d-1)`-sphere is symmetric, `h_j = h_{d-j}`. The trusted helpers (`FiniteSimplicialSphere`, `faceCount`, `hVector`, …) are non-holes. Mathlib has simplicial complexes but no f-/h-vector or Dehn–Sommerville theory. The companion upper-bound theorem for simplicial spheres is already in lean-eval (#380).
🤖 Prepared with Claude Code