### PR TITLE
feat: add Hurewicz degree-1 eval problem

### DIFF
--- a/LeanEval/Topology/Hurewicz.lean
+++ b/LeanEval/Topology/Hurewicz.lean
@@ -1,0 +1,32 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Topology.Hurewicz
+
+/-!
+# Hurewicz theorem (degree 1): H₁ is the abelianization of π₁
+
+`hurewicz_h1_abelianization`: for a path-connected space, the first integral
+singular homology group is the abelianization of the fundamental group. Trusted
+helper `IntegralHomology` (non-hole). Path-connectedness is essential. Mathlib
+has singular homology and the fundamental group but not the degree-1 Hurewicz
+isomorphism.
+Category-(b) candidate from §153 of the Knill survey.
+-/
+
+open CategoryTheory AlgebraicTopology
+
+/-- Integral singular homology in degree `n`, as an additive group. -/
+noncomputable abbrev IntegralHomology (n : ℕ) (X : Type) [TopologicalSpace X] : AddCommGrpCat :=
+  ((singularHomologyFunctor AddCommGrpCat n).obj (AddCommGrpCat.of ℤ)).obj (TopCat.of X)
+
+/-- **Hurewicz (n = 1).** For a path-connected space `X`, `H₁(X;ℤ)` is the
+abelianization of `π₁(X, x)`. -/
+@[eval_problem]
+theorem hurewicz_h1_abelianization
+    (X : Type) [TopologicalSpace X] [PathConnectedSpace X] (x : X) :
+    Nonempty (Additive (Abelianization (FundamentalGroup X x)) ≃+
+      (IntegralHomology 1 X : Type)) := by
+  sorry
+
+end LeanEval.Topology.Hurewicz

--- a/manifests/problems/hurewicz_h1_abelianization.toml
+++ b/manifests/problems/hurewicz_h1_abelianization.toml
@@ -1,0 +1,9 @@
+id = "hurewicz_h1_abelianization"
+title = "Hurewicz theorem in degree 1 (H₁ = abelianization of π₁)"
+test = false
+module = "LeanEval.Topology.Hurewicz"
+holes = ["hurewicz_h1_abelianization"]
+submitter = "Kim Morrison"
+notes = "For a path-connected space X, the first integral singular homology group is the abelianization of the fundamental group. Trusted helper IntegralHomology (non-hole). Path-connectedness is essential. Mathlib has singular homology and the fundamental group but not the degree-1 Hurewicz isomorphism. Candidate from §153 of the Knill survey."
+source = "W. Hurewicz (1935); see Hatcher, *Algebraic Topology*, Theorem 2A.1. Knill, *Some fundamental theorems in mathematics*, §153."
+informal_solution = "Construct the natural map h : π₁(X,x) → H₁(X;ℤ) sending a loop to its singular 1-cycle. It kills commutators (H₁ is abelian), giving Φ : π₁^{ab} → H₁. Surjectivity: for path-connected X every 1-cycle is homologous to a sum of loops based at x (connect with paths). Injectivity: a loop bounding a 2-chain can be filled by a homotopy, using the path-connectedness to base everything at x. Hence Φ is an isomorphism. Requires comparing the simplicial/singular chain model with π₁, not in Mathlib."


### PR DESCRIPTION
This PR adds the degree-1 Hurewicz theorem (§153 of the Knill survey): for a path-connected space `X`, the first integral singular homology group `H₁(X;ℤ)` is the abelianization of the fundamental group `π₁(X,x)`. The trusted helper `IntegralHomology` is a non-hole. Path-connectedness is essential. Mathlib has singular homology and the fundamental group but not the degree-1 Hurewicz isomorphism.
🤖 Prepared with Claude Code