### PR TITLE
feat: add Pick's theorem eval problem

### DIFF
--- a/LeanEval/Geometry/PicksTheorem.lean
+++ b/LeanEval/Geometry/PicksTheorem.lean
@@ -1,0 +1,63 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Geometry.PicksTheorem
+
+/-!
+# Pick's theorem
+
+`pick` (Pick 1899): a simple lattice polygon has area `I + B/2 − 1`, with `I`/`B`
+the interior/boundary lattice-point counts. Trusted helpers (`toPlane`,
+`latPoly`, `inside`, `area`, `Adjacent`, `IsSimple`, `boundaryPts`,
+`interiorPts`) are non-holes. Mathlib has `Polygon` and its boundary but no
+polygon interior, lattice-point counts, or Pick's theorem.
+Category-(b) candidate from §154 of the Knill survey.
+-/
+
+open MeasureTheory
+
+/-- Coordinatewise cast of a lattice point to the plane. -/
+def toPlane (z : ℤ × ℤ) : ℝ × ℝ := ((z.1 : ℝ), (z.2 : ℝ))
+
+/-- The lattice polygon on integer vertex data `v`. -/
+def latPoly {n : ℕ} (v : Fin n → ℤ × ℤ) : Polygon (ℝ × ℝ) n :=
+  ⟨fun i => toPlane (v i)⟩
+
+/-- The open interior region of a planar curve `S`: points off `S` whose
+component in `Sᶜ` is bounded (the Jordan interior for a simple closed curve). -/
+def inside (S : Set (ℝ × ℝ)) : Set (ℝ × ℝ) :=
+  {x | x ∉ S ∧ Bornology.IsBounded (connectedComponentIn Sᶜ x)}
+
+/-- Enclosed area: Lebesgue measure of the interior region. -/
+noncomputable def area (S : Set (ℝ × ℝ)) : ℝ := (volume (inside S)).toReal
+
+/-- Cyclic adjacency of edge indices. -/
+def Adjacent {n : ℕ} (i j : Fin n) : Prop :=
+  finRotate n i = j ∨ finRotate n j = i
+
+/-- A simple (Jordan) polygon. -/
+def IsSimple {n : ℕ} (poly : Polygon (ℝ × ℝ) n) : Prop :=
+  poly.HasNondegenerateEdges ∧
+  (∀ i j : Fin n, i ≠ j → ¬ Adjacent i j →
+      Disjoint (poly.edgeSet ℝ i) (poly.edgeSet ℝ j)) ∧
+  (∀ i : Fin n, poly.edgeSet ℝ i ∩ poly.edgeSet ℝ (finRotate n i)
+      = {poly (finRotate n i)})
+
+/-- Number of boundary lattice points. -/
+noncomputable def boundaryPts {n : ℕ} (v : Fin n → ℤ × ℤ) : ℕ :=
+  Nat.card {z : ℤ × ℤ | toPlane z ∈ (latPoly v).boundary (R := ℝ)}
+
+/-- Number of interior lattice points. -/
+noncomputable def interiorPts {n : ℕ} (v : Fin n → ℤ × ℤ) : ℕ :=
+  Nat.card {z : ℤ × ℤ | toPlane z ∈ inside ((latPoly v).boundary (R := ℝ))}
+
+/-- **Pick's theorem.** A simple lattice polygon with `n ≥ 3` vertices has area
+`I + B/2 − 1`. -/
+@[eval_problem]
+theorem pick {n : ℕ} (hn : 3 ≤ n) (v : Fin n → ℤ × ℤ)
+    (hsimple : IsSimple (latPoly v)) :
+    area ((latPoly v).boundary (R := ℝ))
+      = (interiorPts v : ℝ) + (boundaryPts v : ℝ) / 2 - 1 := by
+  sorry
+
+end LeanEval.Geometry.PicksTheorem

--- a/manifests/problems/pick.toml
+++ b/manifests/problems/pick.toml
@@ -1,0 +1,9 @@
+id = "pick"
+title = "Pick's theorem"
+test = false
+module = "LeanEval.Geometry.PicksTheorem"
+holes = ["pick"]
+submitter = "Kim Morrison"
+notes = "A simple lattice polygon with n ≥ 3 vertices has area I + B/2 − 1, with I/B the interior/boundary lattice-point counts. Trusted helpers (toPlane, latPoly, inside, area, Adjacent, IsSimple, boundaryPts, interiorPts) are non-holes; the simplicity hypothesis is mandatory (the formula is false for self-intersecting polygons). Mathlib has Polygon and its boundary but no polygon interior, lattice counts, or Pick's theorem (formalized in Isabelle/HOL but not Lean). Candidate from §154 of the Knill survey."
+source = "G. Pick, *Geometrisches zur Zahlenlehre* (1899). Knill, *Some fundamental theorems in mathematics*, §154."
+informal_solution = "Additivity + triangulation. Pick's measure P(poly) = I + B/2 − 1 is additive when gluing polygons along an edge (shared boundary points are double-counted as boundary then become interior, and the −1 terms combine correctly). Triangulate the simple polygon into lattice triangles; reduce to elementary (no interior/edge lattice points) triangles, each of area 1/2 with P = 0 + 3/2 − 1 = 1/2. Since both area and P are additive over the triangulation and agree on elementary triangles, they agree on the polygon. Requires the lattice triangulation + additivity machinery, absent from Mathlib."


### PR DESCRIPTION
This PR adds Pick's theorem (§154 of the Knill survey): a simple lattice polygon with `n ≥ 3` vertices has area `I + B/2 − 1`, where `I`/`B` are the interior/boundary lattice-point counts. The trusted helpers (`inside`, `area`, `IsSimple`, `boundaryPts`, `interiorPts`, …) are non-holes; the simplicity hypothesis is mandatory (the formula fails for self-intersecting polygons). Mathlib has `Polygon` and its boundary but no polygon interior, lattice-point counts, or Pick's theorem (it is formalized in Isabelle/HOL but not Lean).
🤖 Prepared with Claude Code