### PR TITLE
feat: add Bertrand's theorem (central force) eval problem

### DIFF
--- a/LeanEval/Dynamics/Bertrand.lean
+++ b/LeanEval/Dynamics/Bertrand.lean
@@ -1,0 +1,74 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Dynamics.Bertrand
+
+/-!
+# Bertrand's theorem on central-force motion
+
+`bertrand_central_force` (Bertrand 1873): among central potentials admitting a
+non-circular bounded non-collision orbit, those for which *every* bounded
+non-collision orbit is periodic are exactly the Hooke (harmonic) and Kepler
+(inverse-radius) potentials. Trusted helpers (`velocity`, `acceleration`,
+`centralAcceleration`, `IsCentralOrbit`, `IsBoundedOrbit`, `IsPeriodicOrbit`,
+`AllBoundedOrbitsPeriodic`, `HasNonCircularBoundedOrbit`, `IsBertrandPotential`)
+are non-holes; the non-degeneracy hypothesis is essential. Mathlib has no
+central-force/Bertrand theory.
+Category-(b) candidate from §156 of the Knill survey.
+-/
+
+/-- The physical plane. -/
+abbrev Plane := EuclideanSpace ℝ (Fin 2)
+
+/-- Velocity of a parametrized orbit. -/
+noncomputable def velocity (q : ℝ → Plane) (t : ℝ) : Plane := fderiv ℝ q t 1
+
+/-- Acceleration of a parametrized orbit. -/
+noncomputable def acceleration (q : ℝ → Plane) (t : ℝ) : Plane :=
+  fderiv ℝ (fun s => velocity q s) t 1
+
+/-- The acceleration field of a radial potential `V`: `-V'(ρ) x / ρ`. -/
+noncomputable def centralAcceleration (V : ℝ → ℝ) (x : Plane) : Plane :=
+  -((deriv V ‖x‖) / ‖x‖) • x
+
+/-- A global non-collision `C²` solution of the central-force equation. -/
+def IsCentralOrbit (V : ℝ → ℝ) (q : ℝ → Plane) : Prop :=
+  ContDiff ℝ 2 q ∧ (∀ t, q t ≠ 0) ∧
+    ∀ t, acceleration q t = centralAcceleration V (q t)
+
+/-- The orbit is bounded in phase space (position and velocity). -/
+def IsBoundedOrbit (q : ℝ → Plane) : Prop :=
+  Bornology.IsBounded (Set.range q) ∧
+    Bornology.IsBounded (Set.range (velocity q))
+
+/-- The orbit closes up after a positive time. -/
+def IsPeriodicOrbit (q : ℝ → Plane) : Prop :=
+  ∃ T : ℝ, 0 < T ∧ Function.Periodic q T
+
+/-- Every bounded global non-collision orbit of `V` is periodic. -/
+def AllBoundedOrbitsPeriodic (V : ℝ → ℝ) : Prop :=
+  ∀ q : ℝ → Plane, IsCentralOrbit V q → IsBoundedOrbit q → IsPeriodicOrbit q
+
+/-- `V` admits a non-circular bounded non-collision orbit (radius takes ≥ 2
+values) — the non-degeneracy Bertrand actually classifies. -/
+def HasNonCircularBoundedOrbit (V : ℝ → ℝ) : Prop :=
+  ∃ q : ℝ → Plane, IsCentralOrbit V q ∧ IsBoundedOrbit q ∧
+    ∃ t₁ t₂ : ℝ, ‖q t₁‖ ≠ ‖q t₂‖
+
+/-- A Bertrand potential: Hooke `a ρ² + b` (`a > 0`) or Kepler `-a/ρ + b`
+(`a > 0`), for positive radii. -/
+def IsBertrandPotential (V : ℝ → ℝ) : Prop :=
+  (∃ a b : ℝ, 0 < a ∧ ∀ ρ : ℝ, 0 < ρ → V ρ = a * ρ ^ 2 + b) ∨
+  (∃ a b : ℝ, 0 < a ∧ ∀ ρ : ℝ, 0 < ρ → V ρ = -a / ρ + b)
+
+/-- **Bertrand's theorem.** Among central potentials with a non-circular bounded
+non-collision orbit, all-bounded-orbits-periodic holds iff `V` is a Hooke or
+Kepler potential. -/
+@[eval_problem]
+theorem bertrand_central_force
+    (V : ℝ → ℝ) (hV : ContDiffOn ℝ 2 V (Set.Ioi 0))
+    (hne : HasNonCircularBoundedOrbit V) :
+    AllBoundedOrbitsPeriodic V ↔ IsBertrandPotential V := by
+  sorry
+
+end LeanEval.Dynamics.Bertrand

--- a/manifests/problems/bertrand_central_force.toml
+++ b/manifests/problems/bertrand_central_force.toml
@@ -1,0 +1,9 @@
+id = "bertrand_central_force"
+title = "Bertrand's theorem on central-force motion"
+test = false
+module = "LeanEval.Dynamics.Bertrand"
+holes = ["bertrand_central_force"]
+submitter = "Kim Morrison"
+notes = "Among central potentials admitting a non-circular bounded non-collision orbit, those for which every bounded non-collision orbit is periodic are exactly the Hooke (harmonic) and Kepler (inverse-radius) potentials. Trusted helpers (velocity, acceleration, centralAcceleration, IsCentralOrbit, IsBoundedOrbit, IsPeriodicOrbit, AllBoundedOrbitsPeriodic, HasNonCircularBoundedOrbit, IsBertrandPotential) are non-holes; the non-degeneracy hypothesis HasNonCircularBoundedOrbit is essential (else V≡0 is a vacuous counterexample). Mathlib has no central-force/Bertrand theory. Candidate from §156 of the Knill survey."
+source = "J. Bertrand, *Théorème relatif au mouvement d'un point attiré vers un centre fixe*, C. R. Acad. Sci. 77 (1873). Knill, *Some fundamental theorems in mathematics*, §156."
+informal_solution = "Reduce to the radial equation: with angular momentum L, the orbit radius obeys d²u/dθ² + u = -F(1/u)/(L²u²) where u = 1/ρ. Circular orbits exist where the effective potential has a minimum; the apsidal angle Δθ between successive perihelia, linearized about a circular orbit of radius ρ, is π/√(3 + ρ V''/V'). For all bounded orbits to close, Δθ must be a constant rational multiple of π for all ρ, forcing ρ V''/V' = const, i.e. a power law V ∝ ρ^k. A finite-amplitude (non-perturbative) closure analysis then pins k ∈ {2, -1}: Hooke and Kepler. Requires ODE/orbit theory absent from Mathlib."


### PR DESCRIPTION
This PR adds Bertrand's theorem (§156 of the Knill survey): among central potentials admitting a non-circular bounded non-collision orbit, those for which *every* bounded non-collision orbit is periodic are exactly the Hooke (harmonic) and Kepler (inverse-radius) potentials. The trusted helpers (`IsCentralOrbit`, `AllBoundedOrbitsPeriodic`, `HasNonCircularBoundedOrbit`, `IsBertrandPotential`, …) are non-holes; the non-degeneracy hypothesis is essential (otherwise `V ≡ 0` is a vacuous counterexample). Mathlib has no central-force / Bertrand theory.
🤖 Prepared with Claude Code