### PR TITLE
feat: add Onsager 2D Ising phase transition eval problem

### DIFF
--- a/LeanEval/Analysis/IsingPhaseTransition.lean
+++ b/LeanEval/Analysis/IsingPhaseTransition.lean
@@ -1,0 +1,62 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.IsingPhaseTransition
+
+/-!
+# Onsager's 2D Ising phase transition
+
+`ising_2d_phase_transition` (Onsager 1944): the thermodynamic-limit free energy
+of the zero-field ferromagnetic square-lattice Ising model exists for every
+inverse temperature and is non-analytic at a positive critical point. Trusted
+helpers (`isingEnergy`, `isingPartitionFunction`, `finiteIsingFreeEnergy`, …)
+are non-holes. Mathlib has no statistical-mechanics / Ising machinery.
+Category-(b) candidate from §158 of the Knill survey.
+-/
+
+open Filter
+open scoped BigOperators Topology
+
+/-- Sites in the `L × L` periodic square lattice. -/
+abbrev IsingSite (L : ℕ) [NeZero L] : Type := ZMod L × ZMod L
+
+/-- Ising spins encoded as `±1`. -/
+def spinValue (b : Bool) : ℝ := if b then 1 else -1
+
+/-- Right neighbour in the periodic lattice. -/
+def rightNeighbour {L : ℕ} [NeZero L] (p : IsingSite L) : IsingSite L :=
+  ((p.1 + 1 : ZMod L), p.2)
+
+/-- Upward neighbour in the periodic lattice. -/
+def upNeighbour {L : ℕ} [NeZero L] (p : IsingSite L) : IsingSite L :=
+  (p.1, (p.2 + 1 : ZMod L))
+
+/-- Zero-field ferromagnetic Ising Hamiltonian on the periodic box. -/
+noncomputable def isingEnergy (L : ℕ) [NeZero L] (σ : IsingSite L → Bool) : ℝ :=
+  -((∑ p : IsingSite L, spinValue (σ p) * spinValue (σ (rightNeighbour p))) +
+      ∑ p : IsingSite L, spinValue (σ p) * spinValue (σ (upNeighbour p)))
+
+/-- Finite-volume partition function at inverse temperature `β`. -/
+noncomputable def isingPartitionFunction (L : ℕ) [NeZero L] (β : ℝ) : ℝ :=
+  ∑ σ : IsingSite L → Bool, Real.exp (-β * isingEnergy L σ)
+
+/-- Finite-volume free energy density. -/
+noncomputable def finiteIsingFreeEnergy (L : ℕ) [NeZero L] (β : ℝ) : ℝ :=
+  Real.log (isingPartitionFunction L β) / (L : ℝ) ^ 2
+
+/-- Free energy along positive side lengths `n+1`. -/
+noncomputable def finiteIsingFreeEnergySeq (n : ℕ) (β : ℝ) : ℝ :=
+  finiteIsingFreeEnergy (n + 1) β
+
+/-- **Onsager's 2D Ising phase transition.** The thermodynamic-limit free
+energy exists for all `β` and is non-analytic at some positive `βc`. -/
+@[eval_problem]
+theorem ising_2d_phase_transition :
+    ∃ (F : ℝ → ℝ) (βc : ℝ),
+      0 < βc ∧
+        (∀ β : ℝ,
+          Tendsto (fun n : ℕ => finiteIsingFreeEnergySeq n β) atTop (𝓝 (F β))) ∧
+        ¬ AnalyticAt ℝ F βc := by
+  sorry
+
+end LeanEval.Analysis.IsingPhaseTransition

--- a/manifests/problems/ising_2d_phase_transition.toml
+++ b/manifests/problems/ising_2d_phase_transition.toml
@@ -1,0 +1,8 @@
+id = "ising_2d_phase_transition"
+title = "Onsager's 2D Ising phase transition"
+test = false
+module = "LeanEval.Analysis.IsingPhaseTransition"
+holes = ["ising_2d_phase_transition"]
+submitter = "Kim Morrison"
+notes = "The thermodynamic-limit free energy of the zero-field ferromagnetic square-lattice Ising model exists for every inverse temperature and is non-analytic at a positive critical βc (Onsager 1944). Trusted helpers (isingEnergy, isingPartitionFunction, finiteIsingFreeEnergy, …) are non-holes; the ∀β limit clause pins F to the genuine infinite-volume free energy so βc must be a real non-analyticity point. Mathlib has no statistical-mechanics machinery. Candidate from §158 of the Knill survey."
+source = "L. Onsager, *Crystal statistics I*, Phys. Rev. 65 (1944). Knill, §158."


### PR DESCRIPTION
This PR adds Onsager's two-dimensional Ising phase transition (§158 of the Knill survey): the thermodynamic-limit free energy of the zero-field ferromagnetic square-lattice Ising model exists for every inverse temperature and is non-analytic at a positive critical `βc`. The trusted helpers (`isingEnergy`, `isingPartitionFunction`, `finiteIsingFreeEnergy`, …) are non-holes; the `∀ β` limit clause pins `F` to the genuine infinite-volume free energy, so `βc` must be a real non-analyticity point. Mathlib has no statistical-mechanics machinery.
🤖 Prepared with Claude Code