### PR TITLE
feat: add Riesz rising sun lemma eval problem

### DIFF
--- a/LeanEval/Analysis/RisingSun.lean
+++ b/LeanEval/Analysis/RisingSun.lean
@@ -1,0 +1,47 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.RisingSun
+
+/-!
+# Riesz's rising sun lemma
+
+`rising_sun_lemma`: every continuous real function on a compact interval has the
+rising-sun property (the shadow set is open, empty iff the function is
+antitone, and otherwise decomposes into disjoint open intervals with endpoint
+inequality `f(c) ≤ f(d)`). Trusted helpers (`risingSunSet`,
+`HasRisingSunDecomposition`, `HasRisingSunProperty`) are non-holes. Mathlib has
+the monotone-a.e.-differentiable consequence but not the rising-sun lemma.
+Category-(b) candidate from §163 of the Knill survey.
+-/
+
+open Set MeasureTheory
+open scoped Topology
+
+/-- Points of `(a,b)` lower than some later point. -/
+def risingSunSet (a b : ℝ) (f : ℝ → ℝ) : Set ℝ :=
+  {x | x ∈ Ioo a b ∧ ∃ t ∈ Icc x b, x < t ∧ f x < f t}
+
+/-- A countable disjoint open-interval decomposition with the endpoint
+inequality `f(c_n) ≤ f(d_n)`. -/
+def HasRisingSunDecomposition (E : Set ℝ) (f : ℝ → ℝ) : Prop :=
+  ∃ c d : ℕ → ℝ,
+    E = ⋃ n : ℕ, Ioo (c n) (d n) ∧
+    (Set.PairwiseDisjoint (Set.univ : Set ℕ) fun n => Ioo (c n) (d n)) ∧
+    ∀ n : ℕ, f (c n) ≤ f (d n)
+
+/-- The rising-sun property on `[a,b]`. -/
+def HasRisingSunProperty (a b : ℝ) (f : ℝ → ℝ) : Prop :=
+  IsOpen (risingSunSet a b f) ∧
+  (risingSunSet a b f = ∅ ↔ AntitoneOn f (Icc a b)) ∧
+  ((risingSunSet a b f).Nonempty → HasRisingSunDecomposition (risingSunSet a b f) f)
+
+/-- **Riesz's rising sun lemma.** Every continuous real function on a compact
+interval has the rising-sun property. -/
+@[eval_problem]
+theorem rising_sun_lemma {a b : ℝ} (hab : a < b) {f : ℝ → ℝ}
+    (hf : ContinuousOn f (Icc a b)) :
+    HasRisingSunProperty a b f := by
+  sorry
+
+end LeanEval.Analysis.RisingSun

--- a/manifests/problems/rising_sun_lemma.toml
+++ b/manifests/problems/rising_sun_lemma.toml
@@ -1,0 +1,8 @@
+id = "rising_sun_lemma"
+title = "Riesz's rising sun lemma"
+test = false
+module = "LeanEval.Analysis.RisingSun"
+holes = ["rising_sun_lemma"]
+submitter = "Kim Morrison"
+notes = "Every continuous real function on a compact interval has the rising-sun property: the shadow set is open, empty iff the function is antitone, else a disjoint union of open intervals with f(c_n) ≤ f(d_n). Trusted helpers (risingSunSet, HasRisingSunDecomposition, HasRisingSunProperty) are non-holes. Mathlib has the monotone-a.e.-differentiable consequence but not the rising-sun lemma. Candidate from §163 of the Knill survey."
+source = "F. Riesz (1932). Knill, §163."


### PR DESCRIPTION
This PR adds Riesz's rising sun lemma (§163 of the Knill survey): every continuous real function on a compact interval has the rising-sun property (shadow set open; empty iff antitone; otherwise a disjoint union of open intervals with `f(cₙ) ≤ f(dₙ)`). The trusted helpers (`risingSunSet`, `HasRisingSunDecomposition`, `HasRisingSunProperty`) are non-holes. Mathlib has the monotone-a.e.-differentiable consequence but not the rising-sun lemma.
🤖 Prepared with Claude Code