### PR TITLE
feat: add alternating sign matrix theorem eval problem

### DIFF
--- a/LeanEval/Combinatorics/AlternatingSignMatrix.lean
+++ b/LeanEval/Combinatorics/AlternatingSignMatrix.lean
@@ -1,0 +1,55 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Combinatorics.AlternatingSignMatrix
+
+/-!
+# The alternating sign matrix theorem
+
+`alternating_sign_matrix_count` (Zeilberger 1994 / Kuperberg 1996): the number
+of `n × n` alternating sign matrices is the Robbins product
+`∏_{k<n} (3k+1)! / (n+k)!`. Trusted helpers (`IsAlternatingSignMatrix`,
+`AlternatingSignMatrix`, `robbinsProduct`, …) are non-holes. Mathlib has no ASM
+enumeration.
+Category-(b) candidate from §168 of the Knill survey.
+-/
+
+open Matrix
+open scoped BigOperators
+
+/-- Partial sum of row `i` up through column `k`. -/
+def rowPartialSum {n : ℕ} (A : Matrix (Fin n) (Fin n) ℤ) (i k : Fin n) : ℤ :=
+  Finset.sum (Finset.univ.filter (fun j : Fin n => j ≤ k)) (fun j => A i j)
+
+/-- Partial sum of column `j` up through row `k`. -/
+def colPartialSum {n : ℕ} (A : Matrix (Fin n) (Fin n) ℤ) (j k : Fin n) : ℤ :=
+  Finset.sum (Finset.univ.filter (fun i : Fin n => i ≤ k)) (fun i => A i j)
+
+/-- A permitted partial sum value for an ASM. -/
+def IsZeroOrOne (a : ℤ) : Prop := a = 0 ∨ a = 1
+
+/-- An `n × n` alternating sign matrix (via the partial-sum characterisation). -/
+def IsAlternatingSignMatrix {n : ℕ} (A : Matrix (Fin n) (Fin n) ℤ) : Prop :=
+  (∀ i j, A i j = -1 ∨ A i j = 0 ∨ A i j = 1) ∧
+  (∀ i k, IsZeroOrOne (rowPartialSum A i k)) ∧
+  (∀ j k, IsZeroOrOne (colPartialSum A j k)) ∧
+  (∀ i, ∑ j, A i j = 1) ∧
+  (∀ j, ∑ i, A i j = 1)
+
+/-- The type of `n × n` alternating sign matrices. -/
+abbrev ASMatrix (n : ℕ) :=
+  { A : Matrix (Fin n) (Fin n) ℤ // IsAlternatingSignMatrix A }
+
+/-- The Robbins / ASM product in `ℚ`. -/
+def robbinsProduct (n : ℕ) : ℚ :=
+  Finset.prod (Finset.range n)
+    (fun k => (Nat.factorial (3 * k + 1) : ℚ) / (Nat.factorial (n + k) : ℚ))
+
+/-- **Alternating sign matrix theorem.** The number of `n × n` ASMs equals the
+Robbins product. -/
+@[eval_problem]
+theorem alternating_sign_matrix_count (n : ℕ) :
+    (Nat.card (ASMatrix n) : ℚ) = robbinsProduct n := by
+  sorry
+
+end LeanEval.Combinatorics.AlternatingSignMatrix

--- a/manifests/problems/alternating_sign_matrix_count.toml
+++ b/manifests/problems/alternating_sign_matrix_count.toml
@@ -4,5 +4,5 @@ test = false
 module = "LeanEval.Combinatorics.AlternatingSignMatrix"
 holes = ["alternating_sign_matrix_count"]
 submitter = "Kim Morrison"
-notes = "The number of n×n alternating sign matrices is the Robbins product ∏_{k<n} (3k+1)!/(n+k)! (Zeilberger 1994; Kuperberg 1996). Trusted helpers (IsAlternatingSignMatrix, AlternatingSignMatrix, robbinsProduct, …) are non-holes. Mathlib has no ASM enumeration. Candidate from §168 of the Knill survey."
+notes = "The number of n×n alternating sign matrices is the Robbins product ∏_{k<n} (3k+1)!/(n+k)! (Zeilberger 1994; Kuperberg 1996). Trusted helpers (IsAlternatingSignMatrix, ASMatrix, robbinsProduct, …) are non-holes. Mathlib has no ASM enumeration. Candidate from §168 of the Knill survey."
 source = "D. Zeilberger (1996); G. Kuperberg (1996). Knill, §168."

--- a/manifests/problems/alternating_sign_matrix_count.toml
+++ b/manifests/problems/alternating_sign_matrix_count.toml
@@ -1,0 +1,8 @@
+id = "alternating_sign_matrix_count"
+title = "The alternating sign matrix theorem"
+test = false
+module = "LeanEval.Combinatorics.AlternatingSignMatrix"
+holes = ["alternating_sign_matrix_count"]
+submitter = "Kim Morrison"
+notes = "The number of n×n alternating sign matrices is the Robbins product ∏_{k<n} (3k+1)!/(n+k)! (Zeilberger 1994; Kuperberg 1996). Trusted helpers (IsAlternatingSignMatrix, AlternatingSignMatrix, robbinsProduct, …) are non-holes. Mathlib has no ASM enumeration. Candidate from §168 of the Knill survey."
+source = "D. Zeilberger (1996); G. Kuperberg (1996). Knill, §168."


### PR DESCRIPTION
This PR adds the alternating sign matrix theorem (§168 of the Knill survey; Zeilberger 1994, Kuperberg 1996): the number of `n × n` alternating sign matrices is the Robbins product `∏_{k<n} (3k+1)!/(n+k)!`. The trusted helpers (`IsAlternatingSignMatrix`, `ASMatrix`, `robbinsProduct`, …) are non-holes. Mathlib has no ASM enumeration.
🤖 Prepared with Claude Code