### PR TITLE
fix: make generated Solution.lean hole delegations noncomputable

### DIFF
--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -742,6 +742,33 @@ def Source.findKeywordBasename (s : Source) (keywords : Array String) (basename 
     i := i + 1
   return none
 
+/-- Rewrite a non-theorem hole signature for the `Solution.lean` delegation:
+inject `@[reducible] noncomputable` immediately before the declaration
+keyword. The delegation must be `noncomputable` because honest solutions to
+data holes are frequently noncomputable (e.g. `genus` in the Jacobian
+challenge), and a computable `def` whose body references a noncomputable
+`Submission.<name>` fails to compile; comparator never sees computability,
+so the marker is invisible to scoring. An existing `noncomputable` modifier
+in the source signature is folded into the rewrite — Lean's grammar puts
+attributes before `noncomputable`, so leaving it in place would produce the
+invalid `noncomputable @[reducible] def`. Returns `none` when no
+`def`/`instance`/`abbrev` keyword anchors the basename. -/
+def injectSolutionHoleModifiers (signature basename : String) : Option String := do
+  let sigSrc := Source.ofString signature
+  let (kwStart, _) ← Source.findKeywordBasename sigSrc #["def", "instance", "abbrev"] basename
+  let prefixText := Source.slice sigSrc 0 kwStart
+  let trimmed := prefixText.trimAsciiEnd.toString
+  let noncomputableKw := "noncomputable"
+  let prefixText :=
+    if trimmed == noncomputableKw then
+      ""
+    else if trimmed.endsWith noncomputableKw &&
+        (trimmed.dropRight noncomputableKw.length).back.isWhitespace then
+      trimmed.dropRight noncomputableKw.length
+    else
+      prefixText
+  return prefixText ++ "@[reducible] noncomputable " ++ Source.slice sigSrc kwStart sigSrc.size
+
 /-! ## Context opens -/
 
 /-- Drop block comments `/- … -/` (nested-aware) that open and close on the
@@ -1498,14 +1525,13 @@ private def renderWorkspaceMultiHole (root : System.FilePath) (entry : EvalProbl
     let basename := lastComponentStr fullName
     let mut signature ← holeDeclSignature declText basename
     if kind != "theorem" then
-      match Source.findKeywordBasename (Source.ofString signature) #["def", "instance", "abbrev"] basename with
+      match injectSolutionHoleModifiers signature basename with
       | none =>
           throw <| IO.userError
-            s!"Could not anchor `@[reducible]` injection in signature for hole '{fullName}'."
-      | some (kwStart, _) =>
-          let sigSrc := Source.ofString signature
-          signature := (Source.slice sigSrc 0 kwStart) ++ "@[reducible] "
-            ++ (Source.slice sigSrc kwStart sigSrc.size)
+            s!"Could not anchor `@[reducible] noncomputable` injection in signature for \
+               hole '{fullName}'."
+      | some rewritten =>
+          signature := rewritten
     let declSrc := Source.ofString declText
     let some (_, kwEnd) := Source.findKeywordBasename declSrc
       #["def", "instance", "theorem", "opaque", "lemma", "abbrev", "class", "example"] basename

--- a/LeanEval/Sandbox/NoncomputableHoleExample.lean
+++ b/LeanEval/Sandbox/NoncomputableHoleExample.lean
@@ -1,0 +1,26 @@
+import Mathlib
+import EvalTools.Markers
+
+/-!
+Minimal example exercising `noncomputable` data holes in the multi-hole
+eval-problem pipeline. Honest solutions to data holes are frequently
+noncomputable (`genus` in the Jacobian challenge is the motivating case),
+so the generated `Solution.lean` delegations must themselves be
+`noncomputable` to compile against such a submission. The `noncomputable`
+modifiers on the holes below additionally exercise folding an existing
+modifier into the rewritten signature: Lean's grammar puts attributes
+before `noncomputable`, so a naive `@[reducible]` injection at the
+declaration keyword would produce invalid syntax.
+-/
+
+@[eval_problem]
+def RWidget : Type := sorry
+
+@[eval_problem]
+noncomputable instance instInhabitedRWidget : Inhabited RWidget := sorry
+
+@[eval_problem]
+noncomputable def rwidgetPoint : RWidget := sorry
+
+@[eval_problem]
+theorem rwidgetPoint_default : rwidgetPoint = (default : RWidget) := sorry

--- a/generated/def_hole_example/Solution.lean
+++ b/generated/def_hole_example/Solution.lean
@@ -8,6 +8,6 @@ defines `Submission.foo := 37` and proves `Submission.foo_def`; comparator
 should accept it.
 -/
 
-@[reducible] def foo : Nat := Submission.foo
+@[reducible] noncomputable def foo : Nat := Submission.foo
 
 theorem foo_def : foo = 37 := Submission.foo_def

--- a/generated/index.json
+++ b/generated/index.json
@@ -1403,6 +1403,20 @@
     "generated_path": "generated/neukirch_uchida"
   },
   {
+    "id": "noncomputable_hole_example",
+    "title": "noncomputable-hole minimal example",
+    "test": true,
+    "submitter": "Kim Morrison",
+    "module": "LeanEval.Sandbox.NoncomputableHoleExample",
+    "holes": [
+      "RWidget",
+      "instInhabitedRWidget",
+      "rwidgetPoint",
+      "rwidgetPoint_default"
+    ],
+    "generated_path": "generated/noncomputable_hole_example"
+  },
+  {
     "id": "novikov_unsolvable",
     "title": "Novikov's theorem: the word problem is undecidable for finitely presented groups",
     "test": false,

--- a/generated/instance_hole_example/Solution.lean
+++ b/generated/instance_hole_example/Solution.lean
@@ -7,6 +7,6 @@ has no non-hole declarations and the generator does not need a
 `ChallengeDeps` split.
 -/
 
-@[reducible] def WidgetCarrier : Type := Submission.WidgetCarrier
+@[reducible] noncomputable def WidgetCarrier : Type := Submission.WidgetCarrier
 
-@[reducible] instance instInhabitedWidget : Inhabited WidgetCarrier := Submission.instInhabitedWidget
+@[reducible] noncomputable instance instInhabitedWidget : Inhabited WidgetCarrier := Submission.instInhabitedWidget

--- a/generated/jacobian_challenge_alggeo/Solution.lean
+++ b/generated/jacobian_challenge_alggeo/Solution.lean
@@ -57,12 +57,12 @@ variable {k : Type u} [Field k] {C : Over (Spec (.of k))}
 
 -- data
 /-- The genus of a smooth proper curve. -/
-@[reducible] def genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+@[reducible] noncomputable def genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
     [GeometricallyIrreducible C.hom] : ℕ := Submission.AlgebraicGeometry.JacobianChallenge.genus C
 
 -- data
 /-- The Jacobian of a smooth, proper curve over a field `k`. -/
-@[reducible] def Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+@[reducible] noncomputable def Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
     [GeometricallyIrreducible C.hom] : Over (Spec (.of k)) := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian C
 
 namespace Jacobian
@@ -71,7 +71,7 @@ namespace Jacobian
 
 -- data
 /-- The group scheme structure on the Jacobian of the curve `C`. -/
-@[reducible] instance instGrpObj : GrpObj (Jacobian C) := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj
+@[reducible] noncomputable instance instGrpObj : GrpObj (Jacobian C) := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj
 
 /-- The Jacobian of `C` is smooth of relative dimension `g` over `k`, where `g` is the
 genus of `C`. -/
@@ -87,7 +87,7 @@ instance instGeometricallyIrreducible : GeometricallyIrreducible (Jacobian C).ho
 -- data
 /-- The Abel-Jacobi map from a smooth, proper curve to its Jacobian associated
 to a `k`-rational point of `C`. -/
-@[reducible] def ofCurve (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) : C ⟶ Jacobian C := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve P
+@[reducible] noncomputable def ofCurve (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) : C ⟶ Jacobian C := Submission.AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve P
 
 /-- The Abel-Jacobi map sends the `k`-rational point `P` to `0`, where `0` (denoted by `η` below) is
 the neutral element of the group scheme `Jacobian C`. -/

--- a/generated/jacobian_challenge_diffgeo/Solution.lean
+++ b/generated/jacobian_challenge_diffgeo/Solution.lean
@@ -42,7 +42,7 @@ variable {X : Type u} [TopologicalSpace X] [T2Space X] [CompactSpace X] [Connect
   [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X]
 
 -- data
-@[reducible] def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+@[reducible] noncomputable def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
     [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : ℕ := Submission.JacobianChallenge.genus X
 
 -- this proof avoids the hack answer `∀ X, genus X = 0`
@@ -51,16 +51,16 @@ theorem genus_eq_zero_iff_homeo :
     genus X = 0 ↔ Nonempty (X ≃ₜ (Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1)) := Submission.JacobianChallenge.genus_eq_zero_iff_homeo
 
 -- data
-@[reducible] def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+@[reducible] noncomputable def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
     [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : Type u := Submission.JacobianChallenge.Jacobian X
 
 namespace Jacobian
 
 -- data
-@[reducible] instance instAddCommGroup : AddCommGroup (Jacobian X) := Submission.JacobianChallenge.Jacobian.instAddCommGroup
+@[reducible] noncomputable instance instAddCommGroup : AddCommGroup (Jacobian X) := Submission.JacobianChallenge.Jacobian.instAddCommGroup
 
 -- data
-@[reducible] instance instTopologicalSpace : TopologicalSpace (Jacobian X) := Submission.JacobianChallenge.Jacobian.instTopologicalSpace
+@[reducible] noncomputable instance instTopologicalSpace : TopologicalSpace (Jacobian X) := Submission.JacobianChallenge.Jacobian.instTopologicalSpace
 
 -- Prop
 instance instT2Space : T2Space (Jacobian X) := Submission.JacobianChallenge.Jacobian.instT2Space
@@ -68,7 +68,7 @@ instance instT2Space : T2Space (Jacobian X) := Submission.JacobianChallenge.Jaco
 -- Prop
 instance instCompactSpace : CompactSpace (Jacobian X) := Submission.JacobianChallenge.Jacobian.instCompactSpace
 
-@[reducible] instance instChartedSpace : ChartedSpace (Fin (genus X) → ℂ) (Jacobian X) := Submission.JacobianChallenge.Jacobian.instChartedSpace
+@[reducible] noncomputable instance instChartedSpace : ChartedSpace (Fin (genus X) → ℂ) (Jacobian X) := Submission.JacobianChallenge.Jacobian.instChartedSpace
 
 -- Prop
 instance instIsManifold :
@@ -78,7 +78,7 @@ instance instIsManifold :
 instance instLieAddGroup :
     LieAddGroup (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := Submission.JacobianChallenge.Jacobian.instLieAddGroup
 
-@[reducible] def ofCurve (P : X) : X → Jacobian X := Submission.JacobianChallenge.Jacobian.ofCurve P
+@[reducible] noncomputable def ofCurve (P : X) : X → Jacobian X := Submission.JacobianChallenge.Jacobian.ofCurve P
 
 theorem ofCurve_contMDiff (P : X) :
     ContMDiff (modelWithCornersSelf ℂ ℂ)
@@ -94,7 +94,7 @@ variable {Y : Type v} [TopologicalSpace Y] [T2Space Y] [CompactSpace Y] [Connect
 
 variable (f : X → Y) (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
 
-@[reducible] def pushforward (f : X → Y)
+@[reducible] noncomputable def pushforward (f : X → Y)
     (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
     Jacobian X →ₜ+ Jacobian Y := Submission.JacobianChallenge.Jacobian.pushforward f hf
 
@@ -120,7 +120,7 @@ theorem pushforward_comp_apply (f : X → Y)
 
 -- if f is constant then the pullback should be the zero map, otherwise it's
 -- the usual pullback
-@[reducible] def pullback (f : X → Y)
+@[reducible] noncomputable def pullback (f : X → Y)
     (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
     Jacobian Y →ₜ+ Jacobian X := Submission.JacobianChallenge.Jacobian.pullback f hf
 
@@ -138,7 +138,7 @@ theorem pullback_comp_apply (f : X → Y)
     (P : Jacobian Z) :
     pullback (g.comp f) (hg.comp hf) P = pullback f hf (pullback g hg P) := Submission.JacobianChallenge.Jacobian.pullback_comp_apply f hf g hg P
 
-@[reducible] def degree (f : X → Y)
+@[reducible] noncomputable def degree (f : X → Y)
     (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) : ℕ := Submission.JacobianChallenge.Jacobian.degree f hf -- 0 for constant case
 
 theorem pushforward_pullback (f : X → Y)

--- a/generated/multi_hole_helpers_example/Solution.lean
+++ b/generated/multi_hole_helpers_example/Solution.lean
@@ -30,7 +30,7 @@ four failure modes the generator used to have:
 namespace Helpers
 
 
-@[reducible] def first : Nat := Submission.Helpers.first
+@[reducible] noncomputable def first : Nat := Submission.Helpers.first
 
 
 

--- a/generated/noncomputable_hole_example/Challenge.lean
+++ b/generated/noncomputable_hole_example/Challenge.lean
@@ -1,0 +1,16 @@
+import Mathlib
+/-!
+Minimal example exercising `noncomputable` data holes in the multi-hole
+eval-problem pipeline. Honest solutions to data holes are frequently
+noncomputable (`genus` in the Jacobian challenge is the motivating case),
+so the generated `Solution.lean` delegations must themselves be
+`noncomputable` to compile against such a submission. The `noncomputable`
+modifiers on the holes below additionally exercise folding an existing
+modifier into the rewritten signature: Lean's grammar puts attributes
+before `noncomputable`, so a naive `@[reducible]` injection at the
+declaration keyword would produce invalid syntax.
+-/
+def RWidget : Type := sorry
+noncomputable instance instInhabitedRWidget : Inhabited RWidget := sorry
+noncomputable def rwidgetPoint : RWidget := sorry
+theorem rwidgetPoint_default : rwidgetPoint = (default : RWidget) := sorry

--- a/generated/noncomputable_hole_example/README.md
+++ b/generated/noncomputable_hole_example/README.md
@@ -1,0 +1,23 @@
+# `noncomputable_hole_example`
+
+noncomputable-hole minimal example
+
+- Problem ID: `noncomputable_hole_example`
+- Test Problem: yes
+- Submitter: Kim Morrison
+- Holes (4): `RWidget` (def), `instInhabitedRWidget` (def), `rwidgetPoint` (def), `rwidgetPoint_default` (theorem)
+- Notes: Minimal example exercising noncomputable def/instance holes; the generated Solution.lean delegations must be noncomputable so that honest (noncomputable) submissions compile.
+
+Do not modify `Challenge.lean` or `Solution.lean`. Those files are part of the
+trusted benchmark and fixed by the repository.
+
+This is a multi-hole problem: the challenge declares multiple `def`s,
+`instance`s, and/or `theorem`s as `sorry`. Fill all of them in
+`Submission.lean` (under `namespace Submission`) for comparator to accept
+your solution.
+
+Participants may use Mathlib freely. Any helper code not already available in
+Mathlib must be inlined into the submission workspace.
+
+`lake test` runs comparator for this problem. The command expects a comparator
+binary in `PATH`, or in the `COMPARATOR_BIN` environment variable.

--- a/generated/noncomputable_hole_example/Solution.lean
+++ b/generated/noncomputable_hole_example/Solution.lean
@@ -1,0 +1,21 @@
+import Mathlib
+import Submission
+/-!
+Minimal example exercising `noncomputable` data holes in the multi-hole
+eval-problem pipeline. Honest solutions to data holes are frequently
+noncomputable (`genus` in the Jacobian challenge is the motivating case),
+so the generated `Solution.lean` delegations must themselves be
+`noncomputable` to compile against such a submission. The `noncomputable`
+modifiers on the holes below additionally exercise folding an existing
+modifier into the rewritten signature: Lean's grammar puts attributes
+before `noncomputable`, so a naive `@[reducible]` injection at the
+declaration keyword would produce invalid syntax.
+-/
+
+@[reducible] noncomputable def RWidget : Type := Submission.RWidget
+
+@[reducible] noncomputable instance instInhabitedRWidget : Inhabited RWidget := Submission.instInhabitedRWidget
+
+@[reducible] noncomputable def rwidgetPoint : RWidget := Submission.rwidgetPoint
+
+theorem rwidgetPoint_default : rwidgetPoint = (default : RWidget) := Submission.rwidgetPoint_default

--- a/generated/noncomputable_hole_example/Submission.lean
+++ b/generated/noncomputable_hole_example/Submission.lean
@@ -1,0 +1,22 @@
+import Mathlib
+import Submission.Helpers
+/-!
+Minimal example exercising `noncomputable` data holes in the multi-hole
+eval-problem pipeline. Honest solutions to data holes are frequently
+noncomputable (`genus` in the Jacobian challenge is the motivating case),
+so the generated `Solution.lean` delegations must themselves be
+`noncomputable` to compile against such a submission. The `noncomputable`
+modifiers on the holes below additionally exercise folding an existing
+modifier into the rewritten signature: Lean's grammar puts attributes
+before `noncomputable`, so a naive `@[reducible]` injection at the
+declaration keyword would produce invalid syntax.
+-/
+
+namespace Submission
+
+def RWidget : Type := sorry
+noncomputable instance instInhabitedRWidget : Inhabited RWidget := sorry
+noncomputable def rwidgetPoint : RWidget := sorry
+theorem rwidgetPoint_default : rwidgetPoint = (default : RWidget) := sorry
+
+end Submission

--- a/generated/noncomputable_hole_example/Submission/Helpers.lean
+++ b/generated/noncomputable_hole_example/Submission/Helpers.lean
@@ -1,0 +1,3 @@
+namespace Submission.Helpers
+
+end Submission.Helpers

--- a/generated/noncomputable_hole_example/WorkspaceTest.lean
+++ b/generated/noncomputable_hole_example/WorkspaceTest.lean
@@ -1,0 +1,19 @@
+import Lean
+
+open Lean
+
+def main : IO UInt32 := do
+  let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
+  try
+    let child ← IO.Process.spawn {
+      cmd := "lake"
+      args := #["env", comparatorBin, "config.json"]
+    }
+    let exitCode ← child.wait
+    pure exitCode
+  catch err =>
+    IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
+    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    IO.eprintln s!"Original error: {err}"
+    pure 1

--- a/generated/noncomputable_hole_example/config.json
+++ b/generated/noncomputable_hole_example/config.json
@@ -1,0 +1,18 @@
+{
+  "challenge_module": "Challenge",
+  "solution_module": "Solution",
+  "theorem_names": [
+    "rwidgetPoint_default"
+  ],
+  "permitted_axioms": [
+    "propext",
+    "Quot.sound",
+    "Classical.choice"
+  ],
+  "enable_nanoda": false,
+  "definition_names": [
+    "RWidget",
+    "instInhabitedRWidget",
+    "rwidgetPoint"
+  ]
+}

--- a/generated/noncomputable_hole_example/holes.json
+++ b/generated/noncomputable_hole_example/holes.json
@@ -1,0 +1,30 @@
+{
+  "id": "noncomputable_hole_example",
+  "module": "LeanEval.Sandbox.NoncomputableHoleExample",
+  "holes": [
+    {
+      "name": "RWidget",
+      "basename": "RWidget",
+      "kind": "def",
+      "body": "def RWidget : Type := sorry"
+    },
+    {
+      "name": "instInhabitedRWidget",
+      "basename": "instInhabitedRWidget",
+      "kind": "def",
+      "body": "noncomputable instance instInhabitedRWidget : Inhabited RWidget := sorry"
+    },
+    {
+      "name": "rwidgetPoint",
+      "basename": "rwidgetPoint",
+      "kind": "def",
+      "body": "noncomputable def rwidgetPoint : RWidget := sorry"
+    },
+    {
+      "name": "rwidgetPoint_default",
+      "basename": "rwidgetPoint_default",
+      "kind": "theorem",
+      "body": "theorem rwidgetPoint_default : rwidgetPoint = (default : RWidget) := sorry"
+    }
+  ]
+}

--- a/generated/noncomputable_hole_example/lakefile.toml
+++ b/generated/noncomputable_hole_example/lakefile.toml
@@ -1,0 +1,24 @@
+name = "noncomputable_hole_example"
+testDriver = "workspace_test"
+defaultTargets = ["Challenge", "Solution", "Submission"]
+
+[leanOptions]
+autoImplicit = false
+
+[[require]]
+name = "mathlib"
+git = "https://github.com/leanprover-community/mathlib4.git"
+rev = "5450b53e5ddc"
+
+[[lean_lib]]
+name = "Challenge"
+
+[[lean_lib]]
+name = "Solution"
+
+[[lean_lib]]
+name = "Submission"
+
+[[lean_exe]]
+name = "workspace_test"
+root = "WorkspaceTest"

--- a/generated/noncomputable_hole_example/lean-toolchain
+++ b/generated/noncomputable_hole_example/lean-toolchain
@@ -1,0 +1,2 @@
+leanprover/lean4:v4.30.0-rc2
+

--- a/manifests/problems/noncomputable_hole_example.toml
+++ b/manifests/problems/noncomputable_hole_example.toml
@@ -1,0 +1,7 @@
+id = "noncomputable_hole_example"
+title = "noncomputable-hole minimal example"
+test = true
+module = "LeanEval.Sandbox.NoncomputableHoleExample"
+holes = ["RWidget", "instInhabitedRWidget", "rwidgetPoint", "rwidgetPoint_default"]
+submitter = "Kim Morrison"
+notes = "Minimal example exercising noncomputable def/instance holes; the generated Solution.lean delegations must be noncomputable so that honest (noncomputable) submissions compile."

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -152,6 +152,34 @@ def main : IO UInt32 := do
     let hasOpenPolynomial := (block.find? "open Polynomial").isSome
     pure <| assertEq "top-level open with 'in' comment kept" hasOpenPolynomial true
 
+  check "injectSolutionHoleModifiers: plain def gains both modifiers" passes fails do
+    pure <| assertEq "rewritten"
+      (injectSolutionHoleModifiers "def foo : Nat := " "foo")
+      (some "@[reducible] noncomputable def foo : Nat := ")
+
+  check "injectSolutionHoleModifiers: existing noncomputable is folded" passes fails do
+    pure <| assertEq "rewritten"
+      (injectSolutionHoleModifiers "noncomputable def foo : Nat := " "foo")
+      (some "@[reducible] noncomputable def foo : Nat := ")
+
+  check "injectSolutionHoleModifiers: instance with doc comment" passes fails do
+    pure <| assertEq "rewritten"
+      (injectSolutionHoleModifiers
+        "/-- doc -/\nnoncomputable instance instFoo : Inhabited Nat := " "instFoo")
+      (some "/-- doc -/\n@[reducible] noncomputable instance instFoo : Inhabited Nat := ")
+
+  -- The word `noncomputable` at the end of a doc comment is not a modifier
+  -- and must not be stripped.
+  check "injectSolutionHoleModifiers: doc comment mentioning noncomputable" passes fails do
+    pure <| assertEq "rewritten"
+      (injectSolutionHoleModifiers "/-- might be noncomputable -/\ndef foo : Nat := " "foo")
+      (some "/-- might be noncomputable -/\n@[reducible] noncomputable def foo : Nat := ")
+
+  check "injectSolutionHoleModifiers: no def/instance/abbrev anchor" passes fails do
+    pure <| assertEq "rewritten"
+      (injectSolutionHoleModifiers "theorem foo : True := " "foo")
+      none
+
   let passCount ← passes.get
   let failCount ← fails.get
   IO.println s!"\n{passCount} passed, {failCount} failed."


### PR DESCRIPTION
This PR makes the generated `Solution.lean` delegations for `def`/`instance`/`abbrev` holes `noncomputable`. Honest solutions to data holes are frequently noncomputable — `genus` and the six other data holes of `jacobian_challenge_diffgeo` are the motivating case — and a computable wrapper `def` whose body references a noncomputable `Submission.<name>` fails to compile, forcing submitters into `@[implemented_by] unsafeCast` stubs just to get past `lake build` (see the [Jacobian challenge thread](https://leanprover.zulipchat.com/#narrow/channel/583336-Autoformalization/topic/Jacobian.20challenge/near/602077183) and the failing [submission run](https://github.com/leanprover/lean-eval-submissions/actions/runs/27332387721/job/80747795362)). Comparator never sees computability, so the marker is invisible to scoring.

The rewrite also folds an existing `noncomputable` modifier on the source hole into the injected prefix: Lean's grammar puts attributes before `noncomputable`, so the previous injection would have produced the invalid `noncomputable @[reducible] def` for such holes.

A new sandbox problem `noncomputable_hole_example` carries `noncomputable` def and instance holes, so the template `Submission.lean` (a source copy) is itself noncomputable and `check-generated-builds` exercises exactly the direction that used to fail: a noncomputable submission behind a Solution delegation. Unit tests cover the signature rewrite, including not mistaking a doc comment ending in the word "noncomputable" for a modifier.

🤖 Prepared with Claude Code
