### PR TITLE
fix: restrict boundary subpolyhedra to faces in families_of_maps_b01

### DIFF
--- a/LeanEval/Topology/FamiliesOfMapsB01.lean
+++ b/LeanEval/Topology/FamiliesOfMapsB01.lean
@@ -38,6 +38,15 @@ The trusted supporting definitions (`Supported`, `AdaptedTo`,
 `IsPolyhedron`, `Subdivision`, `closedCell`, `IsBoundarySubpolyhedron`)
 are factored into `ChallengeDeps.lean` automatically by the multi-hole
 generator.
+
+This statement was corrected on 2026-06-14: the original
+`IsBoundarySubpolyhedron` admitted any convex hull of frontier points,
+including single non-vertex points of `∂P`, for which condition 4's
+support hypothesis is vacuous and spuriously forced the homotopy to
+freeze those points in time — making the lemma false. Lorenzo Luccioli,
+using Harmonic's Aristotle, gave a formal disproof. The repair restricts
+boundary subpolyhedra to genuine faces of `P` (`IsExtreme ℝ P`), matching
+the paper's "convex linear subpolyhedron of `∂P`". Thanks to both.
 -/
 
 open Set unitInterval Geometry
@@ -74,12 +83,17 @@ structure Subdivision (P : Set (Fin k → ℝ)) where
 def closedCell (P : Set (Fin k → ℝ)) (D : Finset (Fin k → ℝ)) : Set P :=
   { p | (p : Fin k → ℝ) ∈ convexHull ℝ (D : Set (Fin k → ℝ)) }
 
-/-- A *boundary subpolyhedron* of `P`: a subset of `P` whose image in `ℝᵏ`
-is itself a polyhedron and lies in the *intrinsic* frontier of `P`. -/
+/-- A *boundary subpolyhedron* of `P`: a **face** of `P` (an `IsExtreme`
+subset, the paper's "convex linear subpolyhedron of `∂P`") whose image in
+`ℝᵏ` is a polyhedron and lies in the *intrinsic* frontier of `P`. The
+face condition is what the construction keeps invariant (`u (I × Q × X) ⊆
+Q`); without it single interior points of `∂P` would qualify and condition
+4 would vacuously force the homotopy to freeze them in time. -/
 def IsBoundarySubpolyhedron {P : Set (Fin k → ℝ)} (Q : Set P) : Prop :=
   (∃ S : Finset (Fin k → ℝ),
       ((↑) : P → Fin k → ℝ) '' Q = convexHull ℝ (S : Set (Fin k → ℝ))) ∧
-    ((↑) : P → Fin k → ℝ) '' Q ⊆ intrinsicFrontier ℝ P
+    ((↑) : P → Fin k → ℝ) '' Q ⊆ intrinsicFrontier ℝ P ∧
+    IsExtreme ℝ P (((↑) : P → Fin k → ℝ) '' Q)
 
 /-- **Lemma B.0.1** of Morrison–Walker, *The Blob Complex*
 (arXiv:1009.5025, §B), continuous case. -/


### PR DESCRIPTION
This PR restricts `IsBoundarySubpolyhedron` to genuine faces of `P` by adding an `IsExtreme ℝ P` clause. The previous definition admitted any convex hull of frontier points, including single non-vertex points of `∂P`; for such a singleton the support hypothesis in condition 4 (`Supported (f|_Q) S'`) is vacuously true, so condition 4 forced `F (t, q, x) = F (t', q, x)` — the homotopy frozen in time at that point. Combined with the adaptation clause this is contradictory, so the lemma as stated was false. Morrison–Walker's "convex linear subpolyhedron of ∂P" means a face of `P`: exactly the sets the construction keeps invariant (`u (I × Q × X) ⊆ Q` in the proof of Lemma B.0.1), and the only ones for which the support hypothesis carries content. Vertices and edges remain faces, and the genuine homotopy still satisfies condition 4 for all of them.

The mis-formalization was found by Lorenzo Luccioli using Harmonic's Aristotle, who gave a formal disproof of the original statement. Thanks to both.

🤖 Prepared with Claude Code