### PR TITLE
fix: add T2Space hypothesis to levi_civita_exists_unique

### DIFF
--- a/LeanEval/Geometry/LeviCivita.lean
+++ b/LeanEval/Geometry/LeviCivita.lean
@@ -23,6 +23,16 @@ hits). One helper definition (`IsMetricCompatible`, ~½ page) and an
 `CovariantDerivative` is bundled over all sections including non-smooth
 ones, so uniqueness is stated on the smooth-section subspace) are added
 here.
+
+A `[T2Space M]` hypothesis was added on 2026-06-14. We are not certain the
+statement is wrong without it, but it looks suspicious: uniqueness on
+smooth sections reduces to global smooth vector fields spanning every
+tangent space, which (given how mathlib's bump-function machinery works)
+needs `M` Hausdorff, and mathlib does not bundle Hausdorffness into
+`IsManifold`. Since the classical Levi-Civita theorem is always stated for
+(Hausdorff) manifolds, the original intent is better reflected with
+`[T2Space M]`, so we add it now. Lorenzo Luccioli, using Harmonic's
+Aristotle, flagged the missing hypothesis. Thanks to both.
 -/
 
 open scoped Manifold ContDiff Bundle Topology
@@ -72,7 +82,7 @@ theorem levi_civita_exists_unique
     {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
       [FiniteDimensional ℝ E] [CompleteSpace E]
     {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
-    {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+    {M : Type*} [TopologicalSpace M] [T2Space M] [ChartedSpace H M]
       [IsManifold I ∞ M]
     [RiemannianBundle (fun (x : M) ↦ TangentSpace I x)]
     [IsContMDiffRiemannianBundle I ∞ E (fun (x : M) ↦ TangentSpace I x)] :


### PR DESCRIPTION
This PR adds `[T2Space M]` to the Levi-Civita existence/uniqueness theorem. The uniqueness clause `SameOnSmooth` quantifies over globally smooth vector fields, and the difference of two metric-compatible torsion-free connections (a genuine tensor, since `cov Y x` is `→L` in the direction and `cov.torsion` is a tensor) vanishes on smooth sections only when global smooth fields span every tangent space. Realizing an arbitrary tangent vector by a global smooth field needs a bump function supported in a chart, which in mathlib requires `M` to be Hausdorff — and mathlib deliberately does not bundle Hausdorffness into `IsManifold`. The existence half is unaffected (the Koszul construction is local and tensorial), so `[T2Space M]` alone is the minimal addition.

Unlike the boundaryless fix for `hopf_rinow` and the face fix for `families_of_maps_b01`, this is not backed by a formal disproof: we are not certain the statement is false without `[T2Space M]` (the usual non-Hausdorff example, the line with two origins, still spans every tangent space). But it is not provable as stated, and the classical Levi-Civita theorem is always about Hausdorff manifolds, so the hypothesis better reflects the intended statement.

Lorenzo Luccioli, using Harmonic's Aristotle, flagged the missing hypothesis. Thanks to both.

🤖 Prepared with Claude Code