### PR TITLE
fix: preserve universe commands and coercion instances in generated workspaces

### DIFF
--- a/EvalTools/ExtractTheorem.lean
+++ b/EvalTools/ExtractTheorem.lean
@@ -59,6 +59,27 @@ def resolveDeclName (env : Environment) (moduleName declName : Name) : IO Name :
       return candidate
   findDeclByBasename env moduleName declName
 
+/-- Last components of the coercion type classes. A coercion (`↑`/`⇑`) is
+unfolded during elaboration, so the instance backing it never appears in the
+elaborated term's `getUsedConstantsAsSet` — even when a kept helper's *source
+text* relies on it (e.g. `T x` where `instCoeFun … : CoeFun …`). The generated
+`ChallengeDeps.lean` reproduces source text, so it must carry these instances;
+we recover them structurally rather than from the dependency closure. -/
+def coercionClassLastComponents : Array String :=
+  #["Coe", "CoeTC", "CoeHead", "CoeTail", "CoeHTCT", "CoeHTC", "CoeOut",
+    "CoeDep", "CoeT", "CoeFun", "CoeSort"]
+
+def isCoercionClassName (n : Name) : Bool :=
+  match lastComponent? n with
+  | some s => coercionClassLastComponents.contains s
+  | none => false
+
+/-- The head constant of a (possibly dependent) type's conclusion: strip leading
+`∀`/`→` binders and return the application head. -/
+partial def conclusionHead : Expr → Option Name
+  | .forallE _ _ body _ => conclusionHead body
+  | e => e.getAppFn.constName?
+
 /-- Compute the set of names of declarations in `moduleName` that are reachable from
 the type or value of `start`, following the same-module subgraph of the constant
 dependency relation. The starting declaration itself is excluded from the result.
@@ -68,22 +89,48 @@ are traversed through — so genuine helpers they reference are still found — 
 excluded from the returned set: they have no user source span to extract and are
 regenerated automatically when their parent declaration is re-elaborated. (A
 `noncomputable def` over a `Finset` sum, for instance, emits a `._proof_1` whose
-prefix would otherwise be mistaken for a helper namespace to `open`.) -/
+prefix would otherwise be mistaken for a helper namespace to `open`.)
+
+Coercion instances (see `coercionClassLastComponents`) are pulled in separately:
+once the closure contains a constant, any same-module declaration whose type is a
+coercion class mentioning that constant is added (and re-closed over). Such
+instances vanish from elaborated terms but are still needed by the source text
+the generator re-emits. They are detected structurally by the head of their
+type's conclusion — `Lean.Meta.isInstanceCore` is unreliable against the bare
+environment produced by `importModules` (the instance extension state is not
+materialised), so we do not depend on it. -/
 def collectSameModuleDependencies (env : Environment) (moduleName start : Name) :
     Array Name := Id.run do
   let some moduleIdx := env.getModuleIdx? moduleName | return #[]
+  -- Same-module coercion providers, paired with the constants in their type.
+  let mut coeInstances : Array (Name × Array Name) := #[]
+  for (c, info) in env.constants do
+    if env.getModuleIdxFor? c == some moduleIdx then
+      if let some cls := conclusionHead info.type then
+        if isCoercionClassName cls then
+          coeInstances := coeInstances.push (c, info.type.getUsedConstants)
   let mut closure : NameSet := {}
   let mut stack : Array Name := #[start]
-  while !stack.isEmpty do
-    let current := stack.back!
-    stack := stack.pop
-    if closure.contains current then continue
-    closure := closure.insert current
-    let some info := env.find? current | continue
-    for c in info.getUsedConstantsAsSet do
-      if env.getModuleIdxFor? c == some moduleIdx
-          && c != current && !closure.contains c then
-        stack := stack.push c
+  let mut progress := true
+  while progress do
+    progress := false
+    -- Direct dependency closure over the same-module subgraph.
+    while !stack.isEmpty do
+      let current := stack.back!
+      stack := stack.pop
+      if closure.contains current then continue
+      closure := closure.insert current
+      let some info := env.find? current | continue
+      for c in info.getUsedConstantsAsSet do
+        if env.getModuleIdxFor? c == some moduleIdx
+            && c != current && !closure.contains c then
+          stack := stack.push c
+    -- Pull in coercion instances now reachable, then re-close.
+    for (inst, typeConsts) in coeInstances do
+      if closure.contains inst then continue
+      if typeConsts.any closure.contains then
+        stack := stack.push inst
+        progress := true
   return (closure.erase start).toArray.filter (fun n => !n.isInternalDetail)
 
 def extractTheorem (moduleNameText declNameText : String) : IO ExtractedTheorem := do

--- a/EvalTools/ExtractTheorem.lean
+++ b/EvalTools/ExtractTheorem.lean
@@ -91,24 +91,15 @@ regenerated automatically when their parent declaration is re-elaborated. (A
 `noncomputable def` over a `Finset` sum, for instance, emits a `._proof_1` whose
 prefix would otherwise be mistaken for a helper namespace to `open`.)
 
-Coercion instances (see `coercionClassLastComponents`) are pulled in separately:
-once the closure contains a constant, any same-module declaration whose type is a
-coercion class mentioning that constant is added (and re-closed over). Such
-instances vanish from elaborated terms but are still needed by the source text
-the generator re-emits. They are detected structurally by the head of their
-type's conclusion — `Lean.Meta.isInstanceCore` is unreliable against the bare
-environment produced by `importModules` (the instance extension state is not
-materialised), so we do not depend on it. -/
-def collectSameModuleDependencies (env : Environment) (moduleName start : Name) :
-    Array Name := Id.run do
+Coercion instances (see `coercionClassLastComponents`) are pulled in separately
+via `coeCandidates`: once the closure contains a constant, any candidate whose
+type mentions that constant is added (and re-closed over). Such instances vanish
+from elaborated terms but are still needed by the source text the generator
+re-emits. `coeCandidates` pairs each candidate with the constants appearing in
+its type, and is gathered (and source-order filtered) by the caller. -/
+def collectSameModuleDependencies (env : Environment) (moduleName start : Name)
+    (coeCandidates : Array (Name × Array Name)) : Array Name := Id.run do
   let some moduleIdx := env.getModuleIdx? moduleName | return #[]
-  -- Same-module coercion providers, paired with the constants in their type.
-  let mut coeInstances : Array (Name × Array Name) := #[]
-  for (c, info) in env.constants do
-    if env.getModuleIdxFor? c == some moduleIdx then
-      if let some cls := conclusionHead info.type then
-        if isCoercionClassName cls then
-          coeInstances := coeInstances.push (c, info.type.getUsedConstants)
   let mut closure : NameSet := {}
   let mut stack : Array Name := #[start]
   let mut progress := true
@@ -125,13 +116,35 @@ def collectSameModuleDependencies (env : Environment) (moduleName start : Name) 
         if env.getModuleIdxFor? c == some moduleIdx
             && c != current && !closure.contains c then
           stack := stack.push c
-    -- Pull in coercion instances now reachable, then re-close.
-    for (inst, typeConsts) in coeInstances do
+    -- Pull in coercion candidates now reachable, then re-close.
+    for (inst, typeConsts) in coeCandidates do
       if closure.contains inst then continue
       if typeConsts.any closure.contains then
         stack := stack.push inst
         progress := true
   return (closure.erase start).toArray.filter (fun n => !n.isInternalDetail)
+
+/-- Gather the same-module coercion providers (see `coercionClassLastComponents`)
+that are declared *before* `beforeLine`, paired with the constants in their type.
+
+Restricting to declarations preceding the extracted hole matches Lean scoping: a
+coercion used by a kept helper must be declared before that helper, hence before
+the hole. It also prevents leaking declarations that follow the hole into
+`ChallengeDeps.lean`. Detected structurally by the conclusion head of the type —
+`Lean.Meta.isInstanceCore` is unreliable against the bare environment produced by
+`importModules` (the instance extension state is not materialised). -/
+def gatherCoercionCandidates (env : Environment) (moduleName : Name) (beforeLine : Nat) :
+    CoreM (Array (Name × Array Name)) := do
+  let some moduleIdx := env.getModuleIdx? moduleName | return #[]
+  let mut cands : Array (Name × Array Name) := #[]
+  for (c, info) in env.constants do
+    if env.getModuleIdxFor? c == some moduleIdx then
+      if let some cls := conclusionHead info.type then
+        if isCoercionClassName cls then
+          if let some r ← findDeclarationRanges? c then
+            if r.range.pos.line < beforeLine then
+              cands := cands.push (c, info.type.getUsedConstants)
+  return cands
 
 def extractTheorem (moduleNameText declNameText : String) : IO ExtractedTheorem := do
   let moduleName := parseName moduleNameText
@@ -141,8 +154,13 @@ def extractTheorem (moduleNameText declNameText : String) : IO ExtractedTheorem 
   let resolvedDeclName ← resolveDeclName env moduleName declName
   let some constantInfo := env.find? resolvedDeclName
     | throw <| IO.userError s!"Resolved declaration '{resolvedDeclName}' disappeared unexpectedly."
-  let some declRanges ← ({ env := env } : PPContext).runCoreM do
-    findDeclarationRanges? resolvedDeclName
+  let (declRanges?, coeCandidates) ← ({ env := env } : PPContext).runCoreM do
+    let declRanges? ← findDeclarationRanges? resolvedDeclName
+    let coeCandidates ← match declRanges? with
+      | some r => gatherCoercionCandidates env moduleName r.range.pos.line
+      | none => pure #[]
+    return (declRanges?, coeCandidates)
+  let some declRanges := declRanges?
     | throw <| IO.userError s!"Declaration ranges for '{resolvedDeclName}' were not available."
   let sourceRange : SourceRange := {
     startLine := declRanges.range.pos.line
@@ -157,7 +175,7 @@ def extractTheorem (moduleNameText declNameText : String) : IO ExtractedTheorem 
     | _ => none
   match kind? with
   | some kind =>
-      let deps := collectSameModuleDependencies env moduleName resolvedDeclName
+      let deps := collectSameModuleDependencies env moduleName resolvedDeclName coeCandidates
       return {
         declarationName := toString resolvedDeclName
         module := moduleNameText

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -984,6 +984,20 @@ private def variableShadowedByTheorem (varText : String)
     if !theoremBinderNames.contains name then return false
   return true
 
+/-- Top-level command keywords that begin a fresh declaration/command. A
+whitespace-indented line opening with one of these is never a continuation of a
+preceding `variable`/`universe` block (Lean permits indented top-level
+commands), so the block scanner must stop before absorbing it. -/
+private def startsWithCommandKeyword (stripped : String) : Bool := Id.run do
+  if stripped.startsWith "@[" then return true
+  let kws := #["def", "theorem", "lemma", "instance", "abbrev", "opaque",
+    "axiom", "class", "structure", "inductive", "namespace", "section", "end",
+    "variable", "universe", "open", "example", "noncomputable", "private",
+    "protected", "scoped", "attribute", "macro", "notation", "syntax"]
+  for kw in kws do
+    if startsWithKeyword stripped kw then return true
+  return false
+
 /-- Walk `source` up to `extracted?`'s start line, collecting top-level command
 blocks that begin with `keyword` (e.g. `variable` or `universe`), respecting
 `section`/`namespace` scoping: a block declared inside a `section`/`namespace`
@@ -1055,6 +1069,7 @@ def extractScopedCommandBlocks (source : String) (extracted? : Option ExtractedT
         let next := lines[idx]!
         if next.trimAscii.toString.isEmpty then break
         if !isLineStartingWithWhitespace next then break
+        if startsWithCommandKeyword next.trimAsciiStart.toString then break
         block := block ++ "\n" ++ next
         idx := idx + 1
       if keep block then

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -984,14 +984,18 @@ private def variableShadowedByTheorem (varText : String)
     if !theoremBinderNames.contains name then return false
   return true
 
-def extractContextVariables (source : String) (extracted? : Option ExtractedTheorem)
-    (theoremBinderNames : Array String) : String := Id.run do
+/-- Walk `source` up to `extracted?`'s start line, collecting top-level command
+blocks that begin with `keyword` (e.g. `variable` or `universe`), respecting
+`section`/`namespace` scoping: a block declared inside a `section`/`namespace`
+goes out of scope at the matching `end`. Multi-line blocks absorb following
+whitespace-indented continuation lines. Each collected block is filtered through
+`keep`; only blocks for which `keep` returns true are emitted. Returns the kept
+blocks joined by newlines with a trailing blank line, or `""` if none. -/
+def extractScopedCommandBlocks (source : String) (extracted? : Option ExtractedTheorem)
+    (keyword : String) (keep : String → Bool) : String := Id.run do
   let lines := source.splitOn "\n"
   let targetLine? : Option Nat := extracted?.map fun e => e.startLine
-  -- One layer per `section`/`namespace` we are still inside. A `variable`
-  -- declared in a `section`/`namespace` goes out of scope at the matching
-  -- `end`; treating both the same way matches Lean's scoping for `variable`.
-  let mut variableLayers : Array (Array String) := #[#[]]
+  let mut layers : Array (Array String) := #[#[]]
   let mut frameDepth : Nat := 0
   let mut inBlockComment := false
   let mut idx : Nat := 0
@@ -1034,14 +1038,14 @@ def extractContextVariables (source : String) (extracted? : Option ExtractedTheo
       continue
     if startsWithKeyword stripped "namespace" || startsWithKeyword stripped "section" then
       frameDepth := frameDepth + 1
-      variableLayers := variableLayers.push #[]
+      layers := layers.push #[]
       idx := idx + 1
     else if startsWithKeyword stripped "end" then
       if frameDepth > 0 then
         frameDepth := frameDepth - 1
-        variableLayers := variableLayers.pop
+        layers := layers.pop
       idx := idx + 1
-    else if startsWithKeyword stripped "variable" then
+    else if startsWithKeyword stripped keyword then
       let mut block := line
       idx := idx + 1
       while idx < lines.length do
@@ -1053,18 +1057,34 @@ def extractContextVariables (source : String) (extracted? : Option ExtractedTheo
         if !isLineStartingWithWhitespace next then break
         block := block ++ "\n" ++ next
         idx := idx + 1
-      if !variableShadowedByTheorem block theoremBinderNames then
-        let layerIdx := variableLayers.size - 1
-        let layer := variableLayers[layerIdx]!.push block
-        variableLayers := variableLayers.set! layerIdx layer
+      if keep block then
+        let layerIdx := layers.size - 1
+        let layer := layers[layerIdx]!.push block
+        layers := layers.set! layerIdx layer
     else
       idx := idx + 1
   let mut flat : Array String := #[]
-  for layer in variableLayers do
+  for layer in layers do
     for v in layer do
       flat := flat.push v
   if flat.isEmpty then return ""
   return "\n".intercalate flat.toList ++ "\n\n"
+
+def extractContextVariables (source : String) (extracted? : Option ExtractedTheorem)
+    (theoremBinderNames : Array String) : String :=
+  -- One layer per `section`/`namespace` we are still inside, matching Lean's
+  -- scoping for `variable`. Blocks shadowed by the theorem's own binders are
+  -- dropped (they would otherwise be flagged as unused).
+  extractScopedCommandBlocks source extracted? "variable"
+    (fun block => !variableShadowedByTheorem block theoremBinderNames)
+
+/-- Collect top-level `universe` commands in scope at the theorem. A source
+module may declare `universe u v` and refer to `u`/`v` in a theorem whose
+reconstructed `Challenge.lean` slice (`theorem … := by sorry`) would otherwise
+have no binder for them, failing with `unknown universe level`. Re-emitting the
+in-scope `universe` commands restores them. -/
+def extractContextUniverses (source : String) (extracted? : Option ExtractedTheorem) : String :=
+  extractScopedCommandBlocks source extracted? "universe" (fun _ => true)
 
 /-! ## Render ChallengeDeps.lean -/
 
@@ -1621,6 +1641,8 @@ private def renderWorkspaceSingleHole (root : System.FilePath) (entry : EvalProb
     if hasChallengeDeps then "import ChallengeDeps\nimport Submission.Helpers\n\n"
     else "import Mathlib\nimport Submission.Helpers\n\n"
   let theoremBinderNames := binderIntroducedNames theoremStatement
+  let contextUniverseBlock :=
+    extractContextUniverses sourceText (some extracted)
   let contextVariablesBlock :=
     extractContextVariables sourceText (some extracted) theoremBinderNames
   let includeNamespaces := hasChallengeDeps || !localImports.isEmpty
@@ -1641,13 +1663,13 @@ private def renderWorkspaceSingleHole (root : System.FilePath) (entry : EvalProb
   let readmeLines := renderReadmeLines entry #[extracted] (multiHole := false)
   let readme := "\n".intercalate readmeLines.toList ++ "\n"
   let challengeFile :=
-    challengeImport ++ contextOpenBlock ++ contextVariablesBlock ++
+    challengeImport ++ contextOpenBlock ++ contextUniverseBlock ++ contextVariablesBlock ++
     s!"theorem {theoremName} {theoremStatement} := by\n  sorry\n"
   let solutionFile :=
-    solutionImports ++ contextOpenBlock ++ contextVariablesBlock ++
+    solutionImports ++ contextOpenBlock ++ contextUniverseBlock ++ contextVariablesBlock ++
     s!"theorem {theoremName} {theoremStatement} := by\n  exact {solutionExact}\n"
   let submissionFile :=
-    submissionImports ++ contextOpenBlock ++ contextVariablesBlock ++
+    submissionImports ++ contextOpenBlock ++ contextUniverseBlock ++ contextVariablesBlock ++
     "namespace Submission\n\n" ++
     s!"theorem {theoremName} {theoremStatement} := by\n  sorry\n\n" ++
     "end Submission\n"

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -221,6 +221,26 @@ def main : IO UInt32 := do
     let block := extractContextUniverses source (some extracted)
     pure <| assertEq "out-of-scope universe dropped" block ""
 
+  -- An indented top-level declaration following `universe` is a fresh command,
+  -- not a continuation of the binder list, and must not be absorbed into the
+  -- emitted block (which would produce malformed `Challenge.lean`).
+  check "extractContextUniverses stops at indented declaration" passes fails do
+    let source :=
+      "import Mathlib\n" ++
+      "universe u\n" ++
+      "  def Foo := Type u\n" ++
+      "theorem target : True := trivial\n"
+    let extracted : ExtractedTheorem := {
+      declarationName := "target"
+      module := "Demo"
+      startLine := 4, startColumn := 0
+      endLine := 4, endColumn := 30
+      sameModuleDependencies := #[]
+      kind := "theorem"
+    }
+    let block := extractContextUniverses source (some extracted)
+    pure <| assertEq "universe line only" block "universe u\n\n"
+
   let passCount ← passes.get
   let failCount ← fails.get
   IO.println s!"\n{passCount} passed, {failCount} failed."

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -180,6 +180,47 @@ def main : IO UInt32 := do
       (injectSolutionHoleModifiers "theorem foo : True := " "foo")
       none
 
+  -- Regression for https://github.com/leanprover/lean-eval/issues/421:
+  -- a top-level `universe` command in scope at the theorem must be re-emitted,
+  -- or the reconstructed single-hole `Challenge.lean` slice fails with
+  -- `unknown universe level`.
+  check "extractContextUniverses keeps top-level universe in scope" passes fails do
+    let source :=
+      "import Mathlib\n" ++
+      "universe v u\n" ++
+      "def IsTopos (E : Type u) : Prop := True\n" ++
+      "theorem target {E : Type u} : True := trivial\n"
+    let extracted : ExtractedTheorem := {
+      declarationName := "target"
+      module := "Demo"
+      startLine := 4, startColumn := 0
+      endLine := 4, endColumn := 40
+      sameModuleDependencies := #[]
+      kind := "theorem"
+    }
+    let block := extractContextUniverses source (some extracted)
+    pure <| assertEq "universe line emitted" ((block.find? "universe v u").isSome) true
+
+  -- A `universe` declared inside a `section`/`namespace` that has already been
+  -- closed before the theorem is out of scope and must not be re-emitted.
+  check "extractContextUniverses drops out-of-scope universe" passes fails do
+    let source :=
+      "import Mathlib\n" ++
+      "section\n" ++
+      "universe w\n" ++
+      "end\n" ++
+      "theorem target : True := trivial\n"
+    let extracted : ExtractedTheorem := {
+      declarationName := "target"
+      module := "Demo"
+      startLine := 5, startColumn := 0
+      endLine := 5, endColumn := 30
+      sameModuleDependencies := #[]
+      kind := "theorem"
+    }
+    let block := extractContextUniverses source (some extracted)
+    pure <| assertEq "out-of-scope universe dropped" block ""
+
   let passCount ← passes.get
   let failCount ← fails.get
   IO.println s!"\n{passCount} passed, {failCount} failed."


### PR DESCRIPTION
This PR fixes two gaps in `EvalTools.Generate`'s extraction where a problem builds fine under `lake build` / `validate-manifest` / `check-problem-build` but its generated comparator workspace fails to build, closing https://github.com/leanprover/lean-eval/issues/421.

The first gap is top-level `universe` commands. Single-hole rendering reconstructs `Challenge.lean` / `Solution.lean` / `Submission.lean` from the theorem statement plus collected context, so a `universe v u` in scope at the theorem was dropped and the slice failed with `unknown universe level`. This factors the scoped-block scanner out of `extractContextVariables` into a shared `extractScopedCommandBlocks` and adds `extractContextUniverses` on top of it, emitted alongside the context-variable block. Multi-hole and `ChallengeDeps` already preserve source text verbatim, so they need no change.

The second gap is coercion instances. A `CoeFun` / `CoeSort` coercion (`T x`) is unfolded during elaboration, so the backing instance never appears in the elaborated term's used-constants set, yet `ChallengeDeps` re-emits source text that still relies on it. This augments `collectSameModuleDependencies` to pull in same-module declarations whose type's conclusion is a coercion class mentioning a constant already in the closure, then re-closes. Detection is structural by the type head because `Lean.Meta.isInstanceCore` returns `false` against the bare `importModules` environment the extractor runs in (verified empirically).

Verified by reverting two real problems to their natural formulations (a `universe`-using single-hole theorem and a `CoeFun`-using helper), regenerating, and confirming `check-generated-builds` now produces buildable `ChallengeDeps` / `Challenge` / `Solution` / `Submission`. Those problems are not yet on `main`, so they travel separately; this change touches only the generator and its tests. Regenerating existing `variable`-using and `universe`-using (multi-hole) problems produces byte-identical output, confirming the refactor is behavior-preserving. New unit tests cover in-scope and out-of-scope universe extraction.

🤖 Prepared with Claude Code