### PR TITLE
feat(Analysis): Riesz brothers' theorem

### DIFF
--- a/LeanEval/Analysis/RieszBrothers.lean
+++ b/LeanEval/Analysis/RieszBrothers.lean
@@ -9,65 +9,26 @@ namespace LeanEval
 namespace Analysis
 
 /-!
-# F. and M. Riesz brothers theorem
+# Riesz brothers' theorem
 
-The F. and M. Riesz theorem says that a complex Borel measure on the circle
+The Riesz brothers' theorem says that a complex Borel measure on the circle
 whose positive analytic moments vanish is absolutely continuous with respect to
-Haar measure, and its Radon-Nikodym density belongs to the Hardy space `H^1`.
+Haar measure.
 
-We use the additive circle `AddCircle 1` as the unit circle. The condition
-`complexMoment μ n = 0` is the vector-measure version of
-`∫ z^n dμ = 0`; the conclusion is expressed by writing the complex measure as
-`m.withDensityᵥ h`, where `m` is normalized Haar measure and `h` has vanishing
-negative Fourier coefficients.
 -/
 
-noncomputable section
-
 open MeasureTheory
-open scoped ENNReal
 
-local instance : Fact (0 < (1 : ℝ)) := ⟨zero_lt_one⟩
-
-/-- The unit circle, represented as `R/Z`. -/
-abbrev HardyCircle : Type :=
-  AddCircle (1 : ℝ)
-
-/-- A complex-valued Borel measure on the unit circle. -/
-abbrev CircleComplexMeasure : Type :=
-  ComplexMeasure HardyCircle
-
-/-- The normalized Haar probability measure on the unit circle. -/
-abbrev circleHaar : Measure HardyCircle :=
-  AddCircle.haarAddCircle
-
-/-- The pairing used to integrate complex-valued functions against complex measures. -/
-abbrev complexMulPairing : ℂ →L[ℝ] ℂ →L[ℝ] ℂ :=
-  ContinuousLinearMap.mul ℝ ℂ
-
-/-- The `n`-th analytic moment of a complex measure on the circle:
-`∫ z^n dμ`, written using mathlib's Fourier monomial `fourier n`. -/
-noncomputable def complexMoment (μ : CircleComplexMeasure) (n : ℤ) : ℂ :=
-  ∫ᵛ z, fourier n z ∂[complexMulPairing; μ]
-
-/-- The boundary Hardy space `H^1` condition for a density on the unit circle:
-it is integrable and all negative Fourier coefficients vanish. -/
-def HasHardyH1Density (h : HardyCircle → ℂ) : Prop :=
-  Integrable h circleHaar ∧ ∀ k : ℤ, k < 0 → fourierCoeff (T := (1 : ℝ)) h k = 0
-
-/-- **F. and M. Riesz brothers theorem.** Let `μ` be a complex Borel measure on
+/-- **Riesz brothers' theorem.** Let `μ` be a complex Borel measure on
 the unit circle such that `∫ z^n dμ = 0` for every `n ≥ 1`. Then `μ` is
 absolutely continuous with respect to Haar measure, and more precisely
 `dμ = h dm` for some `h ∈ H^1`, i.e. some integrable density whose negative
 Fourier coefficients vanish. -/
 @[eval_problem]
-theorem riesz_brothers_theorem
-    (μ : CircleComplexMeasure)
-    (hμ : ∀ n : ℕ, 1 ≤ n → complexMoment μ (n : ℤ) = 0) :
-    ∃ h : HardyCircle → ℂ, HasHardyH1Density h ∧ circleHaar.withDensityᵥ h = μ := by
+theorem riesz_brothers_theorem (μ : ComplexMeasure UnitAddCircle)
+    (hμ : ∀ n : ℕ, 1 ≤ n → ∫ᵛ z, fourier n z ∂[ContinuousLinearMap.mul ℝ ℂ; μ] = 0) :
+    μ ≪ᵥ AddCircle.haarAddCircle.toENNRealVectorMeasure := by
   sorry
-
-end
 
 end Analysis
 end LeanEval

--- a/LeanEval/Analysis/RieszBrothers.lean
+++ b/LeanEval/Analysis/RieszBrothers.lean
@@ -1,0 +1,73 @@
+import Mathlib.Analysis.Fourier.AddCircle
+import Mathlib.Analysis.Normed.Operator.Mul
+import Mathlib.MeasureTheory.Measure.Complex
+import Mathlib.MeasureTheory.VectorMeasure.Decomposition.RadonNikodym
+import Mathlib.MeasureTheory.VectorMeasure.Integral
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Analysis
+
+/-!
+# F. and M. Riesz brothers theorem
+
+The F. and M. Riesz theorem says that a complex Borel measure on the circle
+whose positive analytic moments vanish is absolutely continuous with respect to
+Haar measure, and its Radon-Nikodym density belongs to the Hardy space `H^1`.
+
+We use the additive circle `AddCircle 1` as the unit circle. The condition
+`complexMoment μ n = 0` is the vector-measure version of
+`∫ z^n dμ = 0`; the conclusion is expressed by writing the complex measure as
+`m.withDensityᵥ h`, where `m` is normalized Haar measure and `h` has vanishing
+negative Fourier coefficients.
+-/
+
+noncomputable section
+
+open MeasureTheory
+open scoped ENNReal
+
+local instance : Fact (0 < (1 : ℝ)) := ⟨zero_lt_one⟩
+
+/-- The unit circle, represented as `R/Z`. -/
+abbrev HardyCircle : Type :=
+  AddCircle (1 : ℝ)
+
+/-- A complex-valued Borel measure on the unit circle. -/
+abbrev CircleComplexMeasure : Type :=
+  ComplexMeasure HardyCircle
+
+/-- The normalized Haar probability measure on the unit circle. -/
+abbrev circleHaar : Measure HardyCircle :=
+  AddCircle.haarAddCircle
+
+/-- The pairing used to integrate complex-valued functions against complex measures. -/
+abbrev complexMulPairing : ℂ →L[ℝ] ℂ →L[ℝ] ℂ :=
+  ContinuousLinearMap.mul ℝ ℂ
+
+/-- The `n`-th analytic moment of a complex measure on the circle:
+`∫ z^n dμ`, written using mathlib's Fourier monomial `fourier n`. -/
+noncomputable def complexMoment (μ : CircleComplexMeasure) (n : ℤ) : ℂ :=
+  ∫ᵛ z, fourier n z ∂[complexMulPairing; μ]
+
+/-- The boundary Hardy space `H^1` condition for a density on the unit circle:
+it is integrable and all negative Fourier coefficients vanish. -/
+def HasHardyH1Density (h : HardyCircle → ℂ) : Prop :=
+  Integrable h circleHaar ∧ ∀ k : ℤ, k < 0 → fourierCoeff (T := (1 : ℝ)) h k = 0
+
+/-- **F. and M. Riesz brothers theorem.** Let `μ` be a complex Borel measure on
+the unit circle such that `∫ z^n dμ = 0` for every `n ≥ 1`. Then `μ` is
+absolutely continuous with respect to Haar measure, and more precisely
+`dμ = h dm` for some `h ∈ H^1`, i.e. some integrable density whose negative
+Fourier coefficients vanish. -/
+@[eval_problem]
+theorem riesz_brothers_theorem
+    (μ : CircleComplexMeasure)
+    (hμ : ∀ n : ℕ, 1 ≤ n → complexMoment μ (n : ℤ) = 0) :
+    ∃ h : HardyCircle → ℂ, HasHardyH1Density h ∧ circleHaar.withDensityᵥ h = μ := by
+  sorry
+
+end
+
+end Analysis
+end LeanEval

--- a/manifests/problems/riesz_brothers_theorem.toml
+++ b/manifests/problems/riesz_brothers_theorem.toml
@@ -1,9 +1,8 @@
 id = "riesz_brothers_theorem"
-title = "F. and M. Riesz brothers theorem"
+title = "Riesz brothers' theorem"
 test = false
 module = "LeanEval.Analysis.RieszBrothers"
 holes = ["riesz_brothers_theorem"]
 submitter = "Yongxi Lin"
-notes = "The theorem is stated for complex measures on the unit circle, represented as AddCircle 1. The hypothesis uses vector-measure integration to encode the vanishing analytic moments int z^n dmu = 0 for n >= 1. The conclusion strengthens absolute continuity by giving an H^1 density h with mu = m.withDensityᵥ h and vanishing negative Fourier coefficients."
-source = "F. and M. Riesz, 1916; W. Rudin, Real and Complex Analysis; N. K. Nikolski, Operators, Functions, and Systems: An Easy Reading, Volume I: Hardy, Hankel, and Toeplitz."
-informal_solution = "One proof, as in Rudin's Real and Complex Analysis, uses the Poisson integral of the measure. The vanishing analytic moments force the Poisson integral to be the real part of an analytic H^1 function, and uniqueness of the Poisson integral representation identifies the measure with the boundary density h dm. Another operator-theoretic proof, as in Nikolski's Operators, Functions, and Systems, Volume I, interprets the moment condition through the unilateral shift/invariant subspace picture and is closely related to Wold's decomposition."
+source = "W. Rudin, Real and Complex Analysis; N. K. Nikolski, Operators, Functions, and Systems: An Easy Reading, Volume I: Hardy, Hankel, and Toeplitz."
+informal_solution = "One proof, given in Rudin's Real and Complex Analysis, uses the uniqueness of the Poisson integral representation. Another proof presented in Nikolski's book relies on Wold's decomposition."

--- a/manifests/problems/riesz_brothers_theorem.toml
+++ b/manifests/problems/riesz_brothers_theorem.toml
@@ -1,0 +1,9 @@
+id = "riesz_brothers_theorem"
+title = "F. and M. Riesz brothers theorem"
+test = false
+module = "LeanEval.Analysis.RieszBrothers"
+holes = ["riesz_brothers_theorem"]
+submitter = "Yongxi Lin"
+notes = "The theorem is stated for complex measures on the unit circle, represented as AddCircle 1. The hypothesis uses vector-measure integration to encode the vanishing analytic moments int z^n dmu = 0 for n >= 1. The conclusion strengthens absolute continuity by giving an H^1 density h with mu = m.withDensityᵥ h and vanishing negative Fourier coefficients."
+source = "F. and M. Riesz, 1916; W. Rudin, Real and Complex Analysis; N. K. Nikolski, Operators, Functions, and Systems: An Easy Reading, Volume I: Hardy, Hankel, and Toeplitz."
+informal_solution = "One proof, as in Rudin's Real and Complex Analysis, uses the Poisson integral of the measure. The vanishing analytic moments force the Poisson integral to be the real part of an analytic H^1 function, and uniqueness of the Poisson integral representation identifies the measure with the boundary density h dm. Another operator-theoretic proof, as in Nikolski's Operators, Functions, and Systems, Volume I, interprets the moment condition through the unilateral shift/invariant subspace picture and is closely related to Wold's decomposition."


### PR DESCRIPTION
Add a LeanEval problem: the F. and M. Riesz brothers theorem for complex Borel measures on the circle. If a complex measure `μ` has vanishing analytic moments

`∫ z^n dμ = 0`

for all `n ≥ 1`, then `μ` is absolutely continuous with respect to Haar measure, and more precisely `dμ = h dm` for some `h ∈ H^1`.

As far as I know, there are two approaches to this theorem. The first one can be found in Rudin's _Real and Complex Analysis_; the proof relies on the uniqueness of the Poisson integral representation. The second proof can be found in Nikolski's _Operators, Functions, and Systems: An Easy Reading, Volume I: Hardy, Hankel, and Toeplitz_, which I believe relies on [Wold's decomposition](https://en.wikipedia.org/wiki/Wold%27s_decomposition).

Checked with `lake env lean LeanEval/Analysis/RieszBrothers.lean`, `lake exe lean-eval validate-manifest`, `lake exe lean-eval check-problem-build`, and `git diff --check`.

Drafted with the help of Codex.
