### PR TITLE
feat: add coherent cohomology finiteness problem

### DIFF
--- a/LeanEval/AlgebraicGeometry/CoherentCohomologyFinite.lean
+++ b/LeanEval/AlgebraicGeometry/CoherentCohomologyFinite.lean
@@ -26,7 +26,10 @@ open CategoryTheory AlgebraicGeometry TensorProduct
 namespace LeanEval
 namespace AlgebraicGeometry
 
-variable (X : Scheme.{0}) (M : X.Modules)
+-- `X` and `M` are implicit at the variable level so that the eval pipeline's
+-- generated `Solution.lean` can delegate to `Submission` without threading `X`
+-- and `M` through every call: they are inferred from `f` and the conclusion.
+variable {X : Scheme.{0}} {M : X.Modules}
 
 /-- The category of abelian sheaves on `X` has enough injectives, hence
 `Ext`-groups, hence the sheaf cohomology `Sheaf.H` used below is available. -/

--- a/LeanEval/AlgebraicGeometry/CoherentCohomologyFinite.lean
+++ b/LeanEval/AlgebraicGeometry/CoherentCohomologyFinite.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 Brian Nugent. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Brian Nugent
+-/
+import Mathlib
+import EvalTools.Markers
+
+/-!
+# Finite-dimensionality of coherent cohomology
+
+Brian Nugent's formalization of the statement that a coherent sheaf on a scheme
+proper over `ℚ` has finite-dimensional cohomology in every degree (Grothendieck's
+coherent finiteness theorem). Posted to the leanprover Zulip:
+<https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/near/603798763>.
+
+`M.sheaf.H n` is the degree-`n` sheaf cohomology of the underlying sheaf of
+abelian groups of the `𝒪_X`-module `M`, which for a quasi-coherent sheaf computes
+coherent cohomology. Since `X` is a scheme over `ℚ`, this cohomology is a
+`ℚ`-vector space, but Mathlib only exposes its underlying abelian group; tensoring
+with `ℚ` over `ℤ` recovers the `ℚ`-vector space (the natural map `V → ℚ ⊗[ℤ] V` is
+an isomorphism for any `ℚ`-vector space `V`), so `Module.Finite ℚ (ℚ ⊗[ℤ] M.sheaf.H n)`
+faithfully expresses "`Hⁿ(X, M)` is finite-dimensional over `ℚ`".
+-/
+
+open CategoryTheory AlgebraicGeometry TensorProduct
+
+namespace LeanEval
+namespace AlgebraicGeometry
+
+variable (X : Scheme.{0}) (M : X.Modules)
+
+/-- The category of abelian sheaves on `X` has enough injectives, hence
+`Ext`-groups, hence the sheaf cohomology `Sheaf.H` used below is available. -/
+instance instHasExtOpens :
+    HasExt.{0} (CategoryTheory.Sheaf (Opens.grothendieckTopology X) AddCommGrpCat.{0}) :=
+  hasExt_of_enoughInjectives _
+
+/-- The underlying sheaf of abelian groups of an `𝒪_X`-module `M`. -/
+noncomputable abbrev _root_.AlgebraicGeometry.Scheme.Modules.sheaf :
+    TopCat.Sheaf AddCommGrpCat.{0} X :=
+  (SheafOfModules.toSheaf X.ringCatSheaf).obj M
+
+/-- A coherent sheaf `M` (here: quasi-coherent and of finite type, which on the
+locally Noetherian `X` is coherent) on a scheme `X` proper over `ℚ` has
+finite-dimensional cohomology in every degree. -/
+@[eval_problem]
+theorem coherent_cohomology_finite_dimensional
+    (f : X ⟶ Spec (CommRingCat.of ℚ)) [IsProper f]
+    [M.IsFiniteType] [M.IsQuasicoherent] (n : ℕ) :
+    Module.Finite ℚ (ℚ ⊗[ℤ] M.sheaf.H n) := by
+  sorry
+
+end AlgebraicGeometry
+end LeanEval

--- a/LeanEval/AlgebraicGeometry/CoherentCohomologyFinite.lean
+++ b/LeanEval/AlgebraicGeometry/CoherentCohomologyFinite.lean
@@ -1,13 +1,11 @@
-/-
-Copyright (c) 2026 Brian Nugent. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Brian Nugent
--/
 import Mathlib
 import EvalTools.Markers
 
 /-!
 # Finite-dimensionality of coherent cohomology
+
+Author: Brian Nugent.
+
 
 Brian Nugent's formalization of the statement that a coherent sheaf on a scheme
 proper over `ℚ` has finite-dimensional cohomology in every degree (Grothendieck's

--- a/manifests/problems/coherent_cohomology_finite_dimensional.toml
+++ b/manifests/problems/coherent_cohomology_finite_dimensional.toml
@@ -1,0 +1,9 @@
+id = "coherent_cohomology_finite_dimensional"
+title = "Coherent cohomology of a proper scheme over ℚ is finite-dimensional"
+test = false
+module = "LeanEval.AlgebraicGeometry.CoherentCohomologyFinite"
+holes = ["coherent_cohomology_finite_dimensional"]
+submitter = "Brian Nugent"
+notes = "Grothendieck's coherent finiteness theorem: for a coherent sheaf M on a scheme X proper over ℚ, every cohomology group Hⁿ(X, M) is finite-dimensional over ℚ. Coherence is encoded as IsQuasicoherent together with IsFiniteType, which is coherent because properness makes X locally Noetherian. `M.sheaf.H n` is the degree-n sheaf cohomology (Ext from the constant ℤ-sheaf) of the underlying abelian sheaf of M; for a quasi-coherent sheaf this computes coherent cohomology. Mathlib exposes only the underlying abelian group of this cohomology, so the statement tensors with ℚ over ℤ: for the ℚ-vector space Hⁿ(X, M) the natural map V → ℚ ⊗[ℤ] V is an isomorphism, hence Module.Finite ℚ (ℚ ⊗[ℤ] M.sheaf.H n) faithfully expresses finite-dimensionality of the cohomology."
+source = "https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/near/603798763"
+informal_solution = "This is Grothendieck's finiteness theorem for coherent cohomology (EGA III 3.2.1; Hartshorne III.5.2 in the projective case). A coherent sheaf on a scheme proper over a field k has finite-dimensional cohomology in every degree. Over k = ℚ, choose a finite affine cover, compute via the Čech-to-derived-functor spectral sequence (or Serre's vanishing plus a closed immersion into projective space in the projective case), and use that the higher direct images of a coherent sheaf under a proper morphism to Spec k are coherent, i.e. finite-dimensional k-vector spaces."


### PR DESCRIPTION
This PR adds a benchmark problem contributed by Brian Nugent: a coherent sheaf on a scheme proper over ℚ has finite-dimensional cohomology in every degree, the coherent finiteness theorem of Grothendieck. The statement is Brian's formalization from the [LeanEval Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/near/603798763).

Coherence is encoded as `IsQuasicoherent` together with `IsFiniteType`, which is genuine coherence because properness makes `X` locally Noetherian. `M.sheaf.H n` is the degree-`n` sheaf cohomology (`Ext` from the constant `ℤ`-sheaf) of the underlying abelian sheaf of `M`; for a quasi-coherent sheaf this computes coherent cohomology. Mathlib exposes only the underlying abelian group of that cohomology, so the conclusion tensors with `ℚ` over `ℤ`: for the `ℚ`-vector space `Hⁿ(X, M)` the map `V → ℚ ⊗[ℤ] V` is an isomorphism, so `Module.Finite ℚ (ℚ ⊗[ℤ] M.sheaf.H n)` faithfully expresses that the cohomology is finite-dimensional. The `HasExt` instance and `Scheme.Modules.sheaf` abbreviation are non-hole scaffolding carried into `Challenge.lean`; the single hole is `coherent_cohomology_finite_dimensional`.

🤖 Prepared with Claude Code