### PR TITLE
fix: pin diagonal action in m23_irrep_tensor_square_decomp

### DIFF
--- a/LeanEval/RepresentationTheory/M23TensorSquare.lean
+++ b/LeanEval/RepresentationTheory/M23TensorSquare.lean
@@ -34,29 +34,34 @@ also satisfy the existential), but while this does not technically require
 constructing `M₂₃` and studying its representation theory, we suspect that in
 practice it does.
 
-The `MonoidAlgebra ℂ G`-module structures on `V` and `V ⊗[ℂ] V` are bound
-explicitly. The `IsScalarTower` constraints anchor them to the underlying
-ℂ-module structures, and the explicit diagonal-action equation pins the
-`V ⊗ V` action to be `g • (v ⊗ w) = (g • v) ⊗ (g • w)` (extended ℂ-linearly
-to the whole group algebra by ℂ-bilinearity of the tensor).
+The `G`-action is carried by a `Representation ℂ G V`. The diagonal action on
+the tensor square is `ρ.tprod ρ` (`(ρ.tprod ρ) g = TensorProduct.map (ρ g) (ρ g)`),
+which is pinned directly rather than relying on a constraint typeclass
+resolution would not respect. (An earlier version bound a bare
+`Module (MonoidAlgebra ℂ G) (V ⊗[ℂ] V)` witness and tried to pin it to the
+diagonal action via the equation `g • (v ⊗ w) = (g • v) ⊗ (g • w)`; but the `•`
+on `V ⊗[ℂ] V` resolves to `TensorProduct.leftModule`, the left-factor action,
+not the bound witness, so that conjunct forces a trivial action and the whole
+statement is vacuously false.)
+
+The tensor-square module instance is supplied explicitly via `Module.compHom`
+from `ρ.tprod ρ` on the carrier `V ⊗[ℂ] V`. This avoids both the
+`TensorProduct.leftModule` ambiguity above and the `AddCommMonoid`/`AddCommGroup`
+diamond in `Representation.asModule` (which would otherwise force a
+`set_option backward.isDefEq.respectTransparency false`, a modifier the workspace
+extractor does not carry onto the generated `Challenge.lean`).
 -/
 
 @[eval_problem]
 theorem m23_irrep_tensor_square_decomp :
     ∃ (G : Type) (_ : Group G) (_ : Fintype G),
       Fintype.card G = 10200960 ∧
-      ∃ (V : Type) (_ : AddCommGroup V) (_ : Module ℂ V)
-        (_ : Module (MonoidAlgebra ℂ G) V)
-        (_ : IsScalarTower ℂ (MonoidAlgebra ℂ G) V)
-        (_ : Module (MonoidAlgebra ℂ G) (V ⊗[ℂ] V))
-        (_ : IsScalarTower ℂ (MonoidAlgebra ℂ G) (V ⊗[ℂ] V)),
+      ∃ (V : Type) (_ : AddCommGroup V) (_ : Module ℂ V) (ρ : Representation ℂ G V),
         Module.finrank ℂ V = 22 ∧
-        IsSimpleModule (MonoidAlgebra ℂ G) V ∧
-        (∀ (g : G) (v w : V),
-          (MonoidAlgebra.of ℂ G g : MonoidAlgebra ℂ G) • (v ⊗ₜ[ℂ] w) =
-            ((MonoidAlgebra.of ℂ G g : MonoidAlgebra ℂ G) • v) ⊗ₜ[ℂ]
-              ((MonoidAlgebra.of ℂ G g : MonoidAlgebra ℂ G) • w)) ∧
-        (isotypicComponents (MonoidAlgebra ℂ G) (V ⊗[ℂ] V)).ncard = 4 := by
+        ρ.IsIrreducible ∧
+        (@isotypicComponents (MonoidAlgebra ℂ G) (V ⊗[ℂ] V) _ _
+          (Module.compHom (V ⊗[ℂ] V)
+            (Representation.asAlgebraHom (ρ.tprod ρ)).toRingHom)).ncard = 4 := by
   sorry
 
 end RepresentationTheory


### PR DESCRIPTION
This PR fixes the `m23_irrep_tensor_square_decomp` statement, which was vacuously false as elaborated. It bound a `Module (MonoidAlgebra ℂ G) (V ⊗[ℂ] V)` witness and tried to pin it to the diagonal action via the equation `g • (v ⊗ w) = (g • v) ⊗ (g • w)`, but the `•` on `V ⊗[ℂ] V` resolves to `TensorProduct.leftModule` (the left-factor action), not the bound witness. That conjunct therefore forces a trivial `G`-action, contradicting `finrank ℂ V = 22` together with simplicity, so the existential is unsatisfiable. Lorenzo Luccioli, using Harmonic's Aristotle, produced the formal disproof; thanks to both.

Carry the `G`-action as a `Representation ℂ G V` and use the genuinely diagonal `ρ.tprod ρ` for the tensor square, with irreducibility stated as `ρ.IsIrreducible`. The tensor-square module instance is supplied explicitly via `Module.compHom` on the carrier `V ⊗[ℂ] V`, which avoids both the `TensorProduct.leftModule` ambiguity and the `Representation.asModule` `AddCommMonoid`/`AddCommGroup` diamond (whose `set_option backward.isDefEq.respectTransparency false` workaround the workspace extractor does not carry onto the generated `Challenge.lean`). Verified by regenerating and building the workspace locally. The sibling `g2`/`e8` tensor-square problems are unaffected: their diagonal Lie action on `V ⊗ V` is canonical and `leftModule` never fires there.

🤖 Prepared with Claude Code