### PR TITLE
feat: add aspherical integer homology 4-sphere eval problem

### DIFF
--- a/LeanEval/Topology/AsphericalHomologySphere.lean
+++ b/LeanEval/Topology/AsphericalHomologySphere.lean
@@ -1,0 +1,84 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Topology
+
+open CategoryTheory AlgebraicTopology
+open Metric (sphere)
+
+/-!
+# Existence of an aspherical integer homology 4-sphere (Tschantz)
+
+`[Kir97, Problem 4.17]` asks whether there is a closed aspherical 4-manifold
+that is an integer homology 4-sphere. Ratcliffe–Tschantz answered this
+affirmatively (S. Tschantz; see J. Ratcliffe, S. Tschantz, *On the
+Davis hyperbolic 4-manifold*, 2005); their examples even admit metrics of
+non-positive curvature. (Earlier, Luo constructed an aspherical *rational*
+homology 4-sphere.)
+
+We state the existence of such a manifold. A closed topological 4-manifold is
+bundled as `Closed4Manifold` so that we can quantify over its existence
+together with its topological-space and chart data. The two conditions are:
+
+* **aspherical** — every higher homotopy group `πₖ` (`k ≥ 2`) vanishes, at every
+  basepoint. For a connected closed manifold (a CW complex) this is exactly the
+  statement that the universal cover is contractible, i.e. that the manifold is a
+  `K(π, 1)`.
+* **integer homology 4-sphere** — the singular homology with `ℤ` coefficients
+  agrees, in every degree, with that of the standard 4-sphere `S⁴`. (This forces
+  `H₀ ≅ ℤ`, hence connectedness, `H₄ ≅ ℤ`, and `Hₖ = 0` otherwise.)
+
+Mathlib has `HomotopyGroup`, singular homology (`singularHomologyFunctor`),
+`ChartedSpace`, and the sphere as a topological space, but no aspherical
+4-manifolds, no hyperbolic geometry in this range, and nothing resembling the
+Davis/Tschantz construction.
+-/
+
+/-- A closed connected topological 4-manifold, bundled with its topological-space
+and chart instances so its existence can be quantified over. Charts model
+`carrier` on `EuclideanSpace ℝ (Fin 4)` (the whole space, not a half-space), so
+the space is locally Euclidean with no boundary; together with `CompactSpace`
+this is a closed manifold. This is the charted topological-manifold model — it
+carries `ChartedSpace`, not Mathlib's stronger bundled `IsManifold` class, which
+is exactly right for a topological (not necessarily smooth) manifold. -/
+structure Closed4Manifold where
+  /-- The underlying point set. -/
+  carrier : Type
+  [topology : TopologicalSpace carrier]
+  [t2 : T2Space carrier]
+  [secondCountable : SecondCountableTopology carrier]
+  [charted : ChartedSpace (EuclideanSpace ℝ (Fin 4)) carrier]
+  [compact : CompactSpace carrier]
+  [connected : ConnectedSpace carrier]
+
+attribute [instance] Closed4Manifold.topology Closed4Manifold.t2
+  Closed4Manifold.secondCountable Closed4Manifold.charted Closed4Manifold.compact
+  Closed4Manifold.connected
+
+/-- `Hₖ(X; ℤ)`, the `k`-th singular homology with integer coefficients, as an
+object of `ModuleCat ℤ`. -/
+noncomputable def intHomology (k : ℕ) (X : TopCat) : ModuleCat ℤ :=
+  ((singularHomologyFunctor (ModuleCat ℤ) k).obj (ModuleCat.of ℤ ℤ)).obj X
+
+/-- `M` is **aspherical**: every higher homotopy group vanishes at every
+basepoint. -/
+def Closed4Manifold.IsAspherical (M : Closed4Manifold) : Prop :=
+  ∀ k : ℕ, 2 ≤ k → ∀ x : M.carrier, Subsingleton (HomotopyGroup (Fin k) M.carrier x)
+
+/-- `M` is an **integer homology 4-sphere**: in every degree its integral
+singular homology is isomorphic to that of the standard 4-sphere. -/
+def Closed4Manifold.IsIntegerHomologySphere (M : Closed4Manifold) : Prop :=
+  ∀ k : ℕ, Nonempty (intHomology k (TopCat.of M.carrier) ≅
+    intHomology k (TopCat.of (sphere (0 : EuclideanSpace ℝ (Fin 5)) 1)))
+
+/-- **Existence of an aspherical integer homology 4-sphere** (Tschantz, answering
+`[Kir97, Problem 4.17]`). There is a closed topological 4-manifold that is both
+aspherical and an integer homology 4-sphere. -/
+@[eval_problem]
+theorem aspherical_integer_homology_four_sphere :
+    ∃ M : Closed4Manifold, M.IsAspherical ∧ M.IsIntegerHomologySphere := by
+  sorry
+
+end Topology
+end LeanEval

--- a/manifests/problems/aspherical_integer_homology_four_sphere.toml
+++ b/manifests/problems/aspherical_integer_homology_four_sphere.toml
@@ -1,0 +1,9 @@
+id = "aspherical_integer_homology_four_sphere"
+title = "Existence of an aspherical integer homology 4-sphere"
+test = false
+module = "LeanEval.Topology.AsphericalHomologySphere"
+holes = ["aspherical_integer_homology_four_sphere"]
+submitter = "Kim Morrison"
+notes = "Resolves [Kir97, Problem 4.17]: is there a closed aspherical 4-manifold that is an integer homology 4-sphere? Tschantz constructed such manifolds; they even admit metrics of non-positive curvature. We bundle a closed topological 4-manifold and ask for it to be aspherical (all higher homotopy groups vanish) and to have the integral singular homology of S⁴ in every degree."
+source = "J. G. Ratcliffe and S. T. Tschantz, *On the Davis hyperbolic 4-manifold*, Topology Appl. 111 (2001); see also the discussion of [Kir97, Problem 4.17] in the K3 problem list. Earlier, F. Luo constructed an aspherical rational homology 4-sphere (1988)."
+informal_solution = "No formalization is feasible today: Mathlib has no construction of aspherical 4-manifolds, no hyperbolic geometry in dimension 4, and nothing resembling the Davis/Tschantz manifolds. The intended witness is a closed hyperbolic-flavoured 4-manifold whose fundamental group is a 4-dimensional duality group with the integral homology of S⁴."


### PR DESCRIPTION
This PR adds an eval problem stating the existence of a closed aspherical integer homology 4-sphere, resolving [Kir97, Problem 4.17] (Ratcliffe–Tschantz). The statement bundles a closed connected topological 4-manifold and asks for it to be aspherical (every higher homotopy group `πₖ`, `k ≥ 2`, vanishes) and to have the integral singular homology of `S⁴` in every degree, which also forces connectedness.

It is a faithful statement with a `sorry` body; no proof is expected, since Mathlib has nothing of the Davis/Tschantz construction. The statement was reviewed by Codex for semantic faithfulness.

This is one of the "Class B" (stateable today) problems from a walk over the solved Kirby-list problems; the "Class C" problems that Mathlib cannot yet state are tracked in https://github.com/FormalFrontier/TauCetiRoadmap/issues/17.

🤖 Prepared with Claude Code