### PR TITLE
feat: add Manolescu triangulation disproof eval problem

### DIFF
--- a/LeanEval/Topology/ManolescuTriangulation.lean
+++ b/LeanEval/Topology/ManolescuTriangulation.lean
@@ -1,0 +1,79 @@
+import Mathlib
+import EvalTools.Markers
+
+open Geometry
+
+namespace LeanEval
+namespace Topology
+
+/-!
+# Manolescu's disproof of the triangulation conjecture (2016)
+
+The triangulation conjecture asked whether every topological manifold is
+homeomorphic to a simplicial complex. Manolescu disproved it: in every dimension
+`n ≥ 5` there are closed topological `n`-manifolds that are not triangulable. He
+proved this by constructing a `Pin(2)`-equivariant Seiberg–Witten Floer homology
+and using it to refute the existence of an element of the homology-cobordism
+group of homology 3-spheres demanded by the Galewski–Stern / Matumoto reduction
+of the triangulation problem.
+
+We state the resolved theorem: for every `n ≥ 5` there is a closed `n`-manifold
+that is not triangulable.
+
+* A closed topological `n`-manifold is bundled as `ClosedTopManifold n`.
+* **Triangulable** is encoded as being homeomorphic to the geometric realization
+  of a *finite* simplicial complex — Mathlib's `SimplicialComplex ℝ E` with
+  `K.faces` finite, whose `space` is the union of its faces, carrying the
+  subspace topology from `E`. We let `E` range over the finite-dimensional
+  Euclidean spaces `ℝᴺ`. This is faithful for a *closed* (compact) manifold: a
+  triangulation of a compact space is a finite complex, which geometrically
+  realizes in some `ℝᴺ`, and on a finite complex the ambient subspace topology of
+  `ℝᴺ` (a normed space) is the honest polyhedron topology. The finiteness
+  requirement is essential — without it the union-of-faces could be taken to be
+  one singleton `0`-face per point of an embedded copy of `M`, whose `space` is
+  just `M` again, which would make every manifold vacuously "triangulable".
+
+Mathlib has `SimplicialComplex` and `ChartedSpace`, but no PL topology, no
+manifold triangulation theory, no Seiberg–Witten / Floer homology, and nothing
+of the Galewski–Stern obstruction — so neither the construction nor the
+obstruction is anywhere in reach.
+-/
+
+/-- A closed connected topological `n`-manifold, bundled with its
+topological-space and chart instances so its existence can be quantified over.
+Charts model `carrier` on `EuclideanSpace ℝ (Fin n)` (the whole space), so it is
+locally Euclidean with no boundary; with `CompactSpace` this is a closed
+manifold. -/
+structure ClosedTopManifold (n : ℕ) where
+  /-- The underlying point set. -/
+  carrier : Type
+  [topology : TopologicalSpace carrier]
+  [t2 : T2Space carrier]
+  [secondCountable : SecondCountableTopology carrier]
+  [charted : ChartedSpace (EuclideanSpace ℝ (Fin n)) carrier]
+  [compact : CompactSpace carrier]
+  [connected : ConnectedSpace carrier]
+
+attribute [instance] ClosedTopManifold.topology ClosedTopManifold.t2
+  ClosedTopManifold.secondCountable ClosedTopManifold.charted
+  ClosedTopManifold.compact ClosedTopManifold.connected
+
+/-- `M` is **triangulable**: it is homeomorphic to the geometric realization (the
+union of the faces, with the subspace topology) of a *finite* simplicial complex
+sitting in some finite-dimensional Euclidean space `ℝᴺ`. For a compact manifold
+this is exactly the usual notion of triangulability; the finiteness of `K.faces`
+is essential (see the module docstring). -/
+def Triangulable {n : ℕ} (M : ClosedTopManifold n) : Prop :=
+  ∃ (N : ℕ) (K : SimplicialComplex ℝ (EuclideanSpace ℝ (Fin N))),
+    K.faces.Finite ∧ Nonempty (M.carrier ≃ₜ K.space)
+
+/-- **Manolescu's theorem (2016): the triangulation conjecture is false**, in
+every dimension `≥ 5`. For each `n ≥ 5` there is a closed connected topological
+`n`-manifold that is not homeomorphic to any simplicial complex. -/
+@[eval_problem]
+theorem manolescu_triangulation_disproof :
+    ∀ n : ℕ, 5 ≤ n → ∃ M : ClosedTopManifold n, ¬ Triangulable M := by
+  sorry
+
+end Topology
+end LeanEval

--- a/manifests/problems/manolescu_triangulation_disproof.toml
+++ b/manifests/problems/manolescu_triangulation_disproof.toml
@@ -1,0 +1,9 @@
+id = "manolescu_triangulation_disproof"
+title = "Manolescu's disproof of the triangulation conjecture"
+test = false
+module = "LeanEval.Topology.ManolescuTriangulation"
+holes = ["manolescu_triangulation_disproof"]
+submitter = "Kim Morrison"
+notes = "The triangulation conjecture (every topological manifold is homeomorphic to a simplicial complex) is false: Manolescu showed that in every dimension n ≥ 5 there are closed topological manifolds that are not triangulable. We state, for every n ≥ 5, the existence of a closed connected n-manifold not homeomorphic to the geometric realization of any simplicial complex. Triangulability is encoded via Mathlib's Geometry.SimplicialComplex over a finite-dimensional Euclidean space ℝᴺ, with finitely many faces (faithful for compact manifolds, whose triangulations are finite complexes realizing in some ℝᴺ with its standard topology; the finiteness requirement is essential, else a degenerate complex of one singleton face per point of an embedded M would make every manifold vacuously triangulable)."
+source = "C. Manolescu, *Pin(2)-equivariant Seiberg–Witten Floer homology and the triangulation conjecture*, J. Amer. Math. Soc. 29 (2016), via the Galewski–Stern and Matumoto reduction. Earlier, the triangulation conjecture was known false in dimension 4 (Casson)."
+informal_solution = "No formalization is feasible today: Mathlib has SimplicialComplex but no PL/manifold triangulation theory, no Seiberg–Witten or Floer homology, and nothing of the Galewski–Stern homology-cobordism obstruction. The intended witnesses are the Galewski–Stern manifolds whose non-triangulability Manolescu established."


### PR DESCRIPTION
This PR adds an eval problem stating Manolescu's disproof of the triangulation conjecture: in every dimension `n ≥ 5` there is a closed connected topological `n`-manifold not homeomorphic to any simplicial complex. (He proved this via `Pin(2)`-equivariant Seiberg–Witten Floer homology and the Galewski–Stern / Matumoto reduction.)

Triangulability is encoded as being homeomorphic to the geometric realization (`K.space`, the union of faces with the subspace topology) of a **finite** `Geometry.SimplicialComplex ℝ (EuclideanSpace ℝ (Fin N))`. This is faithful for a compact manifold: a triangulation of a compact space is a finite complex, realizing in some `ℝᴺ` with its standard topology, so `K.space` is the honest polyhedron. The statement uses plain homeomorphism, matching Manolescu's simplicial (not merely PL/combinatorial) result.

Codex reviewed this and caught a real bug in the first draft: without `K.faces.Finite`, one could take a singleton `0`-face per point of an embedded copy of `M`, whose `space` is just `M` — making every manifold vacuously triangulable and the theorem false. The finiteness requirement (now in place) closes that loophole; Codex confirmed the encoding is faithful once finiteness is imposed.

This is a fifth "Class B" (stateable today) problem, originally sorted into Class C; it turned out expressible after all. The remaining Class C problems Mathlib cannot yet state are tracked in https://github.com/FormalFrontier/TauCetiRoadmap/issues/17.

🤖 Prepared with Claude Code