### PR TITLE
feat: add Lagrange (Cauchy-Binet) identity eval problem

### DIFF
--- a/LeanEval/LinearAlgebra/CauchyBinet.lean
+++ b/LeanEval/LinearAlgebra/CauchyBinet.lean
@@ -1,0 +1,30 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.LinearAlgebra.CauchyBinet
+
+/-!
+# Lagrange / Cauchy–Binet identity
+
+`lagrange_cauchy_binet`: for an `n × m` real matrix `F`, `det(FᵀF)` equals the
+sum over all `m`-element row-subsets `S ⊆ Fin n` of the squared maximal minor
+`det(F_S)²`. This is the Cauchy–Binet formula applied to `Fᵀ * F`, equivalently
+Pythagoras / the Lagrange identity in `det²` form. Mathlib does not yet have the
+Cauchy–Binet determinant formula (the subject of an in-flight PR); the indexing
+mirrors the prospective `Matrix.det_mul_cauchyBinet`. Category-(b) candidate from
+§2 of the Knill survey.
+-/
+
+open Matrix
+
+/-- **Lagrange identity (Cauchy–Binet).** For an `n × m` real matrix `F`,
+`det(FᵀF)` is the sum over all `m`-element row-subsets `S ⊆ Fin n` of the squared
+maximal minor `det(F_S)²`, where `F_S` is the `m × m` submatrix on rows `S`. -/
+@[eval_problem]
+theorem lagrange_cauchy_binet {n m : ℕ} (F : Matrix (Fin n) (Fin m) ℝ) :
+    (Fᵀ * F).det =
+      ∑ S : {s : Finset (Fin n) // s.card = m},
+        ((F.submatrix (S.1.orderEmbOfFin S.2) id).det) ^ 2 := by
+  sorry
+
+end LeanEval.LinearAlgebra.CauchyBinet

--- a/manifests/problems/lagrange_cauchy_binet.toml
+++ b/manifests/problems/lagrange_cauchy_binet.toml
@@ -1,0 +1,9 @@
+id = "lagrange_cauchy_binet"
+title = "Lagrange / Cauchy–Binet identity for det(FᵀF)"
+test = false
+module = "LeanEval.LinearAlgebra.CauchyBinet"
+holes = ["lagrange_cauchy_binet"]
+submitter = "Kim Morrison"
+notes = "For an n × m real matrix F, det(FᵀF) equals the sum over all m-element row-subsets S ⊆ Fin n of the squared maximal minor det(F_S)². This is the Cauchy–Binet formula applied to Fᵀ * F (the Lagrange identity in det² form), with no helper defs beyond the statement. Mathlib does not yet have the Cauchy–Binet determinant formula (the subject of an in-flight PR, leanprover-community/mathlib4#40473); the indexing mirrors the prospective Matrix.det_mul_cauchyBinet. Candidate from §2 of the Knill survey."
+source = "Cauchy–Binet formula; J.-L. Lagrange's identity. See leanprover-community/mathlib4#40473 (Matrix.det_mul_cauchyBinet). Knill, *Some fundamental theorems in mathematics*, §2."
+informal_solution = "Apply the Cauchy–Binet formula to the product Fᵀ * F: det(Fᵀ F) = Σ_{|S|=m} det((Fᵀ)_{·,S}) · det(F_{S,·}), where the sum ranges over m-element subsets S of the row index set Fin n. Since (Fᵀ)_{·,S} is the transpose of F_{S,·}, each term is det(F_S)·det(F_S) = det(F_S)², giving the stated sum of squared maximal minors. The general Cauchy–Binet determinant expansion is not yet in Mathlib."


### PR DESCRIPTION
Draft. Adds **Lagrange (Cauchy-Binet) identity** (Knill survey §2) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code