### PR TITLE
feat: add Erdős–Szekeres theorem eval problem

### DIFF
--- a/LeanEval/Combinatorics/ErdosSzekeres.lean
+++ b/LeanEval/Combinatorics/ErdosSzekeres.lean
@@ -1,0 +1,30 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Combinatorics.ErdosSzekeres
+
+/-!
+# Erdős–Szekeres theorem (finite form)
+
+`erdos_szekeres`: any sequence of `n² + 1` distinct real numbers contains a
+strictly increasing subsequence of length `n + 1` or a strictly decreasing
+subsequence of length `n + 1`, encoded by a strictly monotone index map
+`g : Fin (n + 1) → Fin (n² + 1)`. Mathlib has only the infinitary
+Erdős–Szekeres theorem (`exists_increasing_or_nonincreasing_subseq`); the finite
+quantitative bound is not present. Category-(b) candidate from §16 of the Knill
+survey.
+-/
+
+open Function
+
+/-- **Erdős–Szekeres (finite form).** Any injective sequence
+`f : Fin (n² + 1) → ℝ` admits a strictly monotone index map
+`g : Fin (n + 1) → Fin (n² + 1)` along which `f` is either strictly increasing or
+strictly decreasing. -/
+@[eval_problem]
+theorem erdos_szekeres {n : ℕ} (f : Fin (n ^ 2 + 1) → ℝ) (hf : Function.Injective f) :
+    (∃ g : Fin (n + 1) → Fin (n ^ 2 + 1), StrictMono g ∧ StrictMono (f ∘ g)) ∨
+    (∃ g : Fin (n + 1) → Fin (n ^ 2 + 1), StrictMono g ∧ StrictAnti (f ∘ g)) := by
+  sorry
+
+end LeanEval.Combinatorics.ErdosSzekeres

--- a/manifests/problems/erdos_szekeres.toml
+++ b/manifests/problems/erdos_szekeres.toml
@@ -1,0 +1,9 @@
+id = "erdos_szekeres"
+title = "Erdős–Szekeres monotone subsequence theorem (finite form)"
+test = false
+module = "LeanEval.Combinatorics.ErdosSzekeres"
+holes = ["erdos_szekeres"]
+submitter = "Kim Morrison"
+notes = "Any sequence of n² + 1 distinct real numbers contains a strictly increasing subsequence of length n + 1 or a strictly decreasing subsequence of length n + 1, encoded by a strictly monotone index map g : Fin (n + 1) → Fin (n² + 1). No helper defs beyond the statement. Mathlib has only the infinitary Erdős–Szekeres theorem (exists_increasing_or_nonincreasing_subseq); the finite quantitative bound is absent. Candidate from §16 of the Knill survey."
+source = "P. Erdős and G. Szekeres, *A combinatorial problem in geometry*, Compositio Math. 2 (1935). Knill, *Some fundamental theorems in mathematics*, §16."
+informal_solution = "To each index i assign the pair (a_i, b_i) where a_i is the length of the longest strictly increasing subsequence ending at i and b_i the length of the longest strictly decreasing subsequence ending at i. Distinctness makes the map i ↦ (a_i, b_i) injective: if i < j then either f i < f j (forcing a_i < a_j) or f i > f j (forcing b_i < b_j). With n² + 1 indices, by pigeonhole some a_i or some b_i exceeds n, i.e. reaches n + 1, yielding the desired monotone subsequence. Only the infinitary version is in Mathlib."


### PR DESCRIPTION
Draft. Adds **Erdős–Szekeres theorem** (Knill survey §16) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code