### PR TITLE
feat: add König matching = vertex cover eval problem

### DIFF
--- a/LeanEval/Combinatorics/KonigMatching.lean
+++ b/LeanEval/Combinatorics/KonigMatching.lean
@@ -1,0 +1,32 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Combinatorics.KonigMatching
+
+/-!
+# König's theorem (matching = vertex cover)
+
+`konig_matching_vertex_cover`: in a finite bipartite graph, the maximum size of a
+matching equals the minimum size of a vertex cover. The trusted helper
+`matchingNumber` (the supremum of edge counts over matching subgraphs) is a
+non-hole. Mathlib has `SimpleGraph.Subgraph.IsMatching` and a vertex-cover
+number, but not König's min-max theorem. Category-(b) candidate from §172 of the
+Knill survey.
+-/
+
+open SimpleGraph
+
+/-- The matching number of a graph, as the supremum of the number of edges in a
+matching subgraph. -/
+noncomputable def matchingNumber {V : Type*} (G : SimpleGraph V) : ℕ∞ :=
+  ⨆ (M : G.Subgraph) (_ : M.IsMatching), M.edgeSet.encard
+
+/-- **König's theorem.** In a finite bipartite graph, the maximum size of a
+matching equals the minimum size of a vertex cover. -/
+@[eval_problem]
+theorem konig_matching_vertex_cover {V : Type*} [Finite V] (G : SimpleGraph V)
+    (hG : G.IsBipartite) :
+    matchingNumber G = G.vertexCoverNum := by
+  sorry
+
+end LeanEval.Combinatorics.KonigMatching

--- a/manifests/problems/konig_matching_vertex_cover.toml
+++ b/manifests/problems/konig_matching_vertex_cover.toml
@@ -1,0 +1,9 @@
+id = "konig_matching_vertex_cover"
+title = "König's theorem: maximum matching equals minimum vertex cover"
+test = false
+module = "LeanEval.Combinatorics.KonigMatching"
+holes = ["konig_matching_vertex_cover"]
+submitter = "Kim Morrison"
+notes = "In a finite bipartite graph, the maximum size of a matching equals the minimum size of a vertex cover. The trusted helper matchingNumber (the supremum of edge counts over matching subgraphs) is a non-hole. Mathlib has SimpleGraph.Subgraph.IsMatching and a vertex-cover number but not König's min-max theorem. Candidate from §172 of the Knill survey."
+source = "D. König, *Gráfok és mátrixok*, Mat. Fiz. Lapok 38 (1931). Knill, *Some fundamental theorems in mathematics*, §172."
+informal_solution = "The ≤ direction (matching number ≤ vertex cover number) holds for any graph: a vertex cover must touch every edge of any matching, and distinct matching edges are vertex-disjoint, so each needs its own cover vertex. The ≥ direction uses bipartiteness, via the augmenting-path / max-flow-min-cut argument: a maximum matching with no augmenting path induces, through alternating reachability from unmatched left vertices, a vertex cover of size equal to the matching. Equivalently it is the integral max-flow-min-cut theorem on the bipartite flow network. Mathlib lacks this min-max theorem."


### PR DESCRIPTION
Draft. Adds **König matching = vertex cover** (Knill survey §172) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code