### PR TITLE
feat: add Desnanot–Jacobi identity eval problem

### DIFF
--- a/LeanEval/LinearAlgebra/DesnanotJacobi.lean
+++ b/LeanEval/LinearAlgebra/DesnanotJacobi.lean
@@ -1,0 +1,64 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.LinearAlgebra.DesnanotJacobi
+
+/-!
+# Desnanot–Jacobi identity
+
+`desnanot_jacobi_identity`: for an `(n + 2) × (n + 2)` matrix over a commutative
+ring, the product of the full determinant and the central (boundary-deleted)
+minor equals the determinant of the four corner minors arranged as a `2 × 2`
+determinant. Trusted helpers (`interiorFin`, `deleteFirstFirst`,
+`deleteLastLast`, `deleteFirstLast`, `deleteLastFirst`, `deleteBoundaryBoundary`)
+are non-holes. Mathlib has determinants and submatrices but not the
+Desnanot–Jacobi / Dodgson condensation identity. Category-(b) candidate from
+§201 of the Knill survey.
+-/
+
+open Matrix
+
+variable {R : Type*}
+
+/-- The embedding selecting the interior indices `1, ..., n` inside
+`0, ..., n+1`. -/
+def interiorFin (n : ℕ) : Fin n → Fin (n + 2) :=
+  Fin.succ ∘ Fin.castAdd 1
+
+/-- Delete the first row and first column of an `(n+2) × (n+2)` matrix. -/
+def deleteFirstFirst {R : Type*} (n : ℕ) (A : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
+    Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+  A.submatrix Fin.succ Fin.succ
+
+/-- Delete the last row and last column of an `(n+2) × (n+2)` matrix. -/
+def deleteLastLast {R : Type*} (n : ℕ) (A : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
+    Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+  A.submatrix (Fin.castAdd 1) (Fin.castAdd 1)
+
+/-- Delete the first row and last column of an `(n+2) × (n+2)` matrix. -/
+def deleteFirstLast {R : Type*} (n : ℕ) (A : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
+    Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+  A.submatrix Fin.succ (Fin.castAdd 1)
+
+/-- Delete the last row and first column of an `(n+2) × (n+2)` matrix. -/
+def deleteLastFirst {R : Type*} (n : ℕ) (A : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
+    Matrix (Fin (n + 1)) (Fin (n + 1)) R :=
+  A.submatrix (Fin.castAdd 1) Fin.succ
+
+/-- Delete both boundary rows and both boundary columns. -/
+def deleteBoundaryBoundary {R : Type*} (n : ℕ)
+    (A : Matrix (Fin (n + 2)) (Fin (n + 2)) R) : Matrix (Fin n) (Fin n) R :=
+  A.submatrix (interiorFin n) (interiorFin n)
+
+/-- **Desnanot–Jacobi identity** for the four corner minors.  Knill's `n × n`
+statement is represented here as an `(n+2) × (n+2)` matrix: after deleting
+both boundary rows and columns the remaining minor has size `n`. -/
+@[eval_problem]
+theorem desnanot_jacobi_identity [CommRing R] (n : ℕ)
+    (A : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
+    A.det * (deleteBoundaryBoundary n A).det =
+      (deleteFirstFirst n A).det * (deleteLastLast n A).det -
+        (deleteLastFirst n A).det * (deleteFirstLast n A).det := by
+  sorry
+
+end LeanEval.LinearAlgebra.DesnanotJacobi

--- a/manifests/problems/desnanot_jacobi_identity.toml
+++ b/manifests/problems/desnanot_jacobi_identity.toml
@@ -1,0 +1,9 @@
+id = "desnanot_jacobi_identity"
+title = "Desnanot–Jacobi determinant identity"
+test = false
+module = "LeanEval.LinearAlgebra.DesnanotJacobi"
+holes = ["desnanot_jacobi_identity"]
+submitter = "Kim Morrison"
+notes = "For an (n + 2) × (n + 2) matrix over a commutative ring, det(A) times the central boundary-deleted minor equals the 2 × 2 determinant of the four corner minors: det(A)·det(A_{boundary deleted}) = det(A_{11})·det(A_{nn}) − det(A_{n1})·det(A_{1n}). Trusted helpers (interiorFin, deleteFirstFirst, deleteLastLast, deleteFirstLast, deleteLastFirst, deleteBoundaryBoundary) are non-holes. Mathlib has determinants and submatrices but not the Desnanot–Jacobi / Dodgson condensation identity. Candidate from §201 of the Knill survey."
+source = "P. Desnanot (1819); C. G. J. Jacobi (1833); the basis of Dodgson (Lewis Carroll) condensation. Knill, *Some fundamental theorems in mathematics*, §201."
+informal_solution = "The identity is a special case of Sylvester's determinant identity / the Plücker relations among maximal minors. One standard proof uses the Jacobi complementary-minor theorem: for the adjugate of A, the minor on the corner index pairs equals det(A)^{k-1} times the complementary minor of A. Specialising Jacobi's identity to the two boundary rows/columns of A yields exactly det(A)·det(M) = det(A_{11})det(A_{nn}) − det(A_{n1})det(A_{1n}) where M is the central minor. Alternatively, expand both sides as polynomials in the matrix entries and match coefficients. Mathlib lacks this identity."


### PR DESCRIPTION
Draft. Adds **Desnanot–Jacobi identity** (Knill survey §201) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code