### PR TITLE
feat: add Brun's theorem eval problem

### DIFF
--- a/LeanEval/NumberTheory/BrunConstant.lean
+++ b/LeanEval/NumberTheory/BrunConstant.lean
@@ -1,0 +1,38 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.NumberTheory.BrunConstant
+
+/-!
+# Brun's theorem (convergence of the twin-prime reciprocal sum)
+
+§224 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. Brun's
+theorem states that the sum of the reciprocals of the twin primes converges,
+to a value now known as Brun's constant.
+
+mathlib has `Nat.Prime`, `Summable`, and prime-counting estimates, but no
+Brun sieve and hence no proof of this convergence.
+-/
+
+open Filter Finset MeasureTheory
+open scoped BigOperators Topology
+
+/-- A twin-prime start is a prime `p` such that `p + 2` is also prime. -/
+def IsTwinPrimeStart (p : ℕ) : Prop :=
+  p.Prime ∧ (p + 2).Prime
+
+/-- The reciprocal contribution of the twin pair beginning at `p`.
+
+This counts each pair once, by its smaller prime. -/
+noncomputable def twinPrimeReciprocalTerm (p : ℕ) : ℝ :=
+  by
+    classical
+    exact if IsTwinPrimeStart p then (1 / (p : ℝ)) + (1 / ((p + 2 : ℕ) : ℝ)) else 0
+
+/-- **Brun's theorem.** The reciprocal sum over twin-prime pairs converges. -/
+@[eval_problem]
+theorem brun_constant_converges :
+    Summable twinPrimeReciprocalTerm := by
+  sorry
+
+end LeanEval.NumberTheory.BrunConstant

--- a/manifests/problems/brun_constant_converges.toml
+++ b/manifests/problems/brun_constant_converges.toml
@@ -1,0 +1,9 @@
+id = "brun_constant_converges"
+title = "Brun's theorem (convergence of the twin-prime reciprocal sum)"
+test = false
+module = "LeanEval.NumberTheory.BrunConstant"
+holes = ["brun_constant_converges"]
+submitter = "Kim Morrison"
+notes = "Brun's theorem: the sum of the reciprocals of the twin primes converges, to a value now known as Brun's constant. The statement is phrased via a per-pair reciprocal term `twinPrimeReciprocalTerm p`, which contributes `1/p + 1/(p+2)` when `p` starts a twin pair and `0` otherwise, and asserts that this function is `Summable`. mathlib has `Nat.Prime`, `Summable`, and prime-counting estimates, but no Brun sieve."
+source = "V. Brun, La série 1/5+1/7+1/11+1/13+... où les dénominateurs sont nombres premiers jumeaux est convergente ou finie, Bull. Sci. Math. 43 (1919), 100-104, 124-128. Listed as §224 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §224."
+informal_solution = "Brun's sieve bounds the twin-prime counting function π₂(x) by O(x (log log x)² / (log x)²). Summing the reciprocals by dyadic blocks and applying this bound, the tail sums are dominated by a convergent series (essentially ∑ (log log n)² / (n (log n)²)), so the reciprocal sum over twin pairs converges."


### PR DESCRIPTION
Draft. Adds **Brun's theorem** (Knill survey §224) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code