### PR TITLE
feat: add bounded prime gaps eval problem

### DIFF
--- a/LeanEval/NumberTheory/BoundedPrimeGaps.lean
+++ b/LeanEval/NumberTheory/BoundedPrimeGaps.lean
@@ -1,0 +1,28 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.NumberTheory.BoundedPrimeGaps
+
+/-!
+# Bounded gaps between primes (Zhang/Maynard/Polymath)
+
+§224 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. Zhang's
+breakthrough, sharpened by Maynard and the Polymath project, shows that there
+are infinitely many pairs of primes differing by at most a fixed bound; the
+post-Polymath bound recorded by Knill is `246`.
+
+mathlib has `Nat.Prime` and prime-counting estimates, but no Selberg/GPY
+sieve and hence none of the bounded-gap theorems.
+-/
+
+open Filter Finset MeasureTheory
+open scoped BigOperators Topology
+
+/-- **Bounded gaps between primes.** For every `n` there is a pair of primes
+`p < q` with `n ≤ p` and `q - p ≤ 246`. -/
+@[eval_problem]
+theorem zhang_bounded_prime_gaps :
+    ∀ n : ℕ, ∃ p q : ℕ, n ≤ p ∧ p.Prime ∧ q.Prime ∧ p < q ∧ q - p ≤ 246 := by
+  sorry
+
+end LeanEval.NumberTheory.BoundedPrimeGaps

--- a/manifests/problems/zhang_bounded_prime_gaps.toml
+++ b/manifests/problems/zhang_bounded_prime_gaps.toml
@@ -1,0 +1,9 @@
+id = "zhang_bounded_prime_gaps"
+title = "Bounded gaps between primes"
+test = false
+module = "LeanEval.NumberTheory.BoundedPrimeGaps"
+holes = ["zhang_bounded_prime_gaps"]
+submitter = "Kim Morrison"
+notes = "Zhang's bounded-gaps theorem, sharpened by Maynard and the Polymath8 project: for every `n` there exist primes `p < q` with `n ≤ p` and `q - p ≤ 246`, the post-Polymath bound recorded by Knill. Equivalently, infinitely many prime pairs differ by at most 246. mathlib has `Nat.Prime` and prime-counting estimates, but no Selberg/GPY sieve."
+source = "Y. Zhang, Bounded gaps between primes, Ann. of Math. 179 (2014), 1121-1174; J. Maynard, Small gaps between primes, Ann. of Math. 181 (2015), 383-413; D. H. J. Polymath, Variants of the Selberg sieve, and bounded intervals containing many primes, Res. Math. Sci. 1 (2014), Art. 12. Listed as §224 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §224."
+informal_solution = "Use the GPY/Maynard multidimensional sieve. Choose an admissible k-tuple of linear forms and a sieve weight optimizing a ratio of two quadratic forms in a smooth cutoff; Maynard's variational argument shows that for k large enough the weighted count guarantees at least two primes among the shifted forms in infinitely many translates. The Polymath8 optimization of the cutoff and the choice of an admissible 50-tuple yields the explicit gap bound 246."


### PR DESCRIPTION
Draft. Adds **bounded prime gaps** (Knill survey §224) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code