### PR TITLE
feat: add Chen's theorem eval problem

### DIFF
--- a/LeanEval/NumberTheory/ChenTheorem.lean
+++ b/LeanEval/NumberTheory/ChenTheorem.lean
@@ -1,0 +1,33 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.NumberTheory.ChenTheorem
+
+/-!
+# Chen's theorem
+
+§224 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. Chen's
+theorem states that there are infinitely many primes `p` such that `p + 2` is
+either prime or a product of two primes (a "prime or semiprime").
+
+mathlib has `Nat.Prime` and prime factorization, but no Brun-style sieve and
+hence no proof of Chen's theorem.
+-/
+
+open Filter Finset MeasureTheory
+open scoped BigOperators Topology
+
+/-- `n` has at most two prime factors, counted with multiplicity.  This is the
+standard "prime or semiprime" condition in Chen's theorem. -/
+def HasAtMostTwoPrimeFactors (n : ℕ) : Prop :=
+  (∃ a : ℕ, a.Prime ∧ n = a) ∨
+    ∃ a b : ℕ, a.Prime ∧ b.Prime ∧ n = a * b
+
+/-- **Chen's theorem.** There are infinitely many primes `p` for which `p + 2`
+has at most two prime factors. -/
+@[eval_problem]
+theorem chen_theorem :
+    {p : ℕ | p.Prime ∧ HasAtMostTwoPrimeFactors (p + 2)}.Infinite := by
+  sorry
+
+end LeanEval.NumberTheory.ChenTheorem

--- a/manifests/problems/chen_theorem.toml
+++ b/manifests/problems/chen_theorem.toml
@@ -1,0 +1,9 @@
+id = "chen_theorem"
+title = "Chen's theorem"
+test = false
+module = "LeanEval.NumberTheory.ChenTheorem"
+holes = ["chen_theorem"]
+submitter = "Kim Morrison"
+notes = "Chen's theorem: there are infinitely many primes `p` such that `p + 2` is a prime or a product of two primes (a 'prime or semiprime'). The predicate `HasAtMostTwoPrimeFactors n` is the disjunction 'n is prime' or 'n = a·b with a, b prime'. mathlib has `Nat.Prime` and prime factorization, but no Brun-style weighted sieve."
+source = "J. R. Chen, On the representation of a larger even integer as the sum of a prime and the product of at most two primes, Sci. Sinica 16 (1973), 157-176. Listed as §224 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §224."
+informal_solution = "Chen's argument is a weighted sieve. Apply Selberg's sieve with a switching device (Chen's 'reversal of roles') to bound from below the number of primes p ≤ x with p+2 having at most two prime factors. The key is a careful estimate of the bilinear error terms via the Bombieri-Vinogradov theorem, which controls primes in arithmetic progressions on average and lets the sieve weight stay positive, forcing infinitely many such p."


### PR DESCRIPTION
Draft. Adds **Chen's theorem** (Knill survey §224) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code