### PR TITLE
feat: add Wiener's 1/f theorem eval problem

### DIFF
--- a/LeanEval/Analysis/WienerOneOverF.lean
+++ b/LeanEval/Analysis/WienerOneOverF.lean
@@ -1,0 +1,45 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.WienerOneOverF
+
+/-!
+# Wiener's `1/f` theorem
+
+§226 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. Wiener's
+lemma for the circle algebra: if a continuous function on the circle has
+absolutely summable Fourier coefficients and is nowhere zero, then its
+pointwise inverse again has absolutely summable Fourier coefficients.
+
+mathlib has the additive circle, the Fourier characters `fourier`, Fourier
+coefficients `fourierCoeff`, and `hasSum_fourier_series_of_summable`, but not
+the Wiener algebra or the spectral-invariance theorem.
+-/
+
+open Set
+open scoped ComplexConjugate Real
+
+noncomputable section
+
+variable {T : ℝ} [Fact (0 < T)]
+
+/-- The Wiener-algebra predicate on the additive circle: a continuous
+complex-valued function whose Fourier coefficients are absolutely summable.
+For complex series, `Summable` is equivalent to absolute summability of the
+norms. -/
+def InWienerAlgebra (f : C(AddCircle T, ℂ)) : Prop :=
+  Summable (fourierCoeff f)
+
+/-- **Wiener's `1/f` theorem.** If a function on the circle belongs to the
+Wiener algebra and has no zero on the circle, then its pointwise reciprocal
+again belongs to the Wiener algebra. -/
+@[eval_problem]
+theorem wiener_inverse_closed (f : C(AddCircle T, ℂ))
+    (hf : InWienerAlgebra f) (hzero : ∀ x, f x ≠ 0) :
+    ∃ g : C(AddCircle T, ℂ),
+      (∀ x, g x = (f x)⁻¹) ∧ InWienerAlgebra g := by
+  sorry
+
+end
+
+end LeanEval.Analysis.WienerOneOverF

--- a/manifests/problems/wiener_inverse_closed.toml
+++ b/manifests/problems/wiener_inverse_closed.toml
@@ -1,0 +1,9 @@
+id = "wiener_inverse_closed"
+title = "Wiener's 1/f theorem"
+test = false
+module = "LeanEval.Analysis.WienerOneOverF"
+holes = ["wiener_inverse_closed"]
+submitter = "Kim Morrison"
+notes = "Wiener's lemma for the circle algebra: if a continuous function f on the additive circle has absolutely summable Fourier coefficients (i.e. lies in the Wiener algebra, `InWienerAlgebra f := Summable (fourierCoeff f)`) and is nowhere zero, then its pointwise reciprocal 1/f again belongs to the Wiener algebra. mathlib has the additive circle, `fourier`, `fourierCoeff`, and `hasSum_fourier_series_of_summable`, but not the Wiener algebra or spectral invariance."
+source = "N. Wiener, Tauberian theorems, Ann. of Math. 33 (1932), 1-100. Listed as §226 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §226."
+informal_solution = "The Wiener algebra A(T) is the Banach algebra of absolutely convergent Fourier series with the l¹ norm of the coefficients. Wiener's lemma is the statement that its Gelfand spectrum is exactly the circle (point evaluations), so an element is invertible in A(T) iff it never vanishes. The classical elementary proof (Gelfand's gives it via Banach-algebra theory; Newman's gives a direct localization) covers the circle by short arcs, on each of which f is close to a nonzero constant, inverts a local truncation whose remainder has small Wiener norm, and patches with a smooth partition of unity, using that 1/(1-h) = ∑ hⁿ converges in A(T) when ‖h‖ < 1."


### PR DESCRIPTION
Draft. Adds **Wiener's 1/f theorem** (Knill survey §226) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code