### PR TITLE
feat: add Wiener–Lévy theorem eval problem

### DIFF
--- a/LeanEval/Analysis/WienerLevy.lean
+++ b/LeanEval/Analysis/WienerLevy.lean
@@ -1,0 +1,47 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.WienerLevy
+
+/-!
+# Wiener–Lévy theorem (analytic functional calculus)
+
+§226 of Oliver Knill's *Some Fundamental Theorems in Mathematics*. The
+Wiener–Lévy theorem: if `φ` is complex-analytic on a neighbourhood of the
+range of a Wiener-algebra function `f`, then the composition `φ ∘ f` is again
+in the Wiener algebra.
+
+mathlib has the additive circle, the Fourier characters `fourier`, Fourier
+coefficients `fourierCoeff`, and `hasSum_fourier_series_of_summable`, but not
+the Wiener algebra or its analytic functional calculus.
+-/
+
+open Set
+open scoped ComplexConjugate Real
+
+noncomputable section
+
+variable {T : ℝ} [Fact (0 < T)]
+
+/-- The Wiener-algebra predicate on the additive circle: a continuous
+complex-valued function whose Fourier coefficients are absolutely summable.
+For complex series, `Summable` is equivalent to absolute summability of the
+norms. -/
+def InWienerAlgebra (f : C(AddCircle T, ℂ)) : Prop :=
+  Summable (fourierCoeff f)
+
+/-- **Wiener–Lévy theorem.** If `φ` is complex-analytic on a neighbourhood of
+the range of a Wiener-algebra function `f`, then the composed function
+`φ ∘ f` is again in the Wiener algebra. -/
+@[eval_problem]
+theorem wiener_levy_analytic_calculus (f : C(AddCircle T, ℂ))
+    (φ : ℂ → ℂ) (U : Set ℂ) (hf : InWienerAlgebra f)
+    (hU : IsOpen U) (hrange : range f ⊆ U)
+    (hφ : AnalyticOnNhd ℂ φ U) :
+    ∃ g : C(AddCircle T, ℂ),
+      (∀ x, g x = φ (f x)) ∧ InWienerAlgebra g := by
+  sorry
+
+end
+
+end LeanEval.Analysis.WienerLevy

--- a/manifests/problems/wiener_levy_analytic_calculus.toml
+++ b/manifests/problems/wiener_levy_analytic_calculus.toml
@@ -1,0 +1,9 @@
+id = "wiener_levy_analytic_calculus"
+title = "Wiener–Lévy theorem"
+test = false
+module = "LeanEval.Analysis.WienerLevy"
+holes = ["wiener_levy_analytic_calculus"]
+submitter = "Kim Morrison"
+notes = "The Wiener–Lévy theorem, the analytic functional calculus for the Wiener algebra: if f lies in the Wiener algebra (`InWienerAlgebra f := Summable (fourierCoeff f)`) and φ is complex-analytic on an open neighbourhood U of the range of f, then the composition φ ∘ f again lies in the Wiener algebra. Generalizes Wiener's 1/f theorem (take φ(z) = 1/z). mathlib has the additive circle, `fourier`, `fourierCoeff`, and `hasSum_fourier_series_of_summable`, but not the Wiener algebra or its functional calculus."
+source = "P. Lévy, Sur la convergence absolue des séries de Fourier, Compositio Math. 1 (1935), 1-14; N. Wiener, Tauberian theorems, Ann. of Math. 33 (1932), 1-100. Listed as §226 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §226."
+informal_solution = "This is the holomorphic functional calculus in the commutative Banach algebra A(T). Since the Gelfand spectrum of A(T) is the circle (Wiener's lemma), the range of f as an algebra element equals its pointwise range, which lies in U. For φ analytic on U, define φ(f) by the Cauchy integral φ(f) = (1/2πi) ∮_Γ φ(z) (z - f)⁻¹ dz over a contour Γ in U enclosing the range of f; each resolvent (z - f)⁻¹ exists in A(T) by Wiener's lemma, the integral converges in the Banach algebra norm, and the result agrees pointwise with φ ∘ f, hence has summable Fourier coefficients."


### PR DESCRIPTION
Draft. Adds **Wiener–Lévy theorem** (Knill survey §226) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code