### PR TITLE
feat: add spectral theorem (normal matrices) eval problem

### DIFF
--- a/LeanEval/LinearAlgebra/NormalSpectralTheorem.lean
+++ b/LeanEval/LinearAlgebra/NormalSpectralTheorem.lean
@@ -1,0 +1,32 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.LinearAlgebra.NormalSpectralTheorem
+
+/-!
+# Normal spectral theorem
+
+`normal_spectral_theorem`: a complex matrix `A` is normal (`IsStarNormal A`,
+i.e. `Aᴴ A = A Aᴴ`) iff it is unitarily diagonalizable, `A = U (diagonal d) Uᴴ`
+with `U` unitary. Mathlib has the Hermitian special case
+(`Matrix.IsHermitian.spectral_theorem`) but not the normal generalization; the
+forward implication (a normal matrix has an orthonormal eigenbasis) is the
+substantive content. Category-(b) candidate from §14 of the Knill survey.
+-/
+
+open Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Spectral theorem** (§14). A complex matrix `A` is **normal**
+(`Aᴴ A = A Aᴴ`, i.e. `IsStarNormal A`) **iff** it is **unitarily
+diagonalizable**: there is a unitary `U` and a diagonal matrix `diagonal d`
+with `A = U (diagonal d) Uᴴ`. -/
+@[eval_problem]
+theorem normal_spectral_theorem (A : Matrix n n ℂ) :
+    IsStarNormal A ↔
+      ∃ U ∈ unitary (Matrix n n ℂ), ∃ d : n → ℂ,
+        A = U * diagonal d * star U := by
+  sorry
+
+end LeanEval.LinearAlgebra.NormalSpectralTheorem

--- a/manifests/problems/normal_spectral_theorem.toml
+++ b/manifests/problems/normal_spectral_theorem.toml
@@ -1,0 +1,9 @@
+id = "normal_spectral_theorem"
+title = "Normal spectral theorem"
+test = false
+module = "LeanEval.LinearAlgebra.NormalSpectralTheorem"
+holes = ["normal_spectral_theorem"]
+submitter = "Kim Morrison"
+notes = "A complex matrix A is normal (IsStarNormal A, i.e. Aᴴ A = A Aᴴ) iff it is unitarily diagonalizable, A = U (diagonal d) Uᴴ with U unitary. Mathlib has the Hermitian special case (Matrix.IsHermitian.spectral_theorem) and all conjugation/diagonal machinery, but not the normal generalization (no Matrix.IsStarNormal.spectral_theorem). The forward implication (a normal matrix admits an orthonormal eigenbasis) is the substantive content; the converse is a short computation. No new definitions beyond IsStarNormal, unitary, and Matrix.diagonal. Category-(b) candidate."
+source = "Knill, *Some fundamental theorems in mathematics*, §14."
+informal_solution = "Forward: a normal matrix commutes with its conjugate transpose, so by simultaneous unitary triangularization (Schur) the triangular factor is itself normal, hence diagonal; the columns of the Schur unitary form an orthonormal eigenbasis, giving A = U (diagonal d) Uᴴ. Reverse: if A = U (diagonal d) Uᴴ with U unitary, then Aᴴ = U (diagonal d̄) Uᴴ and the two diagonal matrices commute, so A and Aᴴ commute, i.e. A is normal."


### PR DESCRIPTION
Draft. Adds **spectral theorem (normal matrices)** (Knill survey §14) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code