### PR TITLE
feat: add trace Cayley–Hamilton / Newton identity eval problem

### DIFF
--- a/LeanEval/LinearAlgebra/TraceNewton.lean
+++ b/LeanEval/LinearAlgebra/TraceNewton.lean
@@ -1,0 +1,49 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.LinearAlgebra.TraceNewton
+
+/-!
+# Trace Cayley-Hamilton / Newton identity
+
+`trace_cayley_hamilton_newton`: the Newton trace recurrence for the
+coefficients of the characteristic polynomial,
+`k cₖ + ∑_{j=1}^k tr(Aʲ) c_{k-j} = 0`, where `χ_A(X) = Xᴺ + c₁ Xᴺ⁻¹ + ⋯ + c_N`.
+Trusted helper `charpolyDescendingCoeff` (non-hole). Category-(b) candidate from
+§220 of the Knill survey.
+-/
+
+open Matrix Polynomial
+open scoped BigOperators Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The coefficient `c_k` in the usual monic characteristic-polynomial
+expansion `χ_A(X) = X^N + c₁ X^(N-1) + ... + c_N`.
+
+Mathlib's `Matrix.charpoly` is the monic characteristic polynomial
+`det (X • 1 - A)`, so this is the coefficient of degree `N - k`.
+For `k > N`, the coefficient is `0`, which lets the trace recurrence be
+stated uniformly for all positive `k`. -/
+noncomputable def charpolyDescendingCoeff {R : Type*} [CommRing R]
+    (A : Matrix n n R) (k : ℕ) : R :=
+  if k ≤ Fintype.card n then
+    Polynomial.coeff A.charpoly (Fintype.card n - k)
+  else
+    0
+
+/-- The trace Cayley-Hamilton / Newton identity:
+`k c_k + ∑_{j=1}^k tr(A^j) c_{k-j} = 0`, where
+`χ_A(X) = X^N + c₁ X^(N-1) + ... + c_N`.
+
+For `k > N`, `c_k = 0`, and the remaining relation is the trace of
+Cayley-Hamilton multiplied by a power of `A`. -/
+@[eval_problem]
+theorem trace_cayley_hamilton_newton {R : Type*} [CommRing R]
+    (A : Matrix n n R) {k : ℕ} (hk : 1 ≤ k) :
+    (k : R) * charpolyDescendingCoeff A k +
+        ∑ j ∈ Finset.Icc 1 k,
+          trace (A ^ j) * charpolyDescendingCoeff A (k - j) = 0 := by
+  sorry
+
+end LeanEval.LinearAlgebra.TraceNewton

--- a/manifests/problems/trace_cayley_hamilton_newton.toml
+++ b/manifests/problems/trace_cayley_hamilton_newton.toml
@@ -1,0 +1,9 @@
+id = "trace_cayley_hamilton_newton"
+title = "Trace Cayley-Hamilton / Newton identity"
+test = false
+module = "LeanEval.LinearAlgebra.TraceNewton"
+holes = ["trace_cayley_hamilton_newton"]
+submitter = "Kim Morrison"
+notes = "The Newton trace recurrence for the coefficients of the characteristic polynomial: k cₖ + ∑_{j=1}^k tr(Aʲ) c_{k-j} = 0, where χ_A(X) = Xᴺ + c₁ Xᴺ⁻¹ + ⋯ + c_N. The helper charpolyDescendingCoeff packages cₖ as the degree N−k coefficient of Matrix.charpoly (zero for k > N), so the recurrence holds uniformly for all positive k. Mathlib has Cayley-Hamilton (Matrix.aeval_self_charpoly) but not the Newton trace identity relating power sums tr(Aʲ) to the elementary-symmetric charpoly coefficients. Category-(b) candidate."
+source = "Knill, *Some fundamental theorems in mathematics*, §220."
+informal_solution = "These are Newton's identities relating the power sums pⱼ = tr(Aʲ) (sums of j-th powers of eigenvalues) to the elementary symmetric functions eₖ that appear, up to sign, as the charpoly coefficients cₖ = (−1)ᵏ eₖ. Prove by the standard generating-function / logarithmic-derivative argument: differentiate log det(X·1 − A) = ∑ log(X − λᵢ), expand 1/(X − λᵢ) as a power series in 1/X to get ∑ⱼ pⱼ X^{−j}, and match coefficients against the derivative of the charpoly to obtain k cₖ + ∑_{j=1}^k pⱼ c_{k−j} = 0. For k > N the relation is the trace of A^{k−N} times Cayley-Hamilton."


### PR DESCRIPTION
Draft. Adds **trace Cayley–Hamilton / Newton identity** (Knill survey §220) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code