### PR TITLE
feat: add Frobenius group-determinant theorem eval problem

### DIFF
--- a/LeanEval/RepresentationTheory/FrobeniusDeterminant.lean
+++ b/LeanEval/RepresentationTheory/FrobeniusDeterminant.lean
@@ -16,17 +16,18 @@ of the Knill survey.
 
 open MvPolynomial Matrix
 
-variable (G : Type*) [Group G] [Fintype G] [DecidableEq G]
 
 /-- The **group matrix** of Dedekind/Frobenius: a `G × G` matrix over the
 polynomial ring `ℂ[x_g : g ∈ G]`, with entry `(g, h)` the variable indexed by
 the product `g * h`. -/
-noncomputable def groupMatrix : Matrix G G (MvPolynomial G ℂ) :=
+noncomputable def groupMatrix (G : Type*) [Group G] [Fintype G] [DecidableEq G] :
+    Matrix G G (MvPolynomial G ℂ) :=
   fun g h => MvPolynomial.X (g * h)
 
 /-- The **group determinant** `Θ(G) = det(A)`, a polynomial in the variables
 `x_g`. -/
-noncomputable def groupDeterminant : MvPolynomial G ℂ :=
+noncomputable def groupDeterminant (G : Type*) [Group G] [Fintype G] [DecidableEq G] :
+    MvPolynomial G ℂ :=
   (groupMatrix G).det
 
 /-- **Frobenius determinant theorem** (§171). The group determinant factors as
@@ -35,7 +36,8 @@ a product of irreducible polynomials, each appearing to the power of its own
 (*distinct*) and their number equal to the number of conjugacy classes of `G`.
 -/
 @[eval_problem]
-theorem frobenius_group_determinant :
+theorem frobenius_group_determinant
+    (G : Type*) [Group G] [Fintype G] [DecidableEq G] :
     ∃ (r : ℕ) (p : Fin r → MvPolynomial G ℂ),
       r = Nat.card (ConjClasses G) ∧
       (∀ j, Irreducible (p j)) ∧

--- a/LeanEval/RepresentationTheory/FrobeniusDeterminant.lean
+++ b/LeanEval/RepresentationTheory/FrobeniusDeterminant.lean
@@ -1,0 +1,46 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.RepresentationTheory.FrobeniusDeterminant
+
+/-!
+# Frobenius determinant theorem (Dedekind's group determinant)
+
+`frobenius_group_determinant`: the group determinant `Θ(G) = det(A)` of the
+group matrix `A_{gh} = x_{gh}` factors into irreducible polynomials, each to the
+power of its own total degree, with the factors pairwise non-associated and
+their number equal to the number of conjugacy classes of `G`. Trusted helpers
+`groupMatrix`, `groupDeterminant` (non-holes). Category-(b) candidate from §171
+of the Knill survey.
+-/
+
+open MvPolynomial Matrix
+
+variable (G : Type*) [Group G] [Fintype G] [DecidableEq G]
+
+/-- The **group matrix** of Dedekind/Frobenius: a `G × G` matrix over the
+polynomial ring `ℂ[x_g : g ∈ G]`, with entry `(g, h)` the variable indexed by
+the product `g * h`. -/
+noncomputable def groupMatrix : Matrix G G (MvPolynomial G ℂ) :=
+  fun g h => MvPolynomial.X (g * h)
+
+/-- The **group determinant** `Θ(G) = det(A)`, a polynomial in the variables
+`x_g`. -/
+noncomputable def groupDeterminant : MvPolynomial G ℂ :=
+  (groupMatrix G).det
+
+/-- **Frobenius determinant theorem** (§171). The group determinant factors as
+a product of irreducible polynomials, each appearing to the power of its own
+(total) degree `d_j = deg p_j`, with the factors pairwise non-associated
+(*distinct*) and their number equal to the number of conjugacy classes of `G`.
+-/
+@[eval_problem]
+theorem frobenius_group_determinant :
+    ∃ (r : ℕ) (p : Fin r → MvPolynomial G ℂ),
+      r = Nat.card (ConjClasses G) ∧
+      (∀ j, Irreducible (p j)) ∧
+      (∀ i j, i ≠ j → ¬ Associated (p i) (p j)) ∧
+      groupDeterminant G = ∏ j, (p j) ^ (p j).totalDegree := by
+  sorry
+
+end LeanEval.RepresentationTheory.FrobeniusDeterminant

--- a/manifests/problems/frobenius_group_determinant.toml
+++ b/manifests/problems/frobenius_group_determinant.toml
@@ -1,0 +1,9 @@
+id = "frobenius_group_determinant"
+title = "Frobenius determinant theorem"
+test = false
+module = "LeanEval.RepresentationTheory.FrobeniusDeterminant"
+holes = ["frobenius_group_determinant"]
+submitter = "Kim Morrison"
+notes = "Dedekind's group determinant: the determinant of the group matrix A_{gh} = x_{gh} (over ℂ[x_g : g ∈ G]) factors into irreducible polynomials, each to the power of its own total degree, with factors pairwise non-associated and their number equal to the number of conjugacy classes of G. The helpers groupMatrix and groupDeterminant encode the statement; over ℂ this is the algebraically-closed characteristic-zero form where Frobenius's theorem and the character correspondence d_j = deg p_j live. Mathlib has MvPolynomial, Matrix.det, unique factorization, character theory, and ConjClasses, but not the group determinant or its factorization. Category-(b) candidate."
+source = "Knill, *Some fundamental theorems in mathematics*, §171."
+informal_solution = "This is the genesis of representation theory. By Maschke and Wedderburn the group algebra ℂ[G] decomposes as a product of matrix algebras ⨁ⱼ M_{dⱼ}(ℂ), one per irreducible representation ρⱼ of dimension dⱼ. The group matrix is the matrix of left regular multiplication by the generic element ∑_g x_g g, so its determinant is the product over the regular-representation blocks, det = ∏ⱼ det(ρⱼ(∑_g x_g g))^{dⱼ}. Each factor pⱼ = det(ρⱼ(∑_g x_g g)) is an irreducible polynomial of total degree dⱼ, the factors are pairwise non-associated, and the number of irreducibles equals the number of conjugacy classes of G."


### PR DESCRIPTION
Draft. Adds **Frobenius group-determinant theorem** (Knill survey §171) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code