### PR TITLE
feat: add Artin–Mazur zeta (Bowen–Lanford) eval problem

### DIFF
--- a/LeanEval/Dynamics/ArtinMazurZeta.lean
+++ b/LeanEval/Dynamics/ArtinMazurZeta.lean
@@ -1,0 +1,35 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Dynamics.ArtinMazurZeta
+
+/-!
+# Artin–Mazur / Bowen–Lanford zeta identity
+
+`artin_mazur_zeta`: for a complex `k × k` matrix `A`, the Artin–Mazur zeta
+series `ζ(t) = exp(∑_{n ≥ 1} tr(Aⁿ) tⁿ / n)` equals `1 / det(1 − tA)` as a
+formal power series, where `det(1 − tA)` is the reversed characteristic
+polynomial `A.charpolyRev`. Trusted helper `traceSeries` (non-hole). This is the
+companion identity to the Parry–Sullivan invariant; category-(b) candidate from
+§263 of the Knill survey.
+-/
+
+open Matrix PowerSeries
+
+/-- The exponent of the Artin–Mazur zeta series: the power series
+`∑_{n ≥ 1} tr(Aⁿ) tⁿ / n`. The `n = 0` coefficient is `tr(A⁰)/0 = 0` (division
+by zero is zero in a field), so the sum effectively starts at `n = 1`. -/
+noncomputable def traceSeries {k : ℕ} (A : Matrix (Fin k) (Fin k) ℂ) : PowerSeries ℂ :=
+  PowerSeries.mk fun n => Matrix.trace (A ^ n) / (n : ℂ)
+
+/-- **Artin–Mazur / Bowen–Lanford identity** (§263).
+For a complex `k × k` matrix `A`, the Artin–Mazur zeta series
+`ζ(t) = exp(∑_{n ≥ 1} tr(Aⁿ) tⁿ / n)` equals `1 / det(1 − tA)` as a formal
+power series, where `det(1 − tA)` is the reversed characteristic polynomial
+`A.charpolyRev`. -/
+@[eval_problem]
+theorem artin_mazur_zeta {k : ℕ} (A : Matrix (Fin k) (Fin k) ℂ) :
+    (PowerSeries.exp ℂ).subst (traceSeries A) = ((A.charpolyRev : PowerSeries ℂ))⁻¹ := by
+  sorry
+
+end LeanEval.Dynamics.ArtinMazurZeta

--- a/manifests/problems/artin_mazur_zeta.toml
+++ b/manifests/problems/artin_mazur_zeta.toml
@@ -1,0 +1,9 @@
+id = "artin_mazur_zeta"
+title = "Artin–Mazur / Bowen–Lanford zeta identity"
+test = false
+module = "LeanEval.Dynamics.ArtinMazurZeta"
+holes = ["artin_mazur_zeta"]
+submitter = "Kim Morrison"
+notes = "For a complex k × k matrix A, the Artin–Mazur zeta series ζ(t) = exp(∑_{n ≥ 1} tr(Aⁿ) tⁿ / n) equals 1 / det(1 − tA) as a formal power series, where det(1 − tA) is the reversed characteristic polynomial A.charpolyRev. The helper traceSeries packages the exponent. This is the companion (b) statement of the §263 Parry–Sullivan section (the main flow-equivalence theorem is category (c), not stateable within budget). Mathlib has Matrix.charpolyRev, PowerSeries.exp/log/subst, and the field power-series inverse, but not the Bowen–Lanford identity. Category-(b) candidate."
+source = "Knill, *Some fundamental theorems in mathematics*, §263."
+informal_solution = "A purely algebraic identity of formal power series. Take logs: it suffices to show log(1/det(1 − tA)) = ∑_{n ≥ 1} tr(Aⁿ) tⁿ / n, i.e. −log det(1 − tA) = ∑ₙ tr(Aⁿ)tⁿ/n. Using det = exp tr log (or, eigenvalue-wise, det(1 − tA) = ∏ᵢ(1 − λᵢ t)), −log det(1 − tA) = −∑ᵢ log(1 − λᵢ t) = ∑ᵢ ∑_{n≥1} (λᵢ t)ⁿ/n = ∑_{n≥1} (∑ᵢ λᵢⁿ) tⁿ/n = ∑_{n≥1} tr(Aⁿ) tⁿ/n, since tr(Aⁿ) = ∑ᵢ λᵢⁿ. Exponentiating gives the claimed identity."


### PR DESCRIPTION
Draft. Adds **Artin–Mazur zeta (Bowen–Lanford)** (Knill survey §263) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code