### PR TITLE
feat: add Shannon capacity of the pentagon eval problem

### DIFF
--- a/LeanEval/Combinatorics/ShannonCapacityPentagon.lean
+++ b/LeanEval/Combinatorics/ShannonCapacityPentagon.lean
@@ -1,0 +1,55 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Combinatorics.ShannonCapacityPentagon
+
+/-!
+# Shannon capacity of the pentagon (Lovász)
+
+`shannon_capacity_pentagon`: the Shannon capacity of the five-cycle `C₅` is
+`√5`. Trusted helpers `IsIndependent`, `independenceNumber`, `strongPower`,
+`HasShannonCapacity` (non-holes). Mathlib has simple graphs and cycle graphs but
+no Shannon capacity, strong graph powers, or Lovász number. Category-(b)
+candidate from §238 of the Knill survey.
+-/
+
+open Filter
+open scoped Topology
+
+/-- A finite set of vertices is independent if no two distinct members are adjacent. -/
+def IsIndependent {V : Type*} (G : SimpleGraph V) (s : Finset V) : Prop :=
+  ∀ ⦃v⦄, v ∈ s → ∀ ⦃w⦄, w ∈ s → v ≠ w → ¬ G.Adj v w
+
+/-- The independence number of a finite simple graph. -/
+noncomputable def independenceNumber (V : Type*) [Fintype V] (G : SimpleGraph V) : ℕ :=
+  sSup {m : ℕ | ∃ s : Finset V, IsIndependent G s ∧ s.card = m}
+
+/-- The strong graph power on length-`k` words.  Two words are confusable
+when they are distinct and every coordinate is either equal or confusable in
+the base graph. -/
+def strongPower {V : Type*} (G : SimpleGraph V) (k : ℕ) : SimpleGraph (Fin k → V) where
+  Adj x y := x ≠ y ∧ ∀ i, x i = y i ∨ G.Adj (x i) (y i)
+  symm x y := by
+    rintro ⟨hxy, hcoord⟩
+    exact ⟨hxy.symm, fun i => (hcoord i).imp Eq.symm SimpleGraph.Adj.symm⟩
+  loopless := ⟨fun x h => h.1 rfl⟩
+
+/-- The Shannon capacity of `G` is `θ` if the normalized independence
+numbers of the strong powers tend to `θ`. -/
+noncomputable def HasShannonCapacity {V : Type*} [Fintype V] (G : SimpleGraph V) (θ : ℝ) :
+    Prop :=
+  Tendsto
+    (fun k : ℕ =>
+      Real.rpow
+        (independenceNumber (Fin (k + 1) → V) (strongPower G (k + 1)) : ℝ)
+        ((k + 1 : ℝ)⁻¹))
+    atTop (𝓝 θ)
+
+/-- **Lovász's theorem on Shannon capacity of the pentagon** (§238).
+The Shannon capacity of the five-cycle is `√5`. -/
+@[eval_problem]
+theorem shannon_capacity_pentagon :
+    HasShannonCapacity (SimpleGraph.cycleGraph 5) (Real.sqrt 5) := by
+  sorry
+
+end LeanEval.Combinatorics.ShannonCapacityPentagon

--- a/manifests/problems/shannon_capacity_pentagon.toml
+++ b/manifests/problems/shannon_capacity_pentagon.toml
@@ -1,0 +1,9 @@
+id = "shannon_capacity_pentagon"
+title = "Shannon capacity of the pentagon"
+test = false
+module = "LeanEval.Combinatorics.ShannonCapacityPentagon"
+holes = ["shannon_capacity_pentagon"]
+submitter = "Kim Morrison"
+notes = "Lovász's computation: the Shannon capacity of the five-cycle C₅ is √5. The helpers IsIndependent, independenceNumber, strongPower, and HasShannonCapacity encode the capacity as the limit of (α(Gᵏ))^{1/k}, modelling length-k words as Fin k → V. Mathlib has finite simple graphs and cycle graphs but no Shannon capacity, strong graph powers, Lovász theta number, or the semidefinite-programming bound. Category-(b) candidate."
+source = "Knill, *Some fundamental theorems in mathematics*, §238."
+informal_solution = "Lovász's theta-function argument. Lower bound: the strong square C₅⊠C₅ has an independent set of size 5 (e.g. {(0,0),(1,2),(2,4),(3,1),(4,3)}), so α(C₅⊠C₅) ≥ 5, giving capacity ≥ √5. Upper bound: the Lovász number ϑ is multiplicative under the strong product and satisfies α(G) ≤ ϑ(G), so the capacity Θ(G) = lim (α(Gᵏ))^{1/k} ≤ ϑ(G); computing ϑ(C₅) = √5 (via the umbrella/orthonormal-representation construction, or the eigenvalue bound for vertex-transitive graphs) gives capacity ≤ √5. The two bounds coincide at √5."


### PR DESCRIPTION
Draft. Adds **Shannon capacity of the pentagon** (Knill survey §238) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code