### PR TITLE
feat: add Peano existence theorem eval problem

### DIFF
--- a/LeanEval/Analysis/PeanoExistence.lean
+++ b/LeanEval/Analysis/PeanoExistence.lean
@@ -1,0 +1,33 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.PeanoExistence
+
+/-!
+# Peano existence theorem
+
+`peano_existence`: replacing the Lipschitz hypothesis of Picard–Lindelöf with
+mere continuity still yields a local solution of `x' = f(x)`, `x(0) = x₀` (though
+uniqueness may fail). Stated for a finite-dimensional space, since Peano's
+theorem requires local compactness and fails in general Banach spaces. Mathlib
+has Arzelà–Ascoli but not Peano's theorem itself. Category-(b) candidate from
+§19 of the Knill survey.
+-/
+
+open Set
+open scoped NNReal
+
+/-- **Peano existence theorem.** Replacing the Lipschitz condition with mere
+continuity still yields a local solution of `x' = f(x)`, `x(0) = x₀` — but
+uniqueness may fail (e.g. `x' = √x`, `x(0) = 0`). Stated for a
+finite-dimensional space: Peano's theorem requires local compactness and is
+false in general (infinite-dimensional) Banach spaces. -/
+@[eval_problem]
+theorem peano_existence
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {f : E → E} (hf : Continuous f) (x₀ : E) :
+    ∃ a : ℝ, 0 < a ∧ ∃ α : ℝ → E, α 0 = x₀ ∧
+      ∀ t ∈ Ioo (-a) a, HasDerivAt α (f (α t)) t := by
+  sorry
+
+end LeanEval.Analysis.PeanoExistence

--- a/manifests/problems/peano_existence.toml
+++ b/manifests/problems/peano_existence.toml
@@ -1,0 +1,9 @@
+id = "peano_existence"
+title = "Peano existence theorem for ODEs"
+test = false
+module = "LeanEval.Analysis.PeanoExistence"
+holes = ["peano_existence"]
+submitter = "Kim Morrison"
+notes = "If f is continuous, the autonomous initial value problem x'(t) = f(x(t)), x(0) = x₀ admits a local solution on some interval (-a, a); uniqueness may fail (e.g. x' = √x, x(0) = 0). Stated for a finite-dimensional space, since Peano's theorem requires local compactness and is false in general (infinite-dimensional) Banach spaces (Dieudonné). Mathlib has Arzelà–Ascoli (the key ingredient) but not Peano's theorem itself. Candidate from §19 of the Knill survey."
+source = "G. Peano, *Démonstration de l'intégrabilité des équations différentielles ordinaires*, Math. Ann. 37 (1890). Knill, *Some fundamental theorems in mathematics*, §19."
+informal_solution = "Construct approximate solutions via Euler polygons (or Tonelli/Picard approximations) with mesh tending to zero. The continuity of f and finite dimensionality give a uniform bound on the family near x₀, so the approximants are uniformly bounded and equicontinuous on a small interval (-a, a). By the Arzelà–Ascoli theorem a subsequence converges uniformly to a limit α; passing to the limit in the integral equation α(t) = x₀ + ∫₀ᵗ f(α(s)) ds shows α solves the ODE with α(0) = x₀, giving HasDerivAt α (f (α t)) t. Local compactness is essential and fails in infinite dimensions."


### PR DESCRIPTION
Draft. Adds **Peano existence theorem** (Knill survey §19) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code