### PR TITLE
feat: add semisimple compact-group reps eval problem

### DIFF
--- a/LeanEval/RepresentationTheory/CompactGroupSemisimple.lean
+++ b/LeanEval/RepresentationTheory/CompactGroupSemisimple.lean
@@ -1,0 +1,35 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.RepresentationTheory.CompactGroupSemisimple
+
+/-!
+# Complete reducibility for compact groups
+
+`compact_group_semisimple`: a continuous representation of a compact topological
+group on a finite-dimensional real vector space is semisimple (every
+subrepresentation has a `G`-invariant complement). This is the unitarian trick:
+averaging an inner product over Haar measure produces a `G`-invariant inner
+product. Mathlib has `IsSemisimpleRepresentation` and Maschke's theorem (finite
+groups) but no compact-group / Peter–Weyl result. Category-(b) candidate from
+§21 of the Knill survey.
+-/
+
+open Representation
+
+/-- **Representations of compact groups are semisimple** (complete
+reducibility / the unitarian trick). A continuous representation of a compact
+topological group on a finite-dimensional real vector space is semisimple:
+every subrepresentation has a `G`-invariant complement, so the representation
+decomposes as a direct sum of irreducible finite-dimensional
+subrepresentations. -/
+@[eval_problem]
+theorem compact_group_semisimple
+    {G V : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+    [NormedAddCommGroup V] [NormedSpace ℝ V] [FiniteDimensional ℝ V]
+    (ρ : Representation ℝ G V)
+    (hρ : Continuous fun p : G × V => ρ p.1 p.2) :
+    ρ.IsSemisimpleRepresentation := by
+  sorry
+
+end LeanEval.RepresentationTheory.CompactGroupSemisimple

--- a/manifests/problems/compact_group_semisimple.toml
+++ b/manifests/problems/compact_group_semisimple.toml
@@ -1,0 +1,9 @@
+id = "compact_group_semisimple"
+title = "Complete reducibility for compact groups"
+test = false
+module = "LeanEval.RepresentationTheory.CompactGroupSemisimple"
+holes = ["compact_group_semisimple"]
+submitter = "Kim Morrison"
+notes = "A continuous representation of a compact topological group on a finite-dimensional real vector space is semisimple: every subrepresentation has a G-invariant complement (Representation.IsSemisimpleRepresentation). Mathlib has the semisimplicity predicate and Maschke's theorem for finite groups but no compact-group / Peter–Weyl / unitarian-trick result. Continuity of the action G × V → V and finite dimensionality are essential hypotheses. Candidate from §21 of the Knill survey."
+source = "H. Weyl, *Theorie der Darstellung kontinuierlicher halb-einfacher Gruppen durch lineare Transformationen* (1925–26); Peter–Weyl (1927). Knill, *Some fundamental theorems in mathematics*, §21."
+informal_solution = "Apply the unitarian trick. Start from any inner product ⟨·,·⟩₀ on V and average it over the group using normalized Haar measure: ⟨u,v⟩ = ∫_G ⟨ρ(g) u, ρ(g) v⟩₀ dg. Compactness gives a finite total Haar measure and joint continuity makes the integrand continuous, so the integral exists; the result is a positive-definite G-invariant inner product, i.e. ρ acts by isometries. For any subrepresentation W, its orthogonal complement W^⊥ with respect to this invariant inner product is again G-invariant and is a complement of W. Hence every subrepresentation is complemented, which is exactly IsSemisimpleRepresentation."


### PR DESCRIPTION
Draft. Adds **semisimple compact-group reps** (Knill survey §21) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code