### PR TITLE
feat: add general recursive = Turing computable eval problem

### DIFF
--- a/LeanEval/ModelTheory/TuringRecursive.lean
+++ b/LeanEval/ModelTheory/TuringRecursive.lean
@@ -1,0 +1,30 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.ModelTheory.TuringRecursive
+
+/-!
+# General recursive = Turing computable
+
+`turing_recursive_equiv`: a total function `f : ℕ → ℕ` is recursive
+(`Computable`) iff it is computed by some Turing machine (mathlib's `FinTM2`
+model) under the standard binary encoding of `ℕ`. This is the Turing–Kleene
+equivalence. Mathlib has both predicates and the forward direction via
+`tr_eval`, but no theorem linking them; the converse (TM-computable ⇒ recursive)
+is absent. Category-(b) candidate from §23 of the Knill survey.
+-/
+
+open Computability Turing
+
+/-- **General recursive = Turing computable** (total form). A total function
+`f : ℕ → ℕ` is recursive (`Computable`, i.e. partial recursive as a partial
+function) **iff** it is computed by some Turing machine (mathlib's `FinTM2`
+model) under the standard binary encoding of `ℕ`. This is Knill's class
+equality; the backward direction (TM-computable ⇒ recursive) is absent from
+mathlib. -/
+@[eval_problem]
+theorem turing_recursive_equiv (f : ℕ → ℕ) :
+    Computable f ↔ Nonempty (TM2Computable encodeNat encodeNat f) := by
+  sorry
+
+end LeanEval.ModelTheory.TuringRecursive

--- a/manifests/problems/turing_recursive_equiv.toml
+++ b/manifests/problems/turing_recursive_equiv.toml
@@ -1,0 +1,9 @@
+id = "turing_recursive_equiv"
+title = "General recursive equals Turing computable"
+test = false
+module = "LeanEval.ModelTheory.TuringRecursive"
+holes = ["turing_recursive_equiv"]
+submitter = "Kim Morrison"
+notes = "The Turing–Kleene equivalence (total form): a total function f : ℕ → ℕ is recursive (Computable) iff it is computed by some Turing machine (mathlib's FinTM2 model, TM2Computable) under the standard binary encoding encodeNat. Both sides are mathlib predicates but no theorem links them; the forward direction is essentially tr_eval plus plumbing, while the backward direction (TM-computable ⇒ recursive) is absent from mathlib. The total reading is used since general recursive is classically the total recursive functions and TM2Computable is total-only. Candidate from §23 of the Knill survey."
+source = "A. M. Turing, *On Computable Numbers* (1936); S. C. Kleene, *General recursive functions of natural numbers* (1936). Knill, *Some fundamental theorems in mathematics*, §23."
+informal_solution = "Two inclusions. Recursive ⇒ TM-computable: by Nat.Partrec.Code.exists_code every Computable f is the evaluation of a partial recursive code; mathlib's Turing.PartrecToTM2.tr_eval constructively builds a TM2 machine evaluating any ToPartrec.Code, so composing the translations and verifying the encodeNat input/output encoding yields a TM2Computable witness. TM-computable ⇒ recursive: given a FinTM2 machine, its step relation is primitive recursive in the (finite) state and tape data, so the computation history and its halting time are recursive; running the machine until it halts and decoding the output exhibits f as obtained by composition and unbounded minimization over a primitive recursive predicate, hence Computable. This converse is the half missing from mathlib."


### PR DESCRIPTION
Draft. Adds **general recursive = Turing computable** (Knill survey §23) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code