### PR TITLE
feat: add Bourgain polynomial ergodic theorem eval problem

### DIFF
--- a/LeanEval/Dynamics/BourgainErgodic.lean
+++ b/LeanEval/Dynamics/BourgainErgodic.lean
@@ -1,0 +1,49 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Dynamics.BourgainErgodic
+
+/-!
+# Bourgain's polynomial ergodic theorem
+
+`bourgain_polynomial_ergodic`: for every integer-polynomial iterate sequence and
+every `L^p` (`p > 1`) function, the polynomial ergodic averages
+`(1/n) ∑_{k<n} f(T^[a k] x)` converge pointwise almost everywhere. Trusted
+helpers (`IsIntegerPolynomialSequence`, `polynomialErgodicAverage`) are
+non-holes. Mathlib has Birkhoff's ergodic theorem but not Bourgain's polynomial
+extension. Category-(b) candidate from §173 of the Knill survey.
+-/
+
+open Filter Finset Function MeasureTheory
+open scoped BigOperators ENNReal Topology
+
+variable {X : Type*} [MeasurableSpace X] {μ : Measure X}
+
+/-- A sequence of natural iterate exponents coming from an integer polynomial
+which is nonnegative on `ℕ`.  This avoids baking a particular coefficient
+representation into the ergodic theorem statements. -/
+def IsIntegerPolynomialSequence (a : ℕ → ℕ) : Prop :=
+  ∃ P : Polynomial ℤ,
+    ∀ n : ℕ, 0 ≤ P.eval (n : ℤ) ∧ a n = Int.toNat (P.eval (n : ℤ))
+
+/-- Bourgain's polynomial ergodic averages
+`(1 / n) * ∑_{k < n} f (T^[a k] x)`. -/
+noncomputable def polynomialErgodicAverage (a : ℕ → ℕ) (T : X → X) (f : X → ℝ)
+    (n : ℕ) (x : X) : ℝ :=
+  (n : ℝ)⁻¹ * ∑ k ∈ range n, f (T^[a k] x)
+
+/-- Bourgain's polynomial ergodic theorem: for every integer-polynomial
+iterate sequence and every `L^p`, `p > 1`, function, the polynomial ergodic
+averages converge pointwise almost everywhere. -/
+@[eval_problem]
+theorem bourgain_polynomial_ergodic
+    [IsProbabilityMeasure μ] {p : ℝ≥0∞} (hp : 1 < p) (hp_ne_top : p ≠ ∞)
+    {T : X → X} (hT : MeasurePreserving T μ μ)
+    {a : ℕ → ℕ} (ha : IsIntegerPolynomialSequence a)
+    {f : X → ℝ} (hf : MemLp f p μ) :
+    ∃ F : X → ℝ,
+      ∀ᵐ x ∂μ,
+        Tendsto (fun n : ℕ => polynomialErgodicAverage a T f (n + 1) x) atTop (𝓝 (F x)) := by
+  sorry
+
+end LeanEval.Dynamics.BourgainErgodic

--- a/manifests/problems/bourgain_polynomial_ergodic.toml
+++ b/manifests/problems/bourgain_polynomial_ergodic.toml
@@ -1,0 +1,9 @@
+id = "bourgain_polynomial_ergodic"
+title = "Bourgain's polynomial ergodic theorem"
+test = false
+module = "LeanEval.Dynamics.BourgainErgodic"
+holes = ["bourgain_polynomial_ergodic"]
+submitter = "Kim Morrison"
+notes = "For a measure-preserving system on a probability space, every integer-polynomial iterate sequence a, and every f ∈ L^p with p > 1, the polynomial ergodic averages (1/n) ∑_{k<n} f(T^[a k] x) converge pointwise almost everywhere. Trusted helpers (IsIntegerPolynomialSequence, polynomialErgodicAverage) are non-holes. Mathlib has Birkhoff's pointwise ergodic theorem but not Bourgain's polynomial extension. Candidate from §173 of the Knill survey."
+source = "J. Bourgain, *Pointwise ergodic theorems for arithmetic sets*, Publ. Math. IHÉS 69 (1989). Knill, *Some fundamental theorems in mathematics*, §173."
+informal_solution = "Reduce, via a transfer/Calderón principle, to a maximal inequality for the discrete polynomial averaging operators on ℤ. Bourgain's proof establishes the L^p (p > 1) bound for the associated maximal function using circle-method / Hardy–Littlewood estimates: split the Fourier multiplier into major arcs (where it is approximated by a continuous averaging multiplier controlled by the Dunford–Schwartz/Wiener maximal theorem) and minor arcs (controlled by Weyl-type exponential sum bounds and a variational/oscillation argument). The maximal inequality, together with pointwise convergence on a dense subclass (e.g. eigenfunctions / bounded functions), yields a.e. convergence of the averages for all f ∈ L^p by the Banach principle. The limit F is the pointwise limit. Requires harmonic-analysis machinery absent from Mathlib."


### PR DESCRIPTION
Draft. Adds **Bourgain polynomial ergodic theorem** (Knill survey §173) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code