### PR TITLE
feat: add Nyquist–Shannon sampling theorem eval problem

### DIFF
--- a/LeanEval/Analysis/NyquistShannon.lean
+++ b/LeanEval/Analysis/NyquistShannon.lean
@@ -1,0 +1,48 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.NyquistShannon
+
+/-!
+# Nyquist–Shannon sampling theorem
+
+`nyquist_shannon_sampling`: a Schwartz function whose Fourier transform is
+supported in the Nyquist band `[-1/2, 1/2]` (mathlib's `e^{-2π i x ξ}`
+convention) is reconstructed from its integer samples by the Whittaker–Shannon
+cardinal series `f(t) = ∑_{n : ℤ} f(n) * sinc(π(n - t))`. Trusted helpers
+(`sinc`, `FourierSupportedInNyquist`) are non-holes. Mathlib has Schwartz space,
+the Fourier transform, inversion, Plancherel and Poisson summation, but not the
+sampling theorem. Category-(b) candidate from §179 of the Knill survey.
+-/
+
+open scoped FourierTransform SchwartzMap
+open Set
+
+/-- The unnormalised cardinal sine, with the removable singularity filled by
+the standard value `1`.  Knill writes `sinc x = sin x / x`; the reconstruction
+formula evaluates this at `0` when `t` is an integer, so the total version is
+the faithful formal spelling. -/
+noncomputable def sinc (x : ℝ) : ℂ :=
+  if x = 0 then 1 else ((Real.sin x / x : ℝ) : ℂ)
+
+/-- The Fourier transform of `f` is supported in the Nyquist band for
+mathlib's `e^{-2π i x ξ}` Fourier convention, namely `[-1/2, 1/2]`. -/
+def FourierSupportedInNyquist (f : 𝓢(ℝ, ℂ)) : Prop :=
+  ∀ ξ : ℝ, ξ ∉ Icc (-(1 / 2 : ℝ)) (1 / 2 : ℝ) → 𝓕 f ξ = 0
+
+/-- **Nyquist--Shannon sampling theorem / Whittaker--Shannon interpolation
+formula** for Schwartz functions with Fourier support in the mathlib-convention
+Nyquist band `[-1/2, 1/2]`.
+
+The explicit `Summable` conjunct records the convergence content of the
+cardinal series, rather than relying only on Lean's total `tsum`.
+-/
+@[eval_problem]
+theorem nyquist_shannon_sampling (f : 𝓢(ℝ, ℂ)) (hf : FourierSupportedInNyquist f) :
+    ∀ t : ℝ,
+      Summable (fun n : ℤ ↦ f (n : ℝ) * sinc (Real.pi * ((n : ℝ) - t))) ∧
+        f t =
+          ∑' n : ℤ, f (n : ℝ) * sinc (Real.pi * ((n : ℝ) - t)) := by
+  sorry
+
+end LeanEval.Analysis.NyquistShannon

--- a/manifests/problems/nyquist_shannon_sampling.toml
+++ b/manifests/problems/nyquist_shannon_sampling.toml
@@ -1,0 +1,9 @@
+id = "nyquist_shannon_sampling"
+title = "Nyquist–Shannon sampling theorem"
+test = false
+module = "LeanEval.Analysis.NyquistShannon"
+holes = ["nyquist_shannon_sampling"]
+submitter = "Kim Morrison"
+notes = "Whittaker–Shannon interpolation: a Schwartz function f whose Fourier transform is supported in the Nyquist band [-1/2, 1/2] (mathlib's e^{-2π i x ξ} convention) is reconstructed from its integer samples by the cardinal series f(t) = ∑_{n : ℤ} f(n) · sinc(π(n - t)), with the series summable. Trusted helpers (sinc, FourierSupportedInNyquist) are non-holes; the Summable conjunct records convergence rather than relying on Lean's total tsum. Mathlib has Schwartz space, the Fourier transform, inversion, Plancherel and Poisson summation, but not the sampling theorem. Candidate from §179 of the Knill survey."
+source = "C. E. Shannon, *Communication in the presence of noise*, Proc. IRE 37 (1949); H. Nyquist (1928); E. T. Whittaker (1915). Knill, *Some fundamental theorems in mathematics*, §179."
+informal_solution = "Let g = 𝓕 f, supported in [-1/2, 1/2]. Extend g periodically with period 1 and expand it in a Fourier series on [-1/2, 1/2]; the Fourier coefficients are exactly the samples f(n) (up to sign), by Fourier inversion ∫ g(ξ) e^{2π i n ξ} dξ = f(n) since g is band-limited. Substituting this Fourier series for g into the inversion formula f(t) = ∫ g(ξ) e^{2π i t ξ} dξ and integrating term by term (justified by Schwartz decay, giving the Summable claim) produces f(t) = ∑_{n} f(n) ∫_{[-1/2,1/2]} e^{2π i (t - n) ξ} dξ = ∑_{n} f(n) · sinc(π(n - t)), since the band-limited indicator integrates to a cardinal sine. Equivalently this is Poisson summation applied to the band-limited f. Not in Mathlib."


### PR DESCRIPTION
Draft. Adds **Nyquist–Shannon sampling theorem** (Knill survey §179) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code