### PR TITLE
feat: add equichordal point theorem eval problem

### DIFF
--- a/LeanEval/Geometry/Equichordal.lean
+++ b/LeanEval/Geometry/Equichordal.lean
@@ -1,0 +1,47 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Geometry.Equichordal
+
+/-!
+# Equichordal point theorem
+
+`equichordal_point_unique`: a smooth convex plane curve, packaged as the
+frontier of a compact convex planar domain `K` with nonempty interior, cannot
+have two distinct equichordal points. The helper `IsEquichordalPoint` records
+that the sum of the two opposite radial chord distances through an interior
+point is a direction-independent constant. Mathlib has no equichordal-point
+result. Category-(b) candidate from §205 of the Knill survey.
+-/
+
+open Metric Set
+
+/-- The Euclidean plane. -/
+abbrev Plane := EuclideanSpace ℝ (Fin 2)
+
+/-- A point `P` is equichordal for the boundary of a planar domain `K` if
+there is a constant chord length `L` such that every unit direction through
+`P` meets the boundary at opposite chord endpoints whose total chord length
+is `L`.  The open segment condition rules out choosing non-endpoint boundary
+crossings for nonconvex star-like domains. -/
+def IsEquichordalPoint (K : Set Plane) (P : Plane) : Prop :=
+  P ∈ interior K ∧
+    ∃ L : ℝ, 0 < L ∧
+      ∀ u : Plane, u ∈ sphere (0 : Plane) 1 →
+        ∃ a b : ℝ,
+          0 < a ∧ 0 < b ∧
+            P + a • u ∈ frontier K ∧
+              P - b • u ∈ frontier K ∧
+                openSegment ℝ (P - b • u) (P + a • u) ⊆ interior K ∧
+                  dist (P + a • u) (P - b • u) = L
+
+/-- **Equichordal point theorem** (§205).  A convex planar curve cannot have
+two distinct equichordal points. -/
+@[eval_problem]
+theorem equichordal_point_unique {K : Set Plane}
+    (hK : IsCompact K) (hconv : Convex ℝ K) (hne : (interior K).Nonempty) :
+    ¬ ∃ P Q : Plane,
+      P ≠ Q ∧ IsEquichordalPoint K P ∧ IsEquichordalPoint K Q := by
+  sorry
+
+end LeanEval.Geometry.Equichordal

--- a/manifests/problems/equichordal_point_unique.toml
+++ b/manifests/problems/equichordal_point_unique.toml
@@ -1,0 +1,9 @@
+id = "equichordal_point_unique"
+title = "Equichordal point theorem (convex curves have a unique equichordal point)"
+test = false
+module = "LeanEval.Geometry.Equichordal"
+holes = ["equichordal_point_unique"]
+submitter = "Kim Morrison"
+notes = "A compact convex planar domain with nonempty interior cannot have two distinct equichordal points: there is no pair of interior points P ≠ Q such that, for each, every direction yields a boundary chord of one fixed total length. The curve is packaged as the frontier of K; for convex K a line through an interior point meets the boundary on the two opposite rays. Mathlib has StarConvex and the Euclidean plane EuclideanSpace ℝ (Fin 2) but no equichordal-point theory. The original uniqueness was proved by Rychlik; Knill lists it as §205."
+source = "M. R. Rychlik, A complete solution to the equichordal point problem of Fujiwara, Blaschke, Rothe and Weizenböck, Invent. Math. 129 (1997). Listed as §205 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §205."
+informal_solution = "Suppose P and Q were two distinct equichordal points with common chord constant L. Following Rychlik, complexify and analyze the equichordal map (the involution sending one chord endpoint through P to the opposite endpoint through Q); its dynamics define a real-analytic area-preserving map of the annulus whose invariant curves and heteroclinic connections are obstructed. Rychlik shows the resulting functional/dynamical system has no closed convex curve solution for L > 0 unless P = Q, contradicting P ≠ Q. No such argument is available in Mathlib, which lacks the equichordal map, its complex-analytic continuation, and the KAM/heteroclinic machinery used."


### PR DESCRIPTION
Draft. Adds **equichordal point theorem** (Knill survey §205) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code