### PR TITLE
feat: add Kirk normal-structure fixed-point eval problem

### DIFF
--- a/LeanEval/Topology/KirkNormalStructure.lean
+++ b/LeanEval/Topology/KirkNormalStructure.lean
@@ -1,0 +1,65 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Topology.KirkNormalStructure
+
+/-!
+# Kirk's normal-structure fixed point theorem
+
+`kirk_normal_structure`: a nonexpansive self-map of a nonempty bounded closed
+convex subset of a reflexive Banach space with normal structure has a fixed
+point. Reflexivity is genuine Banach-space reflexivity (surjectivity of the
+canonical embedding into the bidual), avoiding the collapse to the
+finite-dimensional case caused by algebraic reflexivity. Helpers
+`metricDiameter`, `pointRadiusIn`, `IsDiametralPoint`, `HasNormalStructure`
+and `IsNonexpansiveSelfMap` express the geometric hypotheses. Category-(b)
+candidate from §228 of the Knill survey.
+-/
+
+open Function
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- The diameter of a set, as a real supremum of all pairwise distances inside
+the set.  This keeps the normal-structure statement in ordinary metric
+language. -/
+noncomputable def metricDiameter (s : Set E) : ℝ :=
+  sSup {r : ℝ | ∃ x ∈ s, ∃ y ∈ s, dist x y = r}
+
+/-- Radius of a point relative to a set, i.e. the supremum of its distances to
+points of the set. -/
+noncomputable def pointRadiusIn (x : E) (s : Set E) : ℝ :=
+  sSup {r : ℝ | ∃ y ∈ s, dist x y = r}
+
+/-- A point is diametral in `s` if its radius in `s` is the diameter of `s`. -/
+def IsDiametralPoint (s : Set E) (x : E) : Prop :=
+  x ∈ s ∧ pointRadiusIn x s = metricDiameter s
+
+/-- A bounded convex set has normal structure if every nontrivial convex subset
+contains a non-diametral point. -/
+def HasNormalStructure (K : Set E) : Prop :=
+  ∀ H : Set E,
+    H ⊆ K →
+      Convex ℝ H →
+        H.Nontrivial →
+          ∃ x ∈ H, ¬ IsDiametralPoint H x
+
+/-- A self-map of a set is nonexpansive when it is `1`-Lipschitz for the
+subtype metric. -/
+def IsNonexpansiveSelfMap (K : Set E) (T : K → K) : Prop :=
+  LipschitzWith 1 T
+
+/-- **Kirk's normal-structure fixed-point theorem** (§228).  A nonexpansive
+self-map of a nonempty bounded closed convex subset of a reflexive Banach
+space with normal structure has a fixed point. -/
+@[eval_problem]
+theorem kirk_normal_structure [CompleteSpace E]
+    (hE_reflexive : Function.Surjective (NormedSpace.inclusionInDoubleDual ℝ E))
+    (K : Set E) (hK_nonempty : K.Nonempty) (hK_closed : IsClosed K)
+    (hK_bounded : Bornology.IsBounded K) (hK_convex : Convex ℝ K)
+    (hK_normal : HasNormalStructure K) (T : K → K)
+    (hT : IsNonexpansiveSelfMap K T) :
+    ∃ x : K, IsFixedPt T x := by
+  sorry
+
+end LeanEval.Topology.KirkNormalStructure

--- a/manifests/problems/kirk_normal_structure.toml
+++ b/manifests/problems/kirk_normal_structure.toml
@@ -1,0 +1,9 @@
+id = "kirk_normal_structure"
+title = "Kirk's normal-structure fixed point theorem"
+test = false
+module = "LeanEval.Topology.KirkNormalStructure"
+holes = ["kirk_normal_structure"]
+submitter = "Kim Morrison"
+notes = "A nonexpansive (1-Lipschitz) self-map of a nonempty bounded closed convex subset K of a reflexive Banach space with normal structure has a fixed point. Reflexivity is expressed as genuine Banach reflexivity: surjectivity of NormedSpace.inclusionInDoubleDual ℝ E into the bidual; using Module.IsReflexive instead would collapse to the finite-dimensional case. Normal structure (HasNormalStructure) asks every nontrivial convex subset to contain a non-diametral point, with the diameter and point-radius written as real suprema. Mathlib has reflexivity, LipschitzWith, and convexity, but no normal-structure theory and no Kirk fixed-point theorem. Listed as §228 of the Knill survey."
+source = "W. A. Kirk, A fixed point theorem for mappings which do not increase distances, Amer. Math. Monthly 72 (1965). Listed as §228 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §228."
+informal_solution = "By reflexivity and the Banach-Alaoglu/Eberlein-Šmulian theorem, the bounded closed convex set K is weakly compact, and the nonempty closed convex T-invariant subsets of K, ordered by reverse inclusion, have a minimal element K₀ (a weakly compact chain intersection is nonempty). If K₀ were a single point it is the fixed point. Otherwise K₀ is nontrivial; normal structure provides a non-diametral point, and averaging/Chebyshev-center arguments show the set of points whose radius in K₀ is minimal is a proper closed convex T-invariant subset of K₀, contradicting minimality. Hence K₀ is a point and T fixes it. Mathlib lacks weak compactness via reflexivity wired to this fixed-point argument, normal structure, and the Chebyshev-center step."


### PR DESCRIPTION
Draft. Adds **Kirk normal-structure fixed-point** (Knill survey §228) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code