### PR TITLE
feat: add Shishikura ∂Mandelbrot dim 2 eval problem

### DIFF
--- a/LeanEval/Dynamics/MandelbrotBoundary.lean
+++ b/LeanEval/Dynamics/MandelbrotBoundary.lean
@@ -1,0 +1,33 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Dynamics.MandelbrotBoundary
+
+/-!
+# Hausdorff dimension of the Mandelbrot boundary (Shishikura)
+
+`mandelbrot_boundary_dimh`: the boundary of the Mandelbrot set has Hausdorff
+dimension `2`. The helpers `Tc` (the quadratic family `z ↦ z² + c`) and
+`Mandelbrot` (the bounded critical-orbit locus) set up the statement over
+mathlib's existing `dimH`. Mathlib has no complex-dynamics, Mandelbrot set, or
+Shishikura dimension API. Category-(b) candidate from §260 of the Knill survey.
+-/
+
+open Function MeasureTheory
+
+/-- The quadratic family member `T_c(z) = z² + c`. -/
+def Tc (c : ℂ) (z : ℂ) : ℂ :=
+  z ^ 2 + c
+
+/-- The **Mandelbrot set** `M = { c ∈ ℂ | T_c^n(0) stays bounded }`. -/
+def Mandelbrot : Set ℂ :=
+  { c : ℂ | ∃ R : ℝ, ∀ n : ℕ, ‖(Tc c)^[n] 0‖ ≤ R }
+
+/-- **Shishikura's theorem** (§260). The boundary of the Mandelbrot set has
+Hausdorff dimension `2`. -/
+@[eval_problem]
+theorem mandelbrot_boundary_dimh :
+    dimH (frontier Mandelbrot) = 2 := by
+  sorry
+
+end LeanEval.Dynamics.MandelbrotBoundary

--- a/manifests/problems/mandelbrot_boundary_dimh.toml
+++ b/manifests/problems/mandelbrot_boundary_dimh.toml
@@ -1,0 +1,9 @@
+id = "mandelbrot_boundary_dimh"
+title = "Hausdorff dimension of the Mandelbrot boundary (Shishikura)"
+test = false
+module = "LeanEval.Dynamics.MandelbrotBoundary"
+holes = ["mandelbrot_boundary_dimh"]
+submitter = "Kim Morrison"
+notes = "Shishikura's theorem: the boundary of the Mandelbrot set has Hausdorff dimension 2. The Mandelbrot set is the bounded critical-orbit locus of the quadratic family T_c(z) = z² + c, and dimH is mathlib's MeasureTheory.dimH. Mathlib has dimH, Hausdorff measure, frontier, and Function.iterate, but no complex-dynamics, Mandelbrot/Julia set, or parabolic-implosion machinery, and no Shishikura theorem. Listed as §260 of the Knill survey."
+source = "M. Shishikura, The Hausdorff dimension of the boundary of the Mandelbrot set and Julia sets, Ann. of Math. 147 (1998). Listed as §260 in O. Knill, Some Fundamental Theorems in Mathematics (https://people.math.harvard.edu/~knill/graphgeometry/papers/fundamental.pdf). Knill, §260."
+informal_solution = "Shishikura proves it via parabolic bifurcation and the theory of parabolic implosion: near parameters with a parabolic cycle, the technique of fattening Cantor repellers and computing the limiting hyperbolic dimension shows that the bifurcation locus accumulates sets of hyperbolic dimension arbitrarily close to 2 on the Mandelbrot boundary. Since the boundary sits in ℂ ≅ ℝ², its dimension is at most 2, and the construction forces it to be exactly 2 (with full Hausdorff dimension at a generic boundary parameter). None of this — parabolic implosion, Lavaurs maps, hyperbolic dimension, or even the Mandelbrot set — exists in Mathlib, so no formalization is currently feasible."


### PR DESCRIPTION
Draft. Adds **Shishikura ∂Mandelbrot dim 2** (Knill survey §260) as a category-(b) eval problem. Trusted helper definitions (if any) are non-holes; the module builds clean against lean-eval's Mathlib with the single expected `sorry`. See the manifest for the statement, source, and proof sketch.

🤖 Prepared with Claude Code