### PR TITLE
feat: add Pardon’s 3D Hilbert–Smith eval problem

### DIFF
--- a/LeanEval/Topology/HilbertSmith3D.lean
+++ b/LeanEval/Topology/HilbertSmith3D.lean
@@ -1,0 +1,38 @@
+import Mathlib.Algebra.Group.Action.Faithful
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Geometry.Manifold.ChartedSpace
+import Mathlib.NumberTheory.Padics.PadicIntegers
+import Mathlib.Topology.Algebra.MulAction
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Topology
+
+/-!
+# Hilbert–Smith conjecture for three-manifolds (Pardon 2013)
+
+John Pardon proved that the additive group of `p`-adic integers cannot act
+continuously and faithfully on a connected three-dimensional topological
+manifold. By the standard reduction of Hilbert–Smith to `p`-adic actions, this
+establishes the Hilbert–Smith conjecture in dimension three.
+
+The statement below is Pardon’s Theorem 1.5. The manifold is represented by a
+Hausdorff, second-countable charted space modelled on `ℝ³`; no differentiable
+structure is assumed.
+-/
+
+/-- **Hilbert–Smith conjecture for three-manifolds** (Pardon 2013,
+Theorem 1.5). The additive group of `p`-adic integers cannot act
+continuously and faithfully on a connected topological three-manifold. -/
+@[eval_problem]
+theorem hilbert_smith_padic_dimension_three
+    (p : ℕ) [Fact p.Prime]
+    (M : Type*) [TopologicalSpace M] [T2Space M] [SecondCountableTopology M]
+    [ConnectedSpace M] [ChartedSpace (EuclideanSpace ℝ (Fin 3)) M]
+    [AddAction (PadicInt p) M] [ContinuousVAdd (PadicInt p) M]
+    [FaithfulVAdd (PadicInt p) M] :
+    False := by
+  sorry
+
+end Topology
+end LeanEval

--- a/LeanEval/Topology/HilbertSmith3D.lean
+++ b/LeanEval/Topology/HilbertSmith3D.lean
@@ -9,7 +9,7 @@ namespace LeanEval
 namespace Topology
 
 /-!
-# Hilbert–Smith conjecture for three-manifolds (Pardon 2013)
+# No continuous faithful ℤ_p action on a connected 3-manifold (Pardon 2013)
 
 John Pardon proved that the additive group of `p`-adic integers cannot act
 continuously and faithfully on a connected three-dimensional topological
@@ -21,9 +21,14 @@ Hausdorff, second-countable charted space modelled on `ℝ³`; no differentiable
 structure is assumed.
 -/
 
-/-- **Hilbert–Smith conjecture for three-manifolds** (Pardon 2013,
-Theorem 1.5). The additive group of `p`-adic integers cannot act
-continuously and faithfully on a connected topological three-manifold. -/
+/-- **No continuous faithful `ℤ_p` action on a connected 3-manifold** (Pardon
+2013, Theorem 1.5). The additive group of `p`-adic integers cannot act
+continuously and faithfully on a connected topological three-manifold.
+
+This is the `p`-adic step, not the full Hilbert–Smith conjecture: deducing that
+every locally compact group acting faithfully on a connected three-manifold is
+a Lie group additionally requires the classical reduction to `ℤ_p` actions,
+which is not part of this statement. -/
 @[eval_problem]
 theorem hilbert_smith_padic_dimension_three
     (p : ℕ) [Fact p.Prime]

--- a/manifests/problems/hilbert_smith_padic_dimension_three.toml
+++ b/manifests/problems/hilbert_smith_padic_dimension_three.toml
@@ -1,9 +1,9 @@
 id = "hilbert_smith_padic_dimension_three"
-title = "Hilbert–Smith conjecture for three-manifolds (Pardon 2013)"
+title = "No continuous faithful ℤ_p action on a connected 3-manifold (Pardon 2013)"
 test = false
 module = "LeanEval.Topology.HilbertSmith3D"
 holes = ["hilbert_smith_padic_dimension_three"]
 submitter = "Jack McCarthy"
-notes = "Pardon's Theorem 1.5: for every prime p, the additive group of p-adic integers admits no continuous faithful action on a connected topological 3-manifold. The statement uses a Hausdorff, second-countable ChartedSpace modelled on ℝ³ and assumes no smooth structure."
+notes = "Pardon's Theorem 1.5: for every prime p, the additive group of p-adic integers admits no continuous faithful action on a connected topological 3-manifold. The statement uses a Hausdorff, second-countable ChartedSpace modelled on ℝ³ and assumes no smooth structure. This is the p-adic step only: the full Hilbert–Smith conjecture in dimension three (every locally compact group acting faithfully on a connected three-manifold is a Lie group) additionally needs the classical reduction to ℤ_p actions, which is not part of the hole."
 source = "John Pardon, 'The Hilbert-Smith conjecture for three-manifolds', Journal of the American Mathematical Society 26 (2013), no. 3, 879-899, Theorem 1.5. https://doi.org/10.1090/S0894-0347-2013-00766-3"
 informal_solution = "Assume that ℤ_p acts faithfully. After passing to a sufficiently small open subgroup, localize the action in a Euclidean chart and construct a suitable invariant region with second homology ℤ. Isotopy classes of incompressible surfaces representing its generator form a lattice, yielding a surface whose isotopy class is fixed by ℤ_p. The induced finite-image homomorphism from ℤ_p to the surface mapping class group produces a nontrivial cyclic p-subgroup with homological properties ruled out by the Nielsen classification, giving a contradiction."

--- a/manifests/problems/hilbert_smith_padic_dimension_three.toml
+++ b/manifests/problems/hilbert_smith_padic_dimension_three.toml
@@ -1,0 +1,9 @@
+id = "hilbert_smith_padic_dimension_three"
+title = "Hilbert–Smith conjecture for three-manifolds (Pardon 2013)"
+test = false
+module = "LeanEval.Topology.HilbertSmith3D"
+holes = ["hilbert_smith_padic_dimension_three"]
+submitter = "Jack McCarthy"
+notes = "Pardon's Theorem 1.5: for every prime p, the additive group of p-adic integers admits no continuous faithful action on a connected topological 3-manifold. The statement uses a Hausdorff, second-countable ChartedSpace modelled on ℝ³ and assumes no smooth structure."
+source = "John Pardon, 'The Hilbert-Smith conjecture for three-manifolds', Journal of the American Mathematical Society 26 (2013), no. 3, 879-899, Theorem 1.5. https://doi.org/10.1090/S0894-0347-2013-00766-3"
+informal_solution = "Assume that ℤ_p acts faithfully. After passing to a sufficiently small open subgroup, localize the action in a Euclidean chart and construct a suitable invariant region with second homology ℤ. Isotopy classes of incompressible surfaces representing its generator form a lattice, yielding a surface whose isotopy class is fixed by ℤ_p. The induced finite-image homomorphism from ℤ_p to the surface mapping class group produces a nontrivial cyclic p-subgroup with homological properties ruled out by the Nielsen classification, giving a contradiction."


### PR DESCRIPTION
This PR adds John Pardon's three-dimensional Hilbert–Smith theorem as a single lean-eval problem. In its exact p-adic form, the theorem says that the additive group `ℤ_[p]` cannot act continuously and faithfully on a connected topological 3-manifold.

The Lean statement models the manifold as a Hausdorff, second-countable `ChartedSpace` over `ℝ³`, with no smooth structure. The manifold type is explicit because the conclusion is `False`; if it were implicit, lean-eval's generated `Solution` bridge could not infer it when forwarding a submitted theorem.

The accompanying manifest records Pardon’s Theorem 1.5, its JAMS citation, and a concise outline of the incompressible-surface and mapping-class-group argument.

Validation:

- `lake build LeanEval.Topology.HilbertSmith3D`
- `lake exe lean-eval generate --problem hilbert_smith_padic_dimension_three`
- `lake exe lean-eval check-generated-builds --problem hilbert_smith_padic_dimension_three`

The trusted source and the generated `Challenge`, blank `Submission`, and comparator `Solution` bridge all build successfully.

Drafted with Codex.