### PR TITLE
feat: require the nanoda external kernel for every solution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,23 @@ jobs:
           lake build comparator
           echo "$PWD/.lake/build/bin" >> "$GITHUB_PATH"
 
+      - name: Build nanoda
+        run: |
+          set -euo pipefail
+          # The external checker. WorkspaceTest forces `enable_nanoda: true`
+          # when it invokes comparator, so every scored Solution is replayed
+          # through nanoda's independent kernel and rejected unless `nanoda_bin`
+          # is on PATH. Built with the runner's stable cargo; the trust boundary
+          # is the pinned source commit, not the Rust compiler version.
+          git clone https://github.com/robsimmons/nanoda_lib.git .ci/nanoda
+          cd .ci/nanoda
+          # nanoda pinned to 68d5ca9 (robsimmons/nanoda_lib HEAD as of 2026-07-29,
+          # the fork comparator-live deploys). Bump procedure: SECURITY.md >
+          # "Bumping pinned dependencies".
+          git checkout 68d5ca9db226849b41a6fff59d796ff19d0a8840  # pin-audit: exempt -- SHA, see comment
+          cargo build --release
+          echo "$PWD/target/release" >> "$GITHUB_PATH"
+
       - name: Audit workflow action pins
         run: python scripts/action_pin_audit.py
 

--- a/README.md
+++ b/README.md
@@ -186,10 +186,12 @@ that tells comparator to check your theorem from the `Submission` namespace.
 lake test
 ```
 
-`lake test` shells out to three external tools that you must install yourself:
-`landrun` (the sandbox), `lean4export` (exports oleans to text), and `comparator`
-(the verifier). All three are pinned to immutable commits; the authoritative pin
-table lives in [`SECURITY.md`](SECURITY.md) ("Trusted dependencies and pin
+`lake test` shells out to four external tools that you must install yourself:
+`landrun` (the sandbox), `lean4export` (exports oleans to text), `comparator`
+(the verifier), and `nanoda` (the independent kernel). `WorkspaceTest` forces
+comparator to replay every Solution through nanoda, so a missing `nanoda_bin`
+fails the check. All four are pinned to immutable commits; the authoritative
+pin table lives in [`SECURITY.md`](SECURITY.md) ("Trusted dependencies and pin
 policy"), and CI installs exactly these in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Reproduce that setup
 locally:
@@ -215,6 +217,16 @@ git clone https://github.com/leanprover/comparator.git
   git checkout 71b52ec29e06d4b7d882726553b1ceb99a2499e0
   lake build comparator )
 export PATH="$PWD/comparator/.lake/build/bin:$PATH"
+
+# nanoda — the external kernel. WorkspaceTest forces comparator to replay the
+# Solution through nanoda, so `lake test` fails unless `nanoda_bin` is on your
+# PATH. Needs a Rust toolchain (`cargo`); the pin is on the source commit, not
+# the compiler version.
+git clone https://github.com/robsimmons/nanoda_lib.git
+( cd nanoda_lib
+  git checkout 68d5ca9db226849b41a6fff59d796ff19d0a8840
+  cargo build --release )
+export PATH="$PWD/nanoda_lib/target/release:$PATH"
 ```
 
 `lean4export` and `comparator` are Lean programs. The pinned lean4export source

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -98,6 +98,7 @@ code.
 | `rm -rf .git` | trusted | runner | No |
 | `lake build comparator` (in `.ci/comparator/`) | trusted | runner | No |
 | `lake build lean4export` (in `.ci/lean4export/`) | trusted | runner | No |
+| `cargo build --release` (in `.ci/nanoda/`) | trusted, pinned source | runner | No |
 | Submission tarball extracted | inert data | runner | No |
 | `evaluate_submission.py` overlay walk | trusted Python | runner | No |
 | `_share_packages` symlink setup | trusted Python | runner | No |
@@ -111,6 +112,7 @@ code.
 | `comparator.safeExport challengeModule` | reads trusted olean | **inside landrun** | No |
 | **`comparator.safeLakeBuild Solution`** | builds Solution -> imports Submission | **inside landrun** | **YES** |
 | `comparator.safeExport solutionModule` | reads the just-built olean | **inside landrun** | No |
+| `runNanoda solution` | pipes the export to `nanoda_bin` (independent kernel) | **inside landrun** | No |
 | `runKernel solution` | replays exported env in comparator process | runner | No |
 
 (`evaluate_submission.py` lives in the submissions repo; the steps above
@@ -203,6 +205,7 @@ time, the upstream publisher controls our supply chain.
 | landrun | zouuup/landrun | `5ed4a3db3a4ad930d577215c6b9abaa19df7f99f` | Linux landlock sandbox | 2026-05-04 |
 | lean4export | leanprover/lean4export | `4e7915201d3f9f04470d9eae002fa695f7cdc589` | exports olean to text | 2026-07-29 |
 | comparator | leanprover/comparator | `71b52ec29e06d4b7d882726553b1ceb99a2499e0` | the verifier | pre-2026-05 |
+| nanoda | robsimmons/nanoda_lib | `68d5ca9db226849b41a6fff59d796ff19d0a8840` | independent kernel (external checker) | 2026-07-29 |
 | `jlumbroso/free-disk-space` | (action) | `54081f138730dfa15788a46383842cd2f914a1be` | runner disk cleanup | 2026-05-04 |
 | `actions/checkout` | (action) | `11bd71901bbe5b1630ceea73d27597364c9af683` | repo checkout | 2026-05-04 |
 | `actions/setup-python` | (action) | `a26af69be951a213d495a4c3e4e4022e16d87065` | python setup | 2026-05-04 |
@@ -230,9 +233,12 @@ own `submission.yml`. A bump must update both repos in lockstep.
    For branch HEAD: `git ls-remote <repo> refs/heads/main`.
 2. Update **every** site listed below in lockstep, and add a dated
    comment of the form `# <dep> pinned to <sha7> (<note> as of YYYY-MM-DD).`
-   - `.github/workflows/ci.yml` (this repo)
+   - `.github/workflows/ci.yml` (this repo; includes the nanoda pin)
    - `.github/workflows/regenerate-main.yml` (this repo)
-   - `.github/workflows/submission.yml` (leanprover/lean-eval-submissions)
+   - `.github/workflows/submission.yml` (leanprover/lean-eval-submissions;
+     includes the nanoda pin)
+   - `README.md` (this repo; the local-setup nanoda / comparator /
+     lean4export / landrun clone commands)
    - `EvalTools/CheckComparatorInstallation.lean` (`landrunInstallTarget`,
      for landrun only)
    - `lean-eval-leaderboard/.benchmark-commit` (for the lean-eval
@@ -314,11 +320,26 @@ escaping, the triage gate) are in the submissions repo's `SECURITY.md`.
    sufficiently constrain a def — and adding one would be at most a
    heuristic. The real guard is PR review of any problem that uses
    def/instance holes.
-5. **Single-kernel defence.** `enable_nanoda: false` in every
-   generated config means the alternate kernel is not run. A Lean
-   kernel soundness bug becomes a false-credit vector. Defence in
-   depth would be `enable_nanoda: true` once nanoda's string
-   handling is upstream-fixed.
+5. **Dual-kernel defence.** nanoda is a global requirement, not a
+   per-problem option. `templates/WorkspaceTest.lean` (the harness that
+   invokes comparator, propagated verbatim into every workspace and
+   rebuilt from the template by `run-eval`) reads the committed
+   `config.json`, overrides `enable_nanoda := true`, and hands that to
+   comparator — so nanoda runs regardless of what any config file says.
+   This mirrors comparator-live, which forces the flag at the invocation
+   site (`exec.ts`) and leaves project configs untouched. A single Lean
+   kernel soundness bug (e.g. the Lean-conjecture counterexample) no
+   longer suffices to claim false credit; the proof must be accepted by
+   both kernels. The residual risk narrows to a bug present in *both*
+   kernels, or in comparator's export/axiom comparison itself. Note the
+   pinned nanoda is `robsimmons/nanoda_lib` (the fork comparator-live
+   deploys); the `builtinTargets` widening in comparator's `Main.lean`
+   still carries a `TODO: fix when nanoda fixes its string handling`, so a
+   nanoda string soundness gap would not be caught. Because enforcement
+   lives in `WorkspaceTest`, a workspace whose committed `config.json`
+   still says `enable_nanoda: false` is not a bypass — the harness
+   overrides it. Bumping the nanoda pin follows the "Bumping pinned
+   dependencies" procedure above.
 
 ## References
 

--- a/templates/WorkspaceTest.lean
+++ b/templates/WorkspaceTest.lean
@@ -2,18 +2,32 @@ import Lean
 
 open Lean
 
+/-- Invoke comparator on this workspace, forcing the external nanoda kernel on.
+
+nanoda is a global requirement of the eval, not a per-problem option: every
+solution must be accepted by comparator **and** replayed through nanoda's
+independent kernel. Rather than encode that in each workspace's `config.json`,
+this harness reads the committed config, overrides `enable_nanoda := true`, and
+hands the result to comparator — so nanoda runs regardless of what the file on
+disk says. This mirrors the comparator-live "gold standard" setup, which forces
+nanoda at the invocation site and leaves project configs untouched. -/
 def main : IO UInt32 := do
   let comparatorBin := (← IO.getEnv "COMPARATOR_BIN").getD "comparator"
   try
-    let child ← IO.Process.spawn {
-      cmd := "lake"
-      args := #["env", comparatorBin, "config.json"]
-    }
-    let exitCode ← child.wait
-    pure exitCode
+    let configText ← IO.FS.readFile "config.json"
+    let config ← IO.ofExcept (Json.parse configText)
+    let config := config.setObjVal! "enable_nanoda" (Json.bool true)
+    IO.FS.withTempFile fun handle enforcedPath => do
+      handle.putStr config.pretty
+      handle.flush
+      let child ← IO.Process.spawn {
+        cmd := "lake"
+        args := #["env", comparatorBin, enforcedPath.toString]
+      }
+      child.wait
   catch err =>
     IO.eprintln s!"Failed to run comparator via `{comparatorBin}`."
-    IO.eprintln "Make sure `comparator` is installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
-    IO.eprintln "See the root repository README for comparator setup details, including landrun and lean4export."
+    IO.eprintln "Make sure `comparator` and the `nanoda_bin` external kernel are installed and on your `PATH`, or set `COMPARATOR_BIN=/path/to/comparator`."
+    IO.eprintln "See the root repository README for comparator setup details, including landrun, lean4export, and nanoda."
     IO.eprintln s!"Original error: {err}"
     pure 1


### PR DESCRIPTION
This PR makes the nanoda independent kernel a global requirement of the eval: every solution must be accepted by comparator **and** replayed through nanoda, so a single Lean kernel soundness bug (like the recent Lean-conjecture counterexample) no longer suffices to claim credit. `templates/WorkspaceTest.lean` reads each workspace's committed `config.json`, overrides `enable_nanoda := true`, and hands the result to comparator. This mirrors [comparator-live](https://github.com/leanprover/comparator-live), which forces the flag at the invocation site (`server/src/exec.ts`) and leaves the project configs untouched, rather than baking the flag into every generated config.

CI builds the pinned [robsimmons/nanoda_lib](https://github.com/robsimmons/nanoda_lib) at `68d5ca9` — the fork comparator-live deploys — and puts `nanoda_bin` on `PATH`; a missing binary fails the check. The pin table and bump procedure in `SECURITY.md`, the local-setup instructions in `README.md`, and the trust-model section are updated to match.

The submission pipeline needs the same nanoda install in lockstep: leanprover/lean-eval-submissions#895 (feat: install the nanoda external kernel for submission scoring).

Validated locally end to end: comparator at the pinned commit plus nanoda accept a real solution (`Nanoda kernel accepts the solution` / `Your solution is okay!`), and removing `nanoda_bin` from `PATH` fails the run, confirming nanoda is genuinely enforced and not silently skipped.

🤖 Prepared with Claude Code