### PR TITLE
fix: serialize manifest inventory builds

### DIFF
--- a/EvalTools/CheckProblemBuild.lean
+++ b/EvalTools/CheckProblemBuild.lean
@@ -10,20 +10,24 @@ private def hasSubstr (haystack pattern : String) : Bool :=
 private def isDisallowedWarning (line : String) : Bool :=
   hasSubstr line "warning:" && !hasSubstr line "declaration uses `sorry`"
 
-/-- Implementation of `lake exe lean-eval check-problem-build`. Builds every
-manifest module via `lake build`, then scans captured output for warnings
-other than the expected `declaration uses \`sorry\`` warnings the problem
-modules emit by design. -/
+/-- Implementation of `lake exe lean-eval check-problem-build`. Builds each
+manifest module separately via `lake build`, then scans captured output for
+warnings other than the expected `declaration uses \`sorry\`` warnings the
+problem modules emit by design.
+
+The separate invocations are intentional: passing the complete catalog to one
+`lake build` lets Lake schedule every independent module at once. -/
 def runCheckProblemBuild (root : System.FilePath) : IO UInt32 := do
   try
     let entries ← loadManifest root
     let modules := uniqueModules entries
-    let output ← runCmdCheckedCaptured "lake" (#["build"] ++ modules) root
-      "Problem module build failed"
-    let combined :=
-      [output.stdout, output.stderr].filter (! ·.isEmpty) |> String.intercalate "\n"
-    let lines := combined.splitOn "\n"
-    let disallowed := lines.filter isDisallowedWarning
+    let mut disallowed := []
+    for moduleName in modules do
+      let output ← runCmdCheckedCaptured "lake" #["build", moduleName] root
+        s!"Problem module '{moduleName}' build failed"
+      let combined :=
+        [output.stdout, output.stderr].filter (! ·.isEmpty) |> String.intercalate "\n"
+      disallowed := disallowed ++ (combined.splitOn "\n").filter isDisallowedWarning
     if !disallowed.isEmpty then
       IO.eprintln "Disallowed build warnings found:"
       for line in disallowed do

--- a/EvalTools/Manifest.lean
+++ b/EvalTools/Manifest.lean
@@ -108,13 +108,21 @@ private def parseInventoryEntries (payload : String) :
         basename := basename, kind := kind }
   return out
 
-/-- Build the lake target and run the `eval_inventory` executable over every
-module referenced by `entries`. -/
+/-- Build the Lake targets and run the `eval_inventory` executable over every
+module referenced by `entries`.
+
+Build the inventory executable first, then each problem module separately.
+Passing every problem module to one `lake build` lets Lake schedule the entire
+catalog at once, which can exhaust machine resources on a clean checkout. -/
 def runInventoryTool (root : System.FilePath) (modules : Array String) :
     IO (Array ManifestInventoryEntry) := do
   let _ ← runCmdCheckedCaptured "lake"
-    (#["build"] ++ modules ++ #["eval_inventory"]) root
+    #["build", "eval_inventory"] root
     "Failed to build Lean problem inventory tool"
+  for moduleName in modules do
+    let _ ← runCmdCheckedCaptured "lake"
+      #["build", moduleName] root
+      s!"Failed to build Lean problem module '{moduleName}'"
   let binPath := root / ".lake" / "build" / "bin" / "eval_inventory"
   let out ← runCmdCheckedCaptured "lake"
     (#["env", binPath.toString] ++ modules) root

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ lake exe lean-eval check-problem-build
 
 `validate-manifest` checks that `@[eval_problem]` declarations and manifest entries
 match. `check-problem-build` builds the problem modules so warning-producing Lean changes
-do not slip through. Both are cheap and catch the most common mistakes before a CI
-roundtrip.
+do not slip through. Both catch the most common mistakes before a CI roundtrip;
+on a clean checkout, validating the full problem inventory can take some time.
 
 ### 5. Open a PR
 


### PR DESCRIPTION
This PR prevents the repository-wide validation commands from scheduling the complete problem catalog in one Lake build. Both `validate-manifest` and `check-problem-build` now build each problem module separately, avoiding a catalog-wide process burst on clean checkouts. It also corrects the README claim that full inventory validation is always cheap.

Validated by elaborating the changed Lean modules with Lean 4.32.2.

:robot: Prepared with OpenAI Codex