### PR TITLE
feat: add Duminil-Copin honeycomb connective-constant eval problem

### DIFF
--- a/LeanEval/Combinatorics/HoneycombConnectiveConstant.lean
+++ b/LeanEval/Combinatorics/HoneycombConnectiveConstant.lean
@@ -104,7 +104,7 @@ exponential growth rate of the number of self-avoiding walks is
 @[eval_problem]
 theorem honeycomb_connective_constant :
     Tendsto
-      (fun n : ℕ => Real.rpow (walkCount n : ℝ) (1 / (n : ℝ)))
+      (fun n ↦ (walkCount n : ℝ) ^ (1 / n : ℝ))
       atTop
       (nhds (Real.sqrt (2 + Real.sqrt 2))) := by
   sorry

--- a/LeanEval/Combinatorics/HoneycombConnectiveConstant.lean
+++ b/LeanEval/Combinatorics/HoneycombConnectiveConstant.lean
@@ -1,0 +1,112 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Combinatorics.HoneycombConnectiveConstant
+
+/-!
+# The connective constant of the honeycomb lattice
+
+Duminil-Copin and Smirnov proved Nienhuis's prediction that the connective
+constant of the honeycomb (hexagonal) lattice is `sqrt (2 + sqrt 2)`.
+
+The lattice is represented in bipartite integer coordinates. A vertex
+`(x, y, false)` is adjacent to `(x, y, true)`, `(x - 1, y, true)`, and
+`(x, y - 1, true)`; the reverse moves apply on the other side. Thus a
+finite direction word determines a walk, and injectivity of its sequence
+of visited vertices is exactly the self-avoiding condition.
+-/
+
+open Filter Topology
+
+/-- Bipartite integer coordinates for the vertices of the honeycomb lattice. -/
+structure HoneycombVertex where
+  x : ℤ
+  y : ℤ
+  side : Bool
+deriving DecidableEq
+
+/-- Take one of the three incident edges at a honeycomb-lattice vertex. -/
+def step (v : HoneycombVertex) (direction : Fin 3) : HoneycombVertex :=
+  if v.side then
+    match direction.1 with
+    | 0 => ⟨v.x, v.y, false⟩
+    | 1 => ⟨v.x + 1, v.y, false⟩
+    | _ => ⟨v.x, v.y + 1, false⟩
+  else
+    match direction.1 with
+    | 0 => ⟨v.x, v.y, true⟩
+    | 1 => ⟨v.x - 1, v.y, true⟩
+    | _ => ⟨v.x, v.y - 1, true⟩
+
+/-- Traversing the same locally labelled edge twice returns to the starting
+vertex. In particular, the coordinate model defines an undirected graph. -/
+@[simp]
+theorem step_step (v : HoneycombVertex) (direction : Fin 3) :
+    step (step v direction) direction = v := by
+  rcases v with ⟨x, y, side⟩
+  fin_cases direction
+  all_goals cases side
+  all_goals simp [step]
+
+/-- The three direction labels at a vertex select three distinct neighbors. -/
+theorem step_injective (v : HoneycombVertex) : Function.Injective (step v) := by
+  intro direction₁ direction₂ h
+  rcases v with ⟨x, y, side⟩
+  cases side
+  all_goals fin_cases direction₁
+  all_goals fin_cases direction₂
+  all_goals simp [step] at h ⊢
+  all_goals omega
+
+/-- A fixed origin in the vertex-transitive honeycomb lattice. -/
+def origin : HoneycombVertex := ⟨0, 0, false⟩
+
+/-- The endpoint reached by following a finite word of directions from the origin. -/
+def endpoint (directions : List (Fin 3)) : HoneycombVertex :=
+  directions.foldl step origin
+
+/-- The vertex visited after the first `i` steps of a direction word. -/
+def vertexAt {n : ℕ} (directions : Fin n → Fin 3) (i : Fin (n + 1)) :
+    HoneycombVertex :=
+  endpoint ((List.ofFn directions).take i.1)
+
+/-- The finite set of vertices visited by a direction word, including the origin. -/
+def visitedVertices {n : ℕ} (directions : Fin n → Fin 3) : Finset HoneycombVertex :=
+  Finset.univ.image (vertexAt directions)
+
+/-- A direction word is self-avoiding when its `n + 1` visited vertices are distinct. -/
+def IsSelfAvoiding {n : ℕ} (directions : Fin n → Fin 3) : Prop :=
+  (visitedVertices directions).card = n + 1
+
+instance {n : ℕ} (directions : Fin n → Fin 3) : Decidable (IsSelfAvoiding directions) := by
+  unfold IsSelfAvoiding
+  infer_instance
+
+/-- The number of `n`-step self-avoiding walks on the honeycomb lattice
+starting at the origin. -/
+def walkCount (n : ℕ) : ℕ :=
+  (Finset.univ.filter fun directions : Fin n → Fin 3 =>
+    IsSelfAvoiding directions).card
+
+/-- A small computable check of the lattice encoding: there are twelve
+three-step self-avoiding walks from a fixed honeycomb vertex. -/
+theorem walkCount_three : walkCount 3 = 12 := by
+  decide
+
+set_option maxRecDepth 10000 in
+/-- At six steps the first hexagonal cycle appears; the standard count is `90`. -/
+theorem walkCount_six : walkCount 6 = 90 := by
+  decide
+
+/-- **Duminil-Copin-Smirnov honeycomb connective-constant theorem.** The
+exponential growth rate of the number of self-avoiding walks is
+`sqrt (2 + sqrt 2)`. -/
+@[eval_problem]
+theorem honeycomb_connective_constant :
+    Tendsto
+      (fun n : ℕ => Real.rpow (walkCount n : ℝ) (1 / (n : ℝ)))
+      atTop
+      (nhds (Real.sqrt (2 + Real.sqrt 2))) := by
+  sorry
+
+end LeanEval.Combinatorics.HoneycombConnectiveConstant

--- a/manifests/problems/honeycomb_connective_constant.toml
+++ b/manifests/problems/honeycomb_connective_constant.toml
@@ -1,0 +1,9 @@
+id = "honeycomb_connective_constant"
+title = "Connective constant of the honeycomb lattice"
+test = false
+module = "LeanEval.Combinatorics.HoneycombConnectiveConstant"
+holes = ["honeycomb_connective_constant"]
+submitter = "Kim Morrison"
+notes = "The honeycomb lattice is given explicitly as the standard bipartite graph on `Int x Int x Bool`: a vertex on one side is joined to the three corresponding vertices on the other side at offsets `(0,0)`, `(-1,0)`, and `(0,-1)`, with reverse moves from the other side. An `n`-step walk is encoded by its `n` choices among the three incident edges, and it is self-avoiding exactly when its `n+1` visited vertices are distinct. Consequently `walkCount n` is exactly the usual `c_n`; the theorem states the defining connective-constant limit, not merely a critical generating-function identity."
+source = "H. Duminil-Copin and S. Smirnov, 'The connective constant of the honeycomb lattice equals sqrt(2 + sqrt 2)', Ann. of Math. 175 (2012), 1653-1665, https://doi.org/10.4007/annals.2012.175.3.14."
+informal_solution = "Let `x_c = 1 / sqrt(2 + sqrt 2)`. Duminil-Copin and Smirnov introduce a parafermionic observable for self-avoiding walks in finite honeycomb domains, weighted by `x_c` to the walk length and by a complex phase determined by winding. At each lattice vertex the observable satisfies a discrete Cauchy-Riemann-type cancellation. Summing this local identity over strip domains gives an exact relation among boundary partition functions. A bridge decomposition then proves that the self-avoiding-walk generating function converges for `x < x_c` and diverges for `x > x_c`. Since the standard submultiplicative argument gives existence of the exponential growth rate of `walkCount n`, its value is `x_c^-1 = sqrt(2 + sqrt 2)`, which is the limit asserted in Lean."


### PR DESCRIPTION
This PR adds the exact honeycomb-lattice connective constant as an eval problem, with an explicit coordinate model and computable regression checks for the standard self-avoiding-walk counts. The problem module elaborates with only the expected eval-hole warning, and the manifest parses successfully.

:robot: Prepared with OpenAI Codex