### PR TITLE
feat: add Maynard Duffin-Schaeffer eval problem

### DIFF
--- a/LeanEval/NumberTheory/DuffinSchaeffer.lean
+++ b/LeanEval/NumberTheory/DuffinSchaeffer.lean
@@ -18,14 +18,14 @@ circle are precisely reduced fractions with denominator `n`.
 
 open MeasureTheory
 
-/-- **Koukoulopoulos-Maynard Duffin-Schaeffer theorem.** For nonnegative
+/-- **Koukoulopoulos-Maynard theorem (Duffin-Schaeffer conjecture).** For nonnegative
 approximation radii `delta`, the corresponding limsup set of reduced
 rational approximations has full measure exactly when
 `sum_n phi(n) * delta(n)` diverges. -/
 @[eval_problem]
 theorem duffin_schaeffer (δ : ℕ → ℝ) (hδ : ∀ n, 0 ≤ δ n) :
     volume (addWellApproximable UnitAddCircle δ) = 1 ↔
-      ¬ Summable (fun n : ℕ => (Nat.totient n : ℝ) * δ n) := by
+      ¬ Summable fun n : ℕ => n.totient * δ n := by
   sorry
 
 end LeanEval.NumberTheory.DuffinSchaeffer

--- a/LeanEval/NumberTheory/DuffinSchaeffer.lean
+++ b/LeanEval/NumberTheory/DuffinSchaeffer.lean
@@ -1,0 +1,31 @@
+import Mathlib.NumberTheory.WellApproximable
+import EvalTools.Markers
+
+namespace LeanEval.NumberTheory.DuffinSchaeffer
+
+/-!
+# The Duffin-Schaeffer conjecture
+
+Koukoulopoulos and Maynard proved the Duffin-Schaeffer conjecture, giving
+the exact divergence criterion for almost every real number to admit
+infinitely many prescribed approximations by reduced fractions.
+
+Mathlib already defines `addWellApproximable UnitAddCircle delta` as the
+set of points lying within `delta n` of a point of exact additive order `n`
+for infinitely many positive `n`. Points of exact order `n` on the unit
+circle are precisely reduced fractions with denominator `n`.
+-/
+
+open MeasureTheory
+
+/-- **Koukoulopoulos-Maynard Duffin-Schaeffer theorem.** For nonnegative
+approximation radii `delta`, the corresponding limsup set of reduced
+rational approximations has full measure exactly when
+`sum_n phi(n) * delta(n)` diverges. -/
+@[eval_problem]
+theorem duffin_schaeffer (δ : ℕ → ℝ) (hδ : ∀ n, 0 ≤ δ n) :
+    volume (addWellApproximable UnitAddCircle δ) = 1 ↔
+      ¬ Summable (fun n : ℕ => (Nat.totient n : ℝ) * δ n) := by
+  sorry
+
+end LeanEval.NumberTheory.DuffinSchaeffer

--- a/manifests/problems/duffin_schaeffer.toml
+++ b/manifests/problems/duffin_schaeffer.toml
@@ -1,0 +1,9 @@
+id = "duffin_schaeffer"
+title = "Duffin-Schaeffer conjecture"
+test = false
+module = "LeanEval.NumberTheory.DuffinSchaeffer"
+holes = ["duffin_schaeffer"]
+submitter = "Kim Morrison"
+notes = "Mathlib's `addWellApproximable UnitAddCircle δ` is the limsup of the sets of points within distance `δ n` of a point of exact additive order `n`; these order-`n` points are exactly the reduced fractions with denominator `n`. Thus the theorem is the standard Duffin-Schaeffer criterion in radius notation: the limsup set has full Lebesgue measure iff `sum_n phi(n) * δ(n)` diverges. Nonnegativity of `δ` makes divergence equivalent to failure of `Summable`. The unit circle has total volume one."
+source = "D. Koukoulopoulos and J. Maynard, 'On the Duffin-Schaeffer conjecture', Ann. of Math. 192 (2020), 251-307, https://doi.org/10.4007/annals.2020.192.1.5."
+informal_solution = "The convergence implication is the first Borel-Cantelli lemma. For the difficult divergence implication, Koukoulopoulos and Maynard reduce the problem to a quantitative second-moment estimate for overlaps between the sets of reduced rational approximations. They organize pairs of denominators by their greatest common divisor and by a graph encoding exceptional common prime factors. A compression argument and estimates for the resulting GCD sums show that any substantial failure of quasi-independence is confined to structured denominator sets whose total contribution can be controlled. This yields positive measure for the limsup set whenever `sum phi(n) * δ(n)` diverges; Gallagher's ergodic zero-one law, already formalized in Mathlib for `addWellApproximable`, upgrades positive measure to full measure."


### PR DESCRIPTION
This PR adds the Koukoulopoulos-Maynard Duffin-Schaeffer theorem as an eval problem using Mathlib's existing addWellApproximable definition. The problem module elaborates with only the expected eval-hole warning, and the manifest parses successfully.

:robot: Prepared with OpenAI Codex