### PR TITLE
feat: add Avila-Jitomirskaya Ten Martini eval problem

### DIFF
--- a/LeanEval/Analysis/TenMartini.lean
+++ b/LeanEval/Analysis/TenMartini.lean
@@ -1,0 +1,50 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval.Analysis.TenMartini
+
+/-!
+# The Ten Martini Problem
+
+Avila and Jitomirskaya proved that the spectrum of the almost Mathieu
+operator is a Cantor set for every irrational frequency and every nonzero
+coupling constant.
+
+The operator acts on `l^2(Z)` by
+
+`(H u)(n) = u(n+1) + u(n-1) + 2 lambda cos(2 pi (theta + n alpha)) u(n)`.
+
+We specify this coordinate formula transparently and ask for construction of
+the bounded operator as part of the theorem, so the spectral conclusion does
+not rest on an existence hypothesis.
+-/
+
+open Set
+
+/-- The Hilbert space `l^2(Z)` of square-summable complex sequences. -/
+abbrev EllTwo : Type := lp (fun _ : ℤ => ℂ) 2
+
+/-- A bounded operator on `l^2(Z)` has the almost Mathieu coordinate formula
+with frequency `alpha`, coupling `lambda`, and phase `theta`. -/
+def IsAlmostMathieuOperator (α coupling θ : ℝ) (H : EllTwo →L[ℂ] EllTwo) : Prop :=
+  ∀ (u : EllTwo) (n : ℤ),
+    H u n =
+      u (n + 1) + u (n - 1) +
+        ((2 * coupling * Real.cos (2 * Real.pi * (θ + (n : ℝ) * α) : ℝ) : ℂ) * u n)
+
+/-- **Avila-Jitomirskaya Ten Martini theorem.** For irrational frequency
+and nonzero coupling, the spectrum of the almost Mathieu operator is a
+Cantor set. Here this means nonempty, compact, perfect, and totally
+disconnected. -/
+@[eval_problem]
+theorem ten_martini_problem (α coupling θ : ℝ)
+    (hα : Irrational α) (hcoupling : coupling ≠ 0) :
+    ∃ H : EllTwo →L[ℂ] EllTwo,
+      IsAlmostMathieuOperator α coupling θ H ∧
+        (spectrum ℂ H).Nonempty ∧
+        IsCompact (spectrum ℂ H) ∧
+        Perfect (spectrum ℂ H) ∧
+        IsTotallyDisconnected (spectrum ℂ H) := by
+  sorry
+
+end LeanEval.Analysis.TenMartini

--- a/manifests/problems/ten_martini_problem.toml
+++ b/manifests/problems/ten_martini_problem.toml
@@ -1,0 +1,9 @@
+id = "ten_martini_problem"
+title = "Avila-Jitomirskaya Ten Martini Problem"
+test = false
+module = "LeanEval.Analysis.TenMartini"
+holes = ["ten_martini_problem"]
+submitter = "Kim Morrison"
+notes = "The theorem constructs the almost Mathieu operator as an actual Mathlib continuous linear endomorphism of `lp (fun _ : Int => Complex) 2`; `IsAlmostMathieuOperator` fixes it by the standard coordinate formula, rather than hiding it in trusted spectral scaffolding. For irrational frequency `alpha`, nonzero coupling `lambda`, and arbitrary phase `theta`, its complex spectrum is asserted to be nonempty, compact, perfect, and totally disconnected, i.e. a Cantor set. Including operator existence in the conclusion prevents vacuity through an uninhabited formula predicate."
+source = "A. Avila and S. Jitomirskaya, 'The Ten Martini Problem', Ann. of Math. 170 (2009), 303-342, https://doi.org/10.4007/annals.2009.170.303."
+informal_solution = "Aubry duality relates the almost Mathieu operators at couplings `lambda` and `1/lambda`, so the proof can combine localization information in one regime with reducibility information in the dual regime. Avila and Jitomirskaya establish nonperturbative localization estimates and analyze the associated quasiperiodic `SL(2,R)` cocycles. For every irrational frequency and nonzero coupling, these estimates rule out intervals in the spectrum and also rule out isolated spectral points. Standard self-adjoint spectral theory supplies nonemptiness and compactness. Thus the spectrum is compact and perfect with no nontrivial connected subsets, which is precisely the Cantor-set conclusion stated in Lean."


### PR DESCRIPTION
This PR adds the Avila-Jitomirskaya Ten Martini theorem as an eval problem, requiring construction of the almost Mathieu operator with its standard coordinate formula and the Cantor-set spectral conclusion. The problem module elaborates with only the expected eval-hole warning, and the manifest parses successfully.

:robot: Prepared with OpenAI Codex