### PR TITLE
ci: update action runtimes and Go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # leanprover/lean-action pinned to 38fbc41a (= refs/tags/v1.5.0, also v1 HEAD as of 2026-05-04).
       - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
@@ -36,7 +37,9 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           # Concrete Go version, not `stable`, so a runner-image bump cannot
-          # silently change the toolchain we install landrun with.
+          # silently change the toolchain we install landrun with. setup-go
+          # v6+ sets GOTOOLCHAIN=local, so this is also the compiler actually
+          # used rather than a minimum that Go may silently replace.
           go-version: '1.25.12'
           # This repository has no Go module dependency file for setup-go to
           # hash; the only Go dependency is pinned directly in `go install`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           # Concrete Go version, not `stable`, so a runner-image bump cannot
           # silently change the toolchain we install landrun with.
-          go-version: '1.24.0'
+          go-version: '1.25.12'
           # This repository has no Go module dependency file for setup-go to
           # hash; the only Go dependency is pinned directly in `go install`.
           cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      # actions/checkout pinned to 11bd7190 (= refs/tags/v4.2.2 as of 2026-05-04).
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
@@ -32,12 +32,15 @@ jobs:
         with:
           use-mathlib-cache: true
 
-      # actions/setup-go pinned to d35c59ab (= refs/tags/v5.5.0 as of 2026-05-04).
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      # actions/setup-go pinned to b7ad1dad (= refs/tags/v7.0.0 as of 2026-07-30).
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           # Concrete Go version, not `stable`, so a runner-image bump cannot
           # silently change the toolchain we install landrun with.
           go-version: '1.24.0'
+          # This repository has no Go module dependency file for setup-go to
+          # hash; the only Go dependency is pinned directly in `go install`.
+          cache: false
 
       - name: Install landrun
         run: |

--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}
+          # The commit-and-push step below authenticates through .git/config.
+          persist-credentials: true
 
       # leanprover/lean-action pinned to 38fbc41a (= refs/tags/v1.5.0, also v1 HEAD as of 2026-05-04).
       - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9

--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -27,8 +27,8 @@ jobs:
     steps:
       - name: Mint lean-eval-regenerator installation token
         id: app_token
-        # actions/create-github-app-token pinned to d72941d7 (= refs/tags/v1 as of 2026-05-04).
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        # actions/create-github-app-token pinned to bcd2ba49 (= refs/tags/v3.2.0 as of 2026-07-30).
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.LEAN_EVAL_REGENERATOR_APP_ID }}
           private-key: ${{ secrets.LEAN_EVAL_REGENERATOR_PRIVATE_KEY }}

--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -33,8 +33,8 @@ jobs:
           app-id: ${{ secrets.LEAN_EVAL_REGENERATOR_APP_ID }}
           private-key: ${{ secrets.LEAN_EVAL_REGENERATOR_PRIVATE_KEY }}
 
-      # actions/checkout pinned to 11bd7190 (= refs/tags/v4.2.2 as of 2026-05-04).
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -208,9 +208,11 @@ time, the upstream publisher controls our supply chain.
 | nanoda | robsimmons/nanoda_lib | `68d5ca9db226849b41a6fff59d796ff19d0a8840` | independent kernel (external checker) | 2026-07-29 |
 | `jlumbroso/free-disk-space` | (action) | `54081f138730dfa15788a46383842cd2f914a1be` | runner disk cleanup | 2026-05-04 |
 | `actions/checkout` | (action) | `3d3c42e5aac5ba805825da76410c181273ba90b1` | repo checkout | 2026-07-30 |
-| `actions/setup-python` | (action) | `a26af69be951a213d495a4c3e4e4022e16d87065` | python setup | 2026-05-04 |
+| `actions/setup-python` | (action) | `5fda3b95a4ea91299a34e894583c3862153e4b97` | python setup | 2026-07-30 |
 | `actions/setup-go` | (action) | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` | go setup | 2026-07-30 |
-| `actions/create-github-app-token` | (action) | `d72941d797fd3113feb6b93fd0dec494b13a2547` | App auth | 2026-05-04 |
+| `actions/create-github-app-token` | (action) | `bcd2ba49218906704ab6c1aa796996da409d3eb1` | App auth | 2026-07-30 |
+| `actions/upload-artifact` | (action) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | submission artifact upload | 2026-07-30 |
+| `actions/download-artifact` | (action) | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | submission artifact download | 2026-07-30 |
 | `leanprover/lean-action` | (action) | `38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9` | Lean toolchain | 2026-05-04 |
 | Go toolchain | (setup-go arg) | `1.25.12` | concrete version, not `stable` | 2026-07-30 |
 | Python | (setup-python arg) | `3.11.10` | concrete patch version | 2026-05-04 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -212,7 +212,7 @@ time, the upstream publisher controls our supply chain.
 | `actions/setup-go` | (action) | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` | go setup | 2026-07-30 |
 | `actions/create-github-app-token` | (action) | `d72941d797fd3113feb6b93fd0dec494b13a2547` | App auth | 2026-05-04 |
 | `leanprover/lean-action` | (action) | `38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9` | Lean toolchain | 2026-05-04 |
-| Go toolchain | (setup-go arg) | `1.24.0` | concrete version, not `stable` | 2026-05-04 |
+| Go toolchain | (setup-go arg) | `1.25.12` | concrete version, not `stable` | 2026-07-30 |
 | Python | (setup-python arg) | `3.11.10` | concrete patch version | 2026-05-04 |
 | `permitted_axioms` (every workspace) | comparator config | `{propext, Quot.sound, Classical.choice}` | axioms allowed in proofs | unchanged |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -207,9 +207,9 @@ time, the upstream publisher controls our supply chain.
 | comparator | leanprover/comparator | `71b52ec29e06d4b7d882726553b1ceb99a2499e0` | the verifier | pre-2026-05 |
 | nanoda | robsimmons/nanoda_lib | `68d5ca9db226849b41a6fff59d796ff19d0a8840` | independent kernel (external checker) | 2026-07-29 |
 | `jlumbroso/free-disk-space` | (action) | `54081f138730dfa15788a46383842cd2f914a1be` | runner disk cleanup | 2026-05-04 |
-| `actions/checkout` | (action) | `11bd71901bbe5b1630ceea73d27597364c9af683` | repo checkout | 2026-05-04 |
+| `actions/checkout` | (action) | `3d3c42e5aac5ba805825da76410c181273ba90b1` | repo checkout | 2026-07-30 |
 | `actions/setup-python` | (action) | `a26af69be951a213d495a4c3e4e4022e16d87065` | python setup | 2026-05-04 |
-| `actions/setup-go` | (action) | `d35c59abb061a4a6fb18e82ac0862c26744d6ab5` | go setup | 2026-05-04 |
+| `actions/setup-go` | (action) | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` | go setup | 2026-07-30 |
 | `actions/create-github-app-token` | (action) | `d72941d797fd3113feb6b93fd0dec494b13a2547` | App auth | 2026-05-04 |
 | `leanprover/lean-action` | (action) | `38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9` | Lean toolchain | 2026-05-04 |
 | Go toolchain | (setup-go arg) | `1.24.0` | concrete version, not `stable` | 2026-05-04 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -207,12 +207,12 @@ time, the upstream publisher controls our supply chain.
 | comparator | leanprover/comparator | `71b52ec29e06d4b7d882726553b1ceb99a2499e0` | the verifier | pre-2026-05 |
 | nanoda | robsimmons/nanoda_lib | `68d5ca9db226849b41a6fff59d796ff19d0a8840` | independent kernel (external checker) | 2026-07-29 |
 | `jlumbroso/free-disk-space` | (action) | `54081f138730dfa15788a46383842cd2f914a1be` | runner disk cleanup | 2026-05-04 |
-| `actions/checkout` | (action) | `3d3c42e5aac5ba805825da76410c181273ba90b1` | repo checkout | 2026-07-30 |
-| `actions/setup-python` | (action) | `5fda3b95a4ea91299a34e894583c3862153e4b97` | python setup | 2026-07-30 |
-| `actions/setup-go` | (action) | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` | go setup | 2026-07-30 |
-| `actions/create-github-app-token` | (action) | `bcd2ba49218906704ab6c1aa796996da409d3eb1` | App auth | 2026-07-30 |
-| `actions/upload-artifact` | (action) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | submission artifact upload | 2026-07-30 |
-| `actions/download-artifact` | (action) | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | submission artifact download | 2026-07-30 |
+| `actions/checkout` | (action) | `3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1) | repo checkout | 2026-07-30 |
+| `actions/setup-python` | (action) | `5fda3b95a4ea91299a34e894583c3862153e4b97` (v7.0.0) | python setup (`lean-eval-submissions`) | 2026-07-30 |
+| `actions/setup-go` | (action) | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` (v7.0.0) | go setup | 2026-07-30 |
+| `actions/create-github-app-token` | (action) | `bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0) | App auth | 2026-07-30 |
+| `actions/upload-artifact` | (action) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1) | submission artifact upload (`lean-eval-submissions`) | 2026-07-30 |
+| `actions/download-artifact` | (action) | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1) | submission artifact download (`lean-eval-submissions`) | 2026-07-30 |
 | `leanprover/lean-action` | (action) | `38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9` | Lean toolchain | 2026-05-04 |
 | Go toolchain | (setup-go arg) | `1.25.12` | concrete version, not `stable` | 2026-07-30 |
 | Python | (setup-python arg) | `3.11.10` | concrete patch version | 2026-05-04 |


### PR DESCRIPTION
## Summary

- pin all evaluation-pipeline JavaScript actions to maintained Node 24 releases at immutable SHAs
- disable setup-go caching because neither repository has a Go module dependency file
- pin Go 1.25.12; setup-go v7 enforces this exact local toolchain
- make checkout credential persistence explicit for both read-only CI and the authenticated regeneration push
- document action versions and cross-repository scope in the trusted-dependency table

Lockstep companion: leanprover/lean-eval-submissions#900.

## Verified pins

- `actions/checkout` v7.0.1 → `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `actions/setup-python` v7.0.0 → `5fda3b95a4ea91299a34e894583c3862153e4b97`
- `actions/setup-go` v7.0.0 → `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e`
- `actions/create-github-app-token` v3.2.0 → `bcd2ba49218906704ab6c1aa796996da409d3eb1`
- `actions/upload-artifact` v7.0.1 → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
- `actions/download-artifact` v8.0.1 → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`

Each pinned action manifest was also checked for `runs.using: node24`; the remaining third-party actions are composite actions.

## Validation

- `python scripts/action_pin_audit.py`
- parsed all workflow YAML with Python/PyYAML
- `git diff --check`
- GitHub CI exercises checkout/setup-go and the Go-built sandbox directly