### PR TITLE
ci: use GitHub App client ID

### DIFF
--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -30,7 +30,7 @@ jobs:
         # actions/create-github-app-token pinned to bcd2ba49 (= refs/tags/v3.2.0 as of 2026-07-30).
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ secrets.LEAN_EVAL_REGENERATOR_APP_ID }}
+          client-id: ${{ secrets.LEAN_EVAL_REGENERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LEAN_EVAL_REGENERATOR_PRIVATE_KEY }}
 
       # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -9,7 +9,7 @@ posture from this file alone — no UI screenshots, no tribal knowledge.
 
 | Item | Type | Stored as | Used by |
 | --- | --- | --- | --- |
-| `lean-eval-regenerator` | GitHub App (owner: `kim-em`) | `LEAN_EVAL_REGENERATOR_APP_ID`, `LEAN_EVAL_REGENERATOR_PRIVATE_KEY` | `regenerate-main.yml` |
+| `lean-eval-regenerator` | GitHub App (owner: `kim-em`) | `LEAN_EVAL_REGENERATOR_CLIENT_ID`, `LEAN_EVAL_REGENERATOR_PRIVATE_KEY` | `regenerate-main.yml` |
 | `LEADERBOARD_WRITE_TOKEN` | Fine-grained PAT | `LEADERBOARD_WRITE_TOKEN` (in both `leanprover/lean-eval` and `leanprover/lean-eval-leaderboard`) | `notify-leaderboard.yml` (this repo); `bump-benchmark-snapshot.yml` (leaderboard) |
 | Ruleset `main protection` | Repository Ruleset | (config in this repo, applied via API) | branch protection on `main` |
 
@@ -35,6 +35,7 @@ branch protection.
 ### App settings
 
 - Owner account: `kim-em` (User account).
+- App ID: `3554839` (public identifier used by the ruleset bypass actor).
 - Webhook: deactivated.
 - Repository permissions:
   - `Contents: Read and write`
@@ -45,7 +46,8 @@ branch protection.
 
 ### Repository secrets (in `leanprover/lean-eval`)
 
-- `LEAN_EVAL_REGENERATOR_APP_ID` — the App ID number.
+- `LEAN_EVAL_REGENERATOR_CLIENT_ID` — the app's Client ID. It is public,
+  but stored as a secret to keep the workflow's app inputs together.
 - `LEAN_EVAL_REGENERATOR_PRIVATE_KEY` — the full PEM contents of a private
   key generated for the app.
 
@@ -53,7 +55,8 @@ branch protection.
 
 [`.github/workflows/regenerate-main.yml`](../.github/workflows/regenerate-main.yml),
 in the `Mint lean-eval-regenerator installation token` step, via
-`actions/create-github-app-token@v1`. The token is used both for
+`actions/create-github-app-token`, pinned to
+`bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0). The token is used both for
 `actions/checkout` (so subsequent `git push` carries the same auth) and
 for the explicit push step that lands the regenerated workspaces on
 `main`.
@@ -80,13 +83,14 @@ fallback steps:
    - Repository permissions → Contents: Read and write (everything else
      stays "No access")
    - Where can this GitHub App be installed: **Any account**
-3. Save → record the App ID.
+3. Save → record both the App ID (for the ruleset bypass actor) and the
+   Client ID (for token minting).
 4. Generate a private key, download the `.pem`.
 5. Install the app on `leanprover/lean-eval` only (Org owner must do this
    if the repo is in an org with restricted third-party app access).
 6. Set the secrets:
    ```bash
-   gh secret set LEAN_EVAL_REGENERATOR_APP_ID -R leanprover/lean-eval --body <APP_ID>
+   gh secret set LEAN_EVAL_REGENERATOR_CLIENT_ID -R leanprover/lean-eval --body <CLIENT_ID>
    gh secret set LEAN_EVAL_REGENERATOR_PRIVATE_KEY -R leanprover/lean-eval < path/to/key.pem
    ```
 7. Add the App ID to the `main` ruleset's bypass list (see Ruleset

--- a/scripts/create_regenerator_app.py
+++ b/scripts/create_regenerator_app.py
@@ -34,7 +34,8 @@ MANIFEST = {
     "url": "https://github.com/leanprover/lean-eval",
     "hook_attributes": {"active": False, "url": "https://example.com/unused"},
     "redirect_url": f"http://localhost:{PORT}/callback",
-    "public": False,
+    # The user-owned app must be installable on the leanprover organization.
+    "public": True,
     "default_permissions": {"contents": "write"},
     "default_events": [],
 }
@@ -108,10 +109,18 @@ def main():
 
     server.shutdown()
 
-    if "id" not in result:
-        print("conversion did not return an app:", result, file=sys.stderr); sys.exit(1)
+    required_fields = {"id", "client_id", "pem", "slug", "html_url"}
+    missing_fields = required_fields - result.keys()
+    if missing_fields:
+        print(
+            "conversion response missing fields: "
+            + ", ".join(sorted(missing_fields)),
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     app_id = result["id"]
+    client_id = result["client_id"]
     pem = result["pem"]
     slug = result["slug"]
     html_url = result["html_url"]
@@ -120,6 +129,7 @@ def main():
     print(f"  Name: {result.get('name')}")
     print(f"  Slug: {slug}")
     print(f"  ID:   {app_id}")
+    print(f"  Client ID: {client_id}")
     print(f"  URL:  {html_url}")
 
     # Persist PEM to disk in case secret-set fails — user can rerun manually.
@@ -134,8 +144,8 @@ def main():
     # Set the repo secrets via gh CLI.
     print(f"\nSetting repo secrets on {REPO}…", flush=True)
     subprocess.run(
-        ["gh", "secret", "set", "LEAN_EVAL_REGENERATOR_APP_ID",
-         "-R", REPO, "--body", str(app_id)],
+        ["gh", "secret", "set", "LEAN_EVAL_REGENERATOR_CLIENT_ID",
+         "-R", REPO, "--body", client_id],
         check=True,
     )
     with open(pem_path) as f:
@@ -155,7 +165,10 @@ def main():
 
     print(f"\n=> Now click this to install on the repo (1 click + select repo + confirm):")
     print(f"   {html_url}/installations/new")
-    print(f"\n=> When done, tell Claude the App ID is {app_id}.")
+    print(
+        f"\n=> When done, tell Claude the App ID is {app_id} "
+        f"and the Client ID is {client_id}."
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace deprecated `app-id` with `client-id` for create-github-app-token v3
- document and provision the Client ID while retaining the App ID for ruleset reconstruction
- fix the app manifest helper so a user-owned app can be installed on the leanprover organization
- validate required manifest conversion fields without printing response values

## Evidence
- post-merge workflow run 30599272447 succeeded but emitted two `app-id` deprecation annotations
- `LEAN_EVAL_REGENERATOR_CLIENT_ID` is present in repository secrets
- local workflow YAML, Python syntax, manifest setting, action-pin audit, stale-input scan, and `git diff --check` pass

## Landing validation
After merge, dispatch `regenerate-main.yml` and require a successful token/checkout path with zero warning annotations before deleting the now-unused legacy App ID secret.
