### PR TITLE
docs: clarify Riesz brothers formal target

### DIFF
--- a/LeanEval/Analysis/RieszBrothers.lean
+++ b/LeanEval/Analysis/RieszBrothers.lean
@@ -21,9 +21,9 @@ open MeasureTheory
 
 /-- **Riesz brothers' theorem.** Let `μ` be a complex Borel measure on
 the unit circle such that `∫ z^n dμ = 0` for every `n ≥ 1`. Then `μ` is
-absolutely continuous with respect to Haar measure, and more precisely
-`dμ = h dm` for some `h ∈ H^1`, i.e. some integrable density whose negative
-Fourier coefficients vanish. -/
+absolutely continuous with respect to Haar measure. The usual density
+formulation follows from this by the Radon–Nikodym theorem together with the
+hypothesis, but that corollary is not part of the formal statement here. -/
 @[eval_problem]
 theorem riesz_brothers_theorem (μ : ComplexMeasure UnitAddCircle)
     (hμ : ∀ n : ℕ, 1 ≤ n → ∫ᵛ z, fourier n z ∂[ContinuousLinearMap.mul ℝ ℂ; μ] = 0) :

--- a/LeanEval/Analysis/RieszBrothers.lean
+++ b/LeanEval/Analysis/RieszBrothers.lean
@@ -22,8 +22,9 @@ open MeasureTheory
 /-- **Riesz brothers' theorem.** Let `μ` be a complex Borel measure on
 the unit circle such that `∫ z^n dμ = 0` for every `n ≥ 1`. Then `μ` is
 absolutely continuous with respect to Haar measure. The usual density
-formulation follows from this by the Radon–Nikodym theorem together with the
-hypothesis, but that corollary is not part of the formal statement here. -/
+formulation follows by applying the Radon–Nikodym theorem to this conclusion;
+the hypothesis transfers the Fourier-vanishing property to that density. This
+corollary is not part of the formal statement here. -/
 @[eval_problem]
 theorem riesz_brothers_theorem (μ : ComplexMeasure UnitAddCircle)
     (hμ : ∀ n : ℕ, 1 ≤ n → ∫ᵛ z, fourier n z ∂[ContinuousLinearMap.mul ℝ ℂ; μ] = 0) :


### PR DESCRIPTION
Clarify that the formal Riesz brothers target asks only for absolute continuity with respect to Haar measure.

The usual density formulation is now described as a Radon–Nikodym corollary rather than as part of the formal conclusion. This removes the apparent informal/formal mismatch without changing the benchmark statement.

Validated with:
- `lake build LeanEval.Analysis.RieszBrothers`
- `lake exe lean-eval check-problem-build`