### PR TITLE
feat(EvalTools): fail validation on problem modules no manifest reaches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,9 @@ jobs:
       - name: Run Generate Tests
         run: lake exe test_generate
 
+      - name: Run Module Coverage Tests
+        run: lake exe test_module_coverage
+
       - name: Run Comparator Installation Checks
         run: |
           lake exe test_check_comparator_installation

--- a/EvalTools/Manifest.lean
+++ b/EvalTools/Manifest.lean
@@ -42,8 +42,18 @@ def loadManifest (root : System.FilePath) : IO (Array EvalProblemMetadata) := do
       s!"Manifest directory `{manifestDir}` does not exist or is not a directory."
   let mut rawFiles : Array System.FilePath := #[]
   for entry in (← manifestDir.readDir) do
-    if entry.path.extension == some "toml" then
-      rawFiles := rawFiles.push entry.path
+    -- Reject rather than skip: a manifest saved as `<id>.lean` used to drop out
+    -- of the catalog silently, taking its problem module with it (issue #519).
+    -- Dotfiles are the one exception, so a stray `.DS_Store` cannot wedge CI.
+    if entry.fileName.startsWith "." then
+      continue
+    if ← entry.path.isDir then
+      throw <| IO.userError
+        s!"`{entry.path}` is a directory; `manifests/problems/` holds one `<id>.toml` file per problem."
+    unless entry.path.extension == some "toml" do
+      throw <| IO.userError
+        s!"`{entry.path}` is not a `.toml` file; `manifests/problems/` holds one `<id>.toml` file per problem."
+    rawFiles := rawFiles.push entry.path
   let files := rawFiles.qsort fun a b =>
     (a.fileName.getD "") < (b.fileName.getD "")
   let mut entries : Array EvalProblemMetadata := #[]

--- a/EvalTools/Manifest.lean
+++ b/EvalTools/Manifest.lean
@@ -44,8 +44,11 @@ def loadManifest (root : System.FilePath) : IO (Array EvalProblemMetadata) := do
   for entry in (← manifestDir.readDir) do
     -- Reject rather than skip: a manifest saved as `<id>.lean` used to drop out
     -- of the catalog silently, taking its problem module with it (issue #519).
-    -- Dotfiles are the one exception, so a stray `.DS_Store` cannot wedge CI.
-    if entry.fileName.startsWith "." then
+    -- The exemption is `.DS_Store` alone, not dotfiles in general: the
+    -- `@[eval_problem]` elaborator reads every `*.toml` here (`Markers.lean`),
+    -- so skipping a hidden `.foo.toml` would let it claim a tagged declaration
+    -- that never reaches the catalog.
+    if entry.fileName == ".DS_Store" then
       continue
     if ← entry.path.isDir then
       throw <| IO.userError

--- a/EvalTools/Markers.lean
+++ b/EvalTools/Markers.lean
@@ -32,6 +32,13 @@ lives in its own file `manifests/problems/<id>.toml` with top-level keys. -/
 def manifestRelativePath : System.FilePath :=
   "manifests" / "problems"
 
+/-- Read a manifest `module` field as a module name: every `.` separates
+components, so `LeanEval.Foo.Bar` is `LeanEval/Foo/Bar.lean` and never
+`LeanEval/Foo.Bar.lean`. The inventory and extractor executables resolve the
+same field the same way; the two must agree or they address different files. -/
+def parseModuleName (text : String) : Name :=
+  text.splitOn "." |>.foldl Name.str .anonymous
+
 /-- Walk up from `dir` searching for the manifest directory
 `manifests/problems/`. Returns the directory itself if found. -/
 partial def findManifestPath? (dir : System.FilePath) : IO (Option System.FilePath) := do

--- a/EvalTools/ModuleCoverage.lean
+++ b/EvalTools/ModuleCoverage.lean
@@ -12,26 +12,30 @@ root. Its module prefix is the directory name. -/
 def problemSourceRelativePath : System.FilePath := "LeanEval"
 
 /-- A `.lean` file under `LeanEval/`, together with the modules its header
-imports. -/
+imports.
+
+Module identity is a `Name`, not a string: `LeanEval/Foo/Bar.lean` is
+`LeanEval.Foo.Bar` while `LeanEval/Foo.Bar.lean` is `LeanEval.«Foo.Bar»`, and
+flattening either to text would conflate two distinct files. -/
 structure ProblemSourceModule where
   /-- Fully qualified module name, for example
   `LeanEval.Geometry.JacobianChallenge`. -/
-  name : String
+  name : Name
   /-- Path of the file, relative to the repository root. -/
   path : String
-  /-- Module names in the file's `import` header, verbatim. -/
-  imports : Array String
+  /-- The modules named in the file's `import` header. -/
+  imports : Array Name
   deriving Inhabited, Repr
 
 private def sourcesByName (sources : Array ProblemSourceModule) :
-    Std.HashMap String ProblemSourceModule :=
+    Std.HashMap Name ProblemSourceModule :=
   sources.foldl (fun m source => m.insert source.name source) ∅
 
 /-- Mark `name` and everything it transitively imports as reached. Imports that
 name no module in `byName` (Mathlib, `EvalTools.Markers`, ...) are recorded but
 not followed. -/
-private partial def markReachable (byName : Std.HashMap String ProblemSourceModule)
-    (reached : Std.HashSet String) (name : String) : Std.HashSet String :=
+private partial def markReachable (byName : Std.HashMap Name ProblemSourceModule)
+    (reached : Std.HashSet Name) (name : Name) : Std.HashSet Name :=
   if reached.contains name then
     reached
   else
@@ -42,8 +46,8 @@ private partial def markReachable (byName : Std.HashMap String ProblemSourceModu
 
 /-- The modules of `sources` that are neither listed in `roots` nor reachable
 from `roots` by following imports. Order follows `sources`. -/
-def unreachableModules (sources : Array ProblemSourceModule) (roots : Array String) :
-    Array String :=
+def unreachableModules (sources : Array ProblemSourceModule) (roots : Array Name) :
+    Array Name :=
   let byName := sourcesByName sources
   let reached := roots.foldl (markReachable byName) ∅
   sources.filterMap fun source =>
@@ -51,21 +55,30 @@ def unreachableModules (sources : Array ProblemSourceModule) (roots : Array Stri
 
 /-- Recursively collect the `.lean` files under `dir`, reading each header for
 its imports. `relDir` and `modulePrefix` describe `dir` itself. -/
-private partial def collectSourceModules (dir : System.FilePath) (relDir modulePrefix : String) :
-    IO (Array ProblemSourceModule) := do
+private partial def collectSourceModules (dir : System.FilePath) (relDir : String)
+    (modulePrefix : Name) : IO (Array ProblemSourceModule) := do
   let entries := (← dir.readDir).qsort fun a b => a.fileName < b.fileName
   let mut out : Array ProblemSourceModule := #[]
   for entry in entries do
-    if ← entry.path.isDir then
-      out := out ++ (← collectSourceModules entry.path
-        s!"{relDir}/{entry.fileName}" s!"{modulePrefix}.{entry.fileName}")
-    else if entry.path.extension == some "lean" then
-      let stem := (entry.fileName.dropEnd 5).toString
-      let header ← parseImports' (← IO.FS.readFile entry.path) entry.path.toString
-      out := out.push
-        { name := s!"{modulePrefix}.{stem}"
-          path := s!"{relDir}/{entry.fileName}"
-          imports := header.imports.map (·.module.toString) }
+    let relPath := s!"{relDir}/{entry.fileName}"
+    -- `symlinkMetadata` rather than `isDir`: the latter follows links, so a
+    -- directory symlink could duplicate a subtree under a second module prefix,
+    -- or point at an ancestor and recurse forever.
+    match (← entry.path.symlinkMetadata).type with
+    | .symlink =>
+        throw <| IO.userError
+          s!"`{relPath}` is a symbolic link. Problem sources must be regular files and \
+             directories, so that a file's path determines its module name."
+    | .dir =>
+        out := out ++ (← collectSourceModules entry.path relPath (modulePrefix.str entry.fileName))
+    | _ =>
+        if entry.path.extension == some "lean" then
+          let stem := (entry.fileName.dropEnd 5).toString
+          let header ← parseImports' (← IO.FS.readFile entry.path) entry.path.toString
+          out := out.push
+            { name := modulePrefix.str stem
+              path := relPath
+              imports := header.imports.map (·.module) }
   return out
 
 /-- Fail unless every `.lean` file under `LeanEval/` is reachable from the
@@ -85,17 +98,17 @@ def checkProblemModuleCoverage
     throw <| IO.userError
       s!"Problem source directory `{sourceRoot}` does not exist or is not a directory."
   let prefixName := problemSourceRelativePath.toString
-  let sources ← collectSourceModules sourceRoot prefixName prefixName
-  let known := sources.foldl (fun s source => s.insert source.name) (∅ : Std.HashSet String)
+  let sources ← collectSourceModules sourceRoot prefixName (.str .anonymous prefixName)
+  let known := sources.foldl (fun s source => s.insert source.name) (∅ : Std.HashSet Name)
   let missing := entries.filterMap fun entry =>
-    if known.contains entry.moduleName then none
+    if known.contains (parseModuleName entry.moduleName) then none
     else some s!"  {entry.moduleName} (manifests/problems/{entry.id}.toml)"
   if !missing.isEmpty then
     throw <| IO.userError <|
       "Manifest entries name modules that have no source file under `LeanEval/`:\n"
         ++ "\n".intercalate missing.toList
         ++ "\nCheck the `module` field for a typo, or add the missing file."
-  let unreachable := unreachableModules sources (entries.map (·.moduleName))
+  let unreachable := unreachableModules sources (entries.map (parseModuleName ·.moduleName))
   if !unreachable.isEmpty then
     let byName := sourcesByName sources
     let described := unreachable.map fun name =>
@@ -108,6 +121,7 @@ def checkProblemModuleCoverage
         ++ "\nEvery file under `LeanEval/` must be named by the `module` field of some \
             `manifests/problems/<id>.toml`, or be imported (directly or transitively) by a \
             module that is. If you did write a manifest for one of these, check that it sits \
-            in `manifests/problems/` and that its name ends in `.toml`."
+            in `manifests/problems/` and that its name ends in `.toml`; if the file is a \
+            leftover, delete it."
 
 end EvalTools

--- a/EvalTools/ModuleCoverage.lean
+++ b/EvalTools/ModuleCoverage.lean
@@ -1,0 +1,113 @@
+import Lean
+import EvalTools.Markers
+
+open Lean
+
+namespace EvalTools
+
+set_option autoImplicit false
+
+/-- Directory holding the trusted problem sources, relative to the repository
+root. Its module prefix is the directory name. -/
+def problemSourceRelativePath : System.FilePath := "LeanEval"
+
+/-- A `.lean` file under `LeanEval/`, together with the modules its header
+imports. -/
+structure ProblemSourceModule where
+  /-- Fully qualified module name, for example
+  `LeanEval.Geometry.JacobianChallenge`. -/
+  name : String
+  /-- Path of the file, relative to the repository root. -/
+  path : String
+  /-- Module names in the file's `import` header, verbatim. -/
+  imports : Array String
+  deriving Inhabited, Repr
+
+private def sourcesByName (sources : Array ProblemSourceModule) :
+    Std.HashMap String ProblemSourceModule :=
+  sources.foldl (fun m source => m.insert source.name source) ∅
+
+/-- Mark `name` and everything it transitively imports as reached. Imports that
+name no module in `byName` (Mathlib, `EvalTools.Markers`, ...) are recorded but
+not followed. -/
+private partial def markReachable (byName : Std.HashMap String ProblemSourceModule)
+    (reached : Std.HashSet String) (name : String) : Std.HashSet String :=
+  if reached.contains name then
+    reached
+  else
+    let reached := reached.insert name
+    match byName[name]? with
+    | none => reached
+    | some source => source.imports.foldl (markReachable byName) reached
+
+/-- The modules of `sources` that are neither listed in `roots` nor reachable
+from `roots` by following imports. Order follows `sources`. -/
+def unreachableModules (sources : Array ProblemSourceModule) (roots : Array String) :
+    Array String :=
+  let byName := sourcesByName sources
+  let reached := roots.foldl (markReachable byName) ∅
+  sources.filterMap fun source =>
+    if reached.contains source.name then none else some source.name
+
+/-- Recursively collect the `.lean` files under `dir`, reading each header for
+its imports. `relDir` and `modulePrefix` describe `dir` itself. -/
+private partial def collectSourceModules (dir : System.FilePath) (relDir modulePrefix : String) :
+    IO (Array ProblemSourceModule) := do
+  let entries := (← dir.readDir).qsort fun a b => a.fileName < b.fileName
+  let mut out : Array ProblemSourceModule := #[]
+  for entry in entries do
+    if ← entry.path.isDir then
+      out := out ++ (← collectSourceModules entry.path
+        s!"{relDir}/{entry.fileName}" s!"{modulePrefix}.{entry.fileName}")
+    else if entry.path.extension == some "lean" then
+      let stem := (entry.fileName.dropEnd 5).toString
+      let header ← parseImports' (← IO.FS.readFile entry.path) entry.path.toString
+      out := out.push
+        { name := s!"{modulePrefix}.{stem}"
+          path := s!"{relDir}/{entry.fileName}"
+          imports := header.imports.map (·.module.toString) }
+  return out
+
+/-- Fail unless every `.lean` file under `LeanEval/` is reachable from the
+manifest: either named by some entry's `module` field, or imported (directly or
+transitively) by a module that is.
+
+Nothing else walks the problem sources, so a module the manifest cannot reach is
+never compiled and never validated; it can carry a broken statement and leave CI
+green. See https://github.com/leanprover/lean-eval/issues/519.
+
+This is a header-level check: it parses imports rather than building anything,
+so it costs no build time and runs before the inventory cross-check. -/
+def checkProblemModuleCoverage
+    (root : System.FilePath) (entries : Array EvalProblemMetadata) : IO Unit := do
+  let sourceRoot := root / problemSourceRelativePath
+  unless ← sourceRoot.isDir do
+    throw <| IO.userError
+      s!"Problem source directory `{sourceRoot}` does not exist or is not a directory."
+  let prefixName := problemSourceRelativePath.toString
+  let sources ← collectSourceModules sourceRoot prefixName prefixName
+  let known := sources.foldl (fun s source => s.insert source.name) (∅ : Std.HashSet String)
+  let missing := entries.filterMap fun entry =>
+    if known.contains entry.moduleName then none
+    else some s!"  {entry.moduleName} (manifests/problems/{entry.id}.toml)"
+  if !missing.isEmpty then
+    throw <| IO.userError <|
+      "Manifest entries name modules that have no source file under `LeanEval/`:\n"
+        ++ "\n".intercalate missing.toList
+        ++ "\nCheck the `module` field for a typo, or add the missing file."
+  let unreachable := unreachableModules sources (entries.map (·.moduleName))
+  if !unreachable.isEmpty then
+    let byName := sourcesByName sources
+    let described := unreachable.map fun name =>
+      match byName[name]? with
+      | some source => s!"  {name} ({source.path})"
+      | none => s!"  {name}"
+    throw <| IO.userError <|
+      "No manifest entry reaches the following module(s), so CI never builds them:\n"
+        ++ "\n".intercalate described.toList
+        ++ "\nEvery file under `LeanEval/` must be named by the `module` field of some \
+            `manifests/problems/<id>.toml`, or be imported (directly or transitively) by a \
+            module that is. If you did write a manifest for one of these, check that it sits \
+            in `manifests/problems/` and that its name ends in `.toml`."
+
+end EvalTools

--- a/EvalTools/ProblemInventory.lean
+++ b/EvalTools/ProblemInventory.lean
@@ -13,9 +13,6 @@ structure InventoryEntry where
   kind : String
   deriving ToJson
 
-def parseName (text : String) : Name :=
-  text.splitOn "." |>.foldl Name.str .anonymous
-
 def lastComponent (name : Name) : String :=
   match name with
   | .str _ s => s
@@ -48,7 +45,7 @@ def inventoryForModule (env : Environment) (moduleName : Name) : Array Inventory
 
 def main (args : List String) : IO UInt32 := do
   initSearchPath (← findSysroot)
-  let moduleNames := args.map parseName
+  let moduleNames := args.map EvalTools.parseModuleName
   let env ← importModules (moduleNames.toArray.map fun moduleName => ({ module := moduleName } : Import)) {}
   let entries := moduleNames.foldl (fun acc moduleName => acc ++ inventoryForModule env moduleName) #[]
   IO.println <| Json.pretty <| toJson entries

--- a/EvalTools/ValidateManifest.lean
+++ b/EvalTools/ValidateManifest.lean
@@ -1,12 +1,18 @@
 import EvalTools.Manifest
+import EvalTools.ModuleCoverage
 
 namespace EvalTools
 
 set_option autoImplicit false
 
 /-- Implementation of `lake exe lean-eval validate-manifest`. Loads the
-manifest (which already enforces id/holes/duplication rules) and cross-checks
-against the `@[eval_problem]` inventory built from source.
+manifest (which already enforces id/holes/duplication rules), checks that it
+reaches every problem module, and cross-checks against the `@[eval_problem]`
+inventory built from source.
+
+The coverage check comes first because it is the only one that does not need a
+build, and because the inventory cross-check is blind to modules the manifest
+never names.
 
 The Python original also called `gp.validate_hole_shape`, a textual pre-check
 for typos in hole names. That check is purely redundant with the inventory
@@ -14,6 +20,7 @@ cross-check (which goes through the elaborator), so it is dropped here. -/
 def runValidateManifest (root : System.FilePath) : IO UInt32 := do
   try
     let entries ← loadManifest root
+    checkProblemModuleCoverage root entries
     validateManifestAgainstInventory root entries
     IO.println "Manifest and @[eval_problem] declarations are consistent."
     return 0

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ The required fields are:
 The one-file-per-problem layout means two PRs adding distinct problems
 never conflict on the manifest.
 
+The manifest is the only entry point CI has into `LeanEval/`, so a module
+no manifest names is never built. `validate-manifest` therefore rejects any
+`.lean` file under `LeanEval/` that is neither named by some `module` field
+nor imported (directly or transitively) by a module that is, and rejects any
+file in `manifests/problems/` that is not a `.toml`.
+
 #### Multi-hole problems
 
 A problem may bundle several `def`s, `instance`s and `theorem`s — list
@@ -106,7 +112,8 @@ lake exe lean-eval check-problem-build
 ```
 
 `validate-manifest` checks that `@[eval_problem]` declarations and manifest entries
-match. `check-problem-build` builds the problem modules so warning-producing Lean changes
+match, and that no module under `LeanEval/` escapes the manifest's reach.
+`check-problem-build` builds the problem modules so warning-producing Lean changes
 do not slip through. Both catch the most common mistakes before a CI roundtrip;
 on a clean checkout, validating the full problem inventory can take some time.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -46,3 +46,8 @@ root = "EvalToolsTests.CheckComparatorInstallationTest"
 name = "test_generate"
 srcDir = "tests/lean"
 root = "EvalToolsTests.GenerateTest"
+
+[[lean_exe]]
+name = "test_module_coverage"
+srcDir = "tests/lean"
+root = "EvalToolsTests.ModuleCoverageTest"

--- a/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
+++ b/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
@@ -1,0 +1,130 @@
+import EvalTools.Manifest
+import EvalTools.ModuleCoverage
+
+open EvalTools
+
+set_option autoImplicit false
+
+private def assertEq {α : Type} [BEq α] [Repr α] (label : String)
+    (actual expected : α) : Option String :=
+  if actual == expected then none
+  else some s!"{label}: expected {repr expected}, got {repr actual}"
+
+private def assertContains (label haystack needle : String) : Option String :=
+  if (haystack.find? needle).isSome then none
+  else some s!"{label}: expected to contain {repr needle}, got {repr haystack}"
+
+private def check (label : String) (passes fails : IO.Ref Nat)
+    (f : IO (Option String)) : IO Unit := do
+  match ← f.toBaseIO with
+  | .ok none => IO.println s!"PASS: {label}"; passes.modify (· + 1)
+  | .ok (some reason) =>
+      IO.eprintln s!"FAIL: {label} — {reason}"
+      fails.modify (· + 1)
+  | .error err =>
+      IO.eprintln s!"FAIL: {label} — unexpected exception: {err}"
+      fails.modify (· + 1)
+
+private def source (name : String) (imports : Array String) : ProblemSourceModule :=
+  { name := name, path := name.replace "." "/" ++ ".lean", imports := imports }
+
+/-- A minimal repository: `manifests/problems/` plus a `LeanEval/` tree written
+from `(relative path, contents)` pairs. -/
+private def withFakeRepo (files : Array (String × String))
+    (f : System.FilePath → IO (Option String)) : IO (Option String) := do
+  let root ← IO.FS.createTempDir
+  try
+    IO.FS.createDirAll (root / "manifests" / "problems")
+    for (relPath, contents) in files do
+      let path := relPath.splitOn "/" |>.foldl (init := root) (· / ·)
+      if let some parent := path.parent then
+        IO.FS.createDirAll parent
+      IO.FS.writeFile path contents
+    f root
+  finally
+    try IO.FS.removeDirAll root catch _ => pure ()
+
+private def problem (id moduleName : String) : EvalProblemMetadata :=
+  { id := id, title := id, test := false, moduleName := moduleName,
+    holes := #["hole"], submitter := "tester" }
+
+def main : IO UInt32 := do
+  let passes ← IO.mkRef 0
+  let fails ← IO.mkRef 0
+
+  -- Regression for https://github.com/leanprover/lean-eval/issues/519: a module
+  -- no manifest reaches is never compiled, so a broken statement leaves CI green.
+  check "unreachableModules reports a module no root reaches" passes fails do
+    let sources := #[source "LeanEval.A" #[], source "LeanEval.Orphan" #[]]
+    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"])
+      #["LeanEval.Orphan"]
+
+  check "unreachableModules follows imports transitively" passes fails do
+    let sources := #[
+      source "LeanEval.A" #["Mathlib", "LeanEval.B"],
+      source "LeanEval.B" #["LeanEval.C"],
+      source "LeanEval.C" #[]]
+    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"]) #[]
+
+  -- Import cycles cannot occur in Lean, but the walk must not diverge if the
+  -- headers on disk describe one.
+  check "unreachableModules terminates on a cycle" passes fails do
+    let sources := #[
+      source "LeanEval.A" #["LeanEval.B"],
+      source "LeanEval.B" #["LeanEval.A"],
+      source "LeanEval.Orphan" #["LeanEval.Orphan"]]
+    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"])
+      #["LeanEval.Orphan"]
+
+  -- Reachability is directed: importing a root does not make you reachable.
+  check "unreachableModules does not follow imports backwards" passes fails do
+    let sources := #[source "LeanEval.A" #[], source "LeanEval.Importer" #["LeanEval.A"]]
+    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"])
+      #["LeanEval.Importer"]
+
+  check "checkProblemModuleCoverage accepts a transitively imported module" passes fails do
+    withFakeRepo
+      #[("LeanEval/Claimed.lean", "import Mathlib\nimport LeanEval.Helper\n"),
+        ("LeanEval/Helper.lean", "import Mathlib\n")] fun root => do
+      match ← (checkProblemModuleCoverage root #[problem "claimed" "LeanEval.Claimed"]).toBaseIO with
+      | .ok _ => pure none
+      | .error err => pure (some s!"expected success, got {err}")
+
+  check "checkProblemModuleCoverage rejects an unreached module" passes fails do
+    withFakeRepo
+      #[("LeanEval/Claimed.lean", "import Mathlib\n"),
+        ("LeanEval/Nested/Orphan.lean", "import Mathlib\n")] fun root => do
+      match ← (checkProblemModuleCoverage root #[problem "claimed" "LeanEval.Claimed"]).toBaseIO with
+      | .ok _ => pure (some "expected rejection")
+      | .error err =>
+          let err := toString err
+          pure <| (assertContains "err" err "LeanEval.Nested.Orphan").or
+            (assertContains "err" err "LeanEval/Nested/Orphan.lean")
+
+  check "checkProblemModuleCoverage rejects a manifest module with no source file" passes fails do
+    withFakeRepo #[("LeanEval/Claimed.lean", "import Mathlib\n")] fun root => do
+      match ← (checkProblemModuleCoverage root #[problem "claimed" "LeanEval.Clamied"]).toBaseIO with
+      | .ok _ => pure (some "expected rejection")
+      | .error err =>
+          pure <| assertContains "err" (toString err) "LeanEval.Clamied"
+
+  -- Regression for https://github.com/leanprover/lean-eval/pull/513: a manifest
+  -- committed as `<id>.lean` was silently skipped, so its module never built.
+  check "loadManifest rejects a non-toml manifest file" passes fails do
+    withFakeRepo #[("manifests/problems/direct_summand.lean", "id = \"direct_summand\"\n")]
+      fun root => do
+        match ← (loadManifest root).toBaseIO with
+        | .ok _ => pure (some "expected rejection")
+        | .error err =>
+            pure <| assertContains "err" (toString err) "is not a `.toml` file"
+
+  check "loadManifest ignores dotfiles" passes fails do
+    withFakeRepo #[("manifests/problems/.DS_Store", "junk\n")] fun root => do
+      match ← (loadManifest root).toBaseIO with
+      | .ok entries => pure <| assertEq "entries" entries.size 0
+      | .error err => pure (some s!"expected success, got {err}")
+
+  let passCount ← passes.get
+  let failCount ← fails.get
+  IO.println s!"\n{passCount} passed, {failCount} failed."
+  return if failCount == 0 then 0 else 1

--- a/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
+++ b/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
@@ -26,7 +26,11 @@ private def check (label : String) (passes fails : IO.Ref Nat)
       fails.modify (· + 1)
 
 private def source (name : String) (imports : Array String) : ProblemSourceModule :=
-  { name := name, path := name.replace "." "/" ++ ".lean", imports := imports }
+  { name := parseModuleName name, path := name.replace "." "/" ++ ".lean",
+    imports := imports.map parseModuleName }
+
+private def moduleNames (names : Array Lean.Name) : Array String :=
+  names.map toString
 
 /-- A minimal repository: `manifests/problems/` plus a `LeanEval/` tree written
 from `(relative path, contents)` pairs. -/
@@ -56,15 +60,16 @@ def main : IO UInt32 := do
   -- no manifest reaches is never compiled, so a broken statement leaves CI green.
   check "unreachableModules reports a module no root reaches" passes fails do
     let sources := #[source "LeanEval.A" #[], source "LeanEval.Orphan" #[]]
-    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"])
-      #["LeanEval.Orphan"]
+    pure <| assertEq "unreachable"
+      (moduleNames (unreachableModules sources #[`LeanEval.A])) #["LeanEval.Orphan"]
 
   check "unreachableModules follows imports transitively" passes fails do
     let sources := #[
       source "LeanEval.A" #["Mathlib", "LeanEval.B"],
       source "LeanEval.B" #["LeanEval.C"],
       source "LeanEval.C" #[]]
-    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"]) #[]
+    pure <| assertEq "unreachable"
+      (moduleNames (unreachableModules sources #[`LeanEval.A])) #[]
 
   -- Import cycles cannot occur in Lean, but the walk must not diverge if the
   -- headers on disk describe one.
@@ -73,14 +78,37 @@ def main : IO UInt32 := do
       source "LeanEval.A" #["LeanEval.B"],
       source "LeanEval.B" #["LeanEval.A"],
       source "LeanEval.Orphan" #["LeanEval.Orphan"]]
-    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"])
-      #["LeanEval.Orphan"]
+    pure <| assertEq "unreachable"
+      (moduleNames (unreachableModules sources #[`LeanEval.A])) #["LeanEval.Orphan"]
 
   -- Reachability is directed: importing a root does not make you reachable.
   check "unreachableModules does not follow imports backwards" passes fails do
     let sources := #[source "LeanEval.A" #[], source "LeanEval.Importer" #["LeanEval.A"]]
-    pure <| assertEq "unreachable" (unreachableModules sources #["LeanEval.A"])
-      #["LeanEval.Importer"]
+    pure <| assertEq "unreachable"
+      (moduleNames (unreachableModules sources #[`LeanEval.A])) #["LeanEval.Importer"]
+
+  -- A dot in a filename is a component separator only in the path, not in the
+  -- module name: `LeanEval/Foo.Bar.lean` is `LeanEval.«Foo.Bar»`, a different
+  -- module from `LeanEval/Foo/Bar.lean`. Flattening both to the text
+  -- "LeanEval.Foo.Bar" would let a manifest entry for the nested file vouch for
+  -- the sibling, which Lake never builds.
+  check "checkProblemModuleCoverage separates Foo.Bar.lean from Foo/Bar.lean" passes fails do
+    withFakeRepo
+      #[("LeanEval/Foo/Bar.lean", "import Mathlib\n"),
+        ("LeanEval/Foo.Bar.lean", "import Mathlib\n")] fun root => do
+      match ← (checkProblemModuleCoverage root #[problem "bar" "LeanEval.Foo.Bar"]).toBaseIO with
+      | .ok _ => pure (some "expected rejection")
+      | .error err => pure <| assertContains "err" (toString err) "LeanEval/Foo.Bar.lean"
+
+  -- The escaped spelling in a header (`«Foo-Bar»`) and the plain spelling on
+  -- disk (`Foo-Bar.lean`) must resolve to the same module.
+  check "checkProblemModuleCoverage matches an escaped import" passes fails do
+    withFakeRepo
+      #[("LeanEval/Claimed.lean", "import LeanEval.«Foo-Bar»\n"),
+        ("LeanEval/Foo-Bar.lean", "import Mathlib\n")] fun root => do
+      match ← (checkProblemModuleCoverage root #[problem "claimed" "LeanEval.Claimed"]).toBaseIO with
+      | .ok _ => pure none
+      | .error err => pure (some s!"expected success, got {err}")
 
   check "checkProblemModuleCoverage accepts a transitively imported module" passes fails do
     withFakeRepo
@@ -118,11 +146,40 @@ def main : IO UInt32 := do
         | .error err =>
             pure <| assertContains "err" (toString err) "is not a `.toml` file"
 
-  check "loadManifest ignores dotfiles" passes fails do
+  check "loadManifest ignores .DS_Store" passes fails do
     withFakeRepo #[("manifests/problems/.DS_Store", "junk\n")] fun root => do
       match ← (loadManifest root).toBaseIO with
       | .ok entries => pure <| assertEq "entries" entries.size 0
       | .error err => pure (some s!"expected success, got {err}")
+
+  -- The `@[eval_problem]` elaborator reads every `*.toml` in the directory,
+  -- hidden or not. If `loadManifest` skipped hidden ones, a `.helper.toml`
+  -- could satisfy the attribute for a tagged declaration that never enters the
+  -- catalog, and the inventory cross-check would never look at its module.
+  check "loadManifest does not skip a hidden toml manifest" passes fails do
+    let hidden :=
+      "id = \".helper\"\n" ++
+      "title = \"Helper\"\n" ++
+      "test = false\n" ++
+      "module = \"LeanEval.Helper\"\n" ++
+      "holes = [\"hole\"]\n" ++
+      "submitter = \"tester\"\n"
+    withFakeRepo #[("manifests/problems/.helper.toml", hidden)] fun root => do
+      match ← (loadManifest root).toBaseIO with
+      | .ok _ => pure (some "expected rejection")
+      | .error err => pure <| assertContains "err" (toString err) "is invalid"
+
+  -- A directory symlink would either duplicate a subtree under a second module
+  -- prefix or, pointed at an ancestor, make the walk recurse forever.
+  check "checkProblemModuleCoverage rejects a symlink in the source tree" passes fails do
+    withFakeRepo #[("LeanEval/Claimed.lean", "import Mathlib\n")] fun root => do
+      IO.FS.createDirAll (root / "Elsewhere")
+      let _ ← IO.Process.run
+        { cmd := "ln", args := #["-s", (root / "Elsewhere").toString,
+                                 (root / "LeanEval" / "Linked").toString] }
+      match ← (checkProblemModuleCoverage root #[problem "claimed" "LeanEval.Claimed"]).toBaseIO with
+      | .ok _ => pure (some "expected rejection")
+      | .error err => pure <| assertContains "err" (toString err) "symbolic link"
 
   let passCount ← passes.get
   let failCount ← fails.get


### PR DESCRIPTION
This PR makes `validate-manifest` fail on any problem module the manifest cannot reach. It parses the header of every `.lean` file under `LeanEval/` and rejects the ones that are neither named by some manifest `module` field nor imported, directly or transitively, by a module that is. `manifests/problems/*.toml` is CI's only entry point into the problem sources, so an unreached module is never compiled and never validated: a new problem can be added with a broken statement and CI stays green. The check parses imports rather than building anything, so it costs no build time and runs before the inventory cross-check.

Two smaller guards come with it. `loadManifest` now rejects non-`.toml` files in `manifests/problems/` instead of skipping them silently, which is what let #513 land a manifest named `direct_summand.lean` and take its module out of the build with it; dotfiles are still ignored so a stray `.DS_Store` cannot wedge CI. And a manifest entry whose `module` names no file under `LeanEval/` is now reported as a typo rather than surfacing later as an unrelated-looking unreachable-module error.

`main` passes the new check as-is: 245 manifest entries name 229 of the 237 modules under `LeanEval/`, and the other 8 are imported by modules that are.

Fixes #519.

🤖 Prepared with Claude Code