### PR TITLE
fix: carry a declaration's scoped command prefix into the workspace

### DIFF
--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -930,6 +930,10 @@ private def stripLineComment (s : String) : String :=
   | x :: _ => x
   | [] => s
 
+/-- The tokens of `line` with comments removed. -/
+private def commandTokens (line : String) : Array String :=
+  splitWhitespace (stripLineComment (stripSingleLineBlockComments line))
+
 /-- True if `stripped` is a scoped `open … in …` line — the single-command
 form that binds an open to one following expression. Detected by an `in`
 token appearing somewhere after the leading `open` keyword. Top-level opens
@@ -940,6 +944,11 @@ def isScopedOpenLine (stripped : String) : Bool := Id.run do
   for i in [1:toks.size] do
     if toks[i]! == "in" then return true
   return false
+
+/-- True if `block` is the single-command `<command> … in` form, which binds to
+the declaration following it rather than to the rest of the enclosing section. -/
+def isScopedCommandBlock (block : String) : Bool :=
+  (commandTokens block).back? == some "in"
 
 /-- True if the upcoming lines starting at `peekIdx` (0-indexed) form the
 continuation of a scoped `open … in` — that is, after any blank or
@@ -1262,7 +1271,10 @@ delegation arguments derived from the source declaration would not fit. -/
 def extractContextIncludes (source : String) (extracted? : Option ExtractedTheorem) : String :=
   extractScopedCommandBlocksWhere source extracted?
     (fun stripped => startsWithKeyword stripped "include" || startsWithKeyword stripped "omit")
-    (fun _ => true)
+    -- The `include … in` form binds to the declaration after it. Hoisting one
+    -- out of an earlier declaration would change our signature; the one that
+    -- belongs to our own declaration comes through `extractDeclarationPrefix`.
+    (fun block => !isScopedCommandBlock block)
 
 /-- Collect notation, syntax, and macro commands still in scope at the target
 declaration. Generated statements retain their source notation, so these
@@ -1378,10 +1390,6 @@ def applyEdits (sourceText : String) (edits : Array (Nat × Nat × String)) : St
     result := Source.slice src 0 start ++ replacement ++ Source.slice src stop src.size
   return result
 
-/-- The tokens of `line` with comments removed. -/
-private def commandTokens (line : String) : Array String :=
-  splitWhitespace (stripLineComment (stripSingleLineBlockComments line))
-
 /-- Commands that can be written as `<command> … in <declaration>` to scope
 themselves onto a single following declaration. -/
 private def scopingCommandKeywords : Array String :=
@@ -1455,6 +1463,29 @@ def extendOverScopingPrefixes (source : Source) (lowerBound start : Nat) : Nat :
       result := if opensCommand commandIdx then lines[commandIdx]!.1 else lineStart
       idx := commandIdx
   return result
+
+/-- The end of the last declaration ending at or before `offset`, or
+`bodyStart` if there is none. Bounds a backward scan so that it cannot reach
+into the text of another declaration. -/
+def previousDeclarationEnd (spans : Array DeclSpan) (bodyStart offset : Nat) : Nat :=
+  spans.foldl (init := bodyStart) fun acc span =>
+    if span.declEnd ≤ offset then max acc span.declEnd else acc
+
+/-- The command prefixes that scope onto the declaration starting at
+`declarationStart` (`include … in`, `open … in`, `set_option … in`, …), as text
+to re-emit ahead of a restated statement.
+
+These forms bind to one following declaration, which is why the context
+collectors pass over them: hoisting one out of an earlier declaration would
+change the meaning of ours. The one attached to our own declaration is a
+different matter, and `include … in` especially so, since it decides which of
+the surrounding `variable` binders the declaration takes. Dropping it gives the
+restated statement a different signature from the source, and the delegation
+derived from the source no longer fits. -/
+def extractDeclarationPrefix (source : Source) (lowerBound declarationStart : Nat) : String :=
+  let prefixStart := extendOverScopingPrefixes source lowerBound declarationStart
+  let text := (Source.slice source prefixStart declarationStart).trimAscii.toString
+  if text.isEmpty then "" else text ++ "\n"
 
 /-- Shared core of single- and multi-hole `ChallengeDeps.lean` rendering.
 
@@ -1989,6 +2020,11 @@ private def renderWorkspaceSingleHole (root : System.FilePath) (entry : EvalProb
     extractContextVariables sourceText (some extracted) theoremBinderNames
   let contextIncludeBlock :=
     extractContextIncludes sourceText (some extracted)
+  -- A prefix scoped onto the target declaration itself belongs with the
+  -- restated statement, not with the surrounding context.
+  let declarationSpans ← loadDeclSpans root entry src
+  let declarationPrefix := extractDeclarationPrefix src
+    (previousDeclarationEnd declarationSpans (importPreludeLength src) startOff) startOff
   let signatureParams? :=
     if hasBareSorryBody declText then extracted.explicitParameters else none
   let some solutionArgs := delegationArgs? signatureParams?
@@ -2020,17 +2056,17 @@ private def renderWorkspaceSingleHole (root : System.FilePath) (entry : EvalProb
   let challengeFile :=
     challengeImport ++ contextOpenBlock ++ contextUniverseBlock ++
       (if hasChallengeDeps then contextLocalSyntaxBlock else contextSyntaxBlock) ++
-      contextVariablesBlock ++ contextIncludeBlock ++
+      contextVariablesBlock ++ contextIncludeBlock ++ declarationPrefix ++
     s!"theorem {theoremName} {theoremStatement} := by\n  sorry\n"
   let solutionFile :=
     solutionImports ++ contextOpenBlock ++ contextUniverseBlock ++ contextLocalSyntaxBlock ++
-      contextVariablesBlock ++ contextIncludeBlock ++
+      contextVariablesBlock ++ contextIncludeBlock ++ declarationPrefix ++
     s!"theorem {theoremName} {theoremStatement} := by\n  exact {solutionExact}\n"
   let submissionFile :=
     submissionImports ++ contextOpenBlock ++ contextUniverseBlock ++
       (if hasChallengeDeps then contextLocalSyntaxBlock else contextSyntaxBlock) ++
       contextVariablesBlock ++ contextIncludeBlock ++
-    "namespace Submission\n\n" ++
+    "namespace Submission\n\n" ++ declarationPrefix ++
     s!"theorem {theoremName} {theoremStatement} := by\n  sorry\n\n" ++
     "end Submission\n"
   let mut files : Array (String × String) := #[

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -187,6 +187,42 @@ def main : IO UInt32 := do
       | pure (some "no theorem in fixture")
     pure <| assertEq "start" (extendOverScopingPrefixes source target target) target
 
+  check "isScopedCommandBlock: include x in binds one declaration" passes fails do
+    pure <| assertEq "scoped" (isScopedCommandBlock "include x in") true
+
+  check "isScopedCommandBlock: include x binds the section" passes fails do
+    pure <| assertEq "scoped" (isScopedCommandBlock "include x") false
+
+  -- `include x in` decides which surrounding `variable` binders the
+  -- declaration takes, so a restated statement without it has a different
+  -- signature than the one the delegation was derived from.
+  check "extractDeclarationPrefix keeps a prefix on its own line" passes fails do
+    let text :=
+      "variable (n : \u2115)\n\n" ++
+      "include n in\n" ++
+      "theorem target : True := by sorry\n"
+    let source := Source.ofString text
+    let some target := Source.find source 0 "theorem".toList
+      | pure (some "no theorem in fixture")
+    pure <| assertEq "prefix" (extractDeclarationPrefix source 0 target) "include n in\n"
+
+  check "extractDeclarationPrefix keeps a prefix sharing the line" passes fails do
+    let text :=
+      "variable (n : \u2115)\n\n" ++
+      "include n in theorem target : True := by sorry\n"
+    let source := Source.ofString text
+    let some target := Source.find source 0 "theorem".toList
+      | pure (some "no theorem in fixture")
+    pure <| assertEq "prefix" (extractDeclarationPrefix source 0 target) "include n in\n"
+
+  -- A declaration with nothing scoped onto it must come out untouched.
+  check "extractDeclarationPrefix is empty without a prefix" passes fails do
+    let text := "variable (n : \u2115)\n\ntheorem target : True := by sorry\n"
+    let source := Source.ofString text
+    let some target := Source.find source 0 "theorem".toList
+      | pure (some "no theorem in fixture")
+    pure <| assertEq "prefix" (extractDeclarationPrefix source 0 target) ""
+
   check "variableBlockExplicitNames collects explicit binders only" passes fails do
     let block :=
       "variable (n : ℕ) {α : Type*} [Fintype α]\n" ++


### PR DESCRIPTION
This PR carries the command prefix scoped onto an eval-problem declaration into its generated workspace.

`include … in`, `open … in` and `set_option … in` bind to the one declaration that follows them, which is why the context collectors pass over them: hoisting one out of an earlier declaration would change the meaning of the extracted one. The prefix attached to the extracted declaration itself is a different matter, and the single-hole renderer restates the statement without it.

`include … in` is where this shows. It decides which of the surrounding `variable` binders the declaration takes, so a restated statement without it has a different signature from the source one, and `Solution.lean` applies the delegation to arguments the restated statement does not bind:

```
error: Function expected at
  Submission.target
but this term has type
  True
```

Recover the prefix by walking back from the declaration's `.ilean` range, bounded by the end of the declaration before it, and emit it ahead of the restated statement in `Challenge.lean`, `Solution.lean` and `Submission.lean`. Both the multi-line and the same-line spelling are covered, and `extractContextIncludes` no longer hoists a scoped `include … in` belonging to an earlier declaration.

No problem module currently carries a prefix on a hole, so every generated workspace is unchanged.

🤖 Prepared with Claude Code
