### PR TITLE
feat(GroupTheory): add the Ore conjecture

### DIFF
--- a/LeanEval/GroupTheory/OreConjecture.lean
+++ b/LeanEval/GroupTheory/OreConjecture.lean
@@ -1,0 +1,30 @@
+import Mathlib.Data.Finite.Defs
+import Mathlib.GroupTheory.Commutator.Basic
+import Mathlib.GroupTheory.Subgroup.Simple
+import EvalTools.Markers
+
+namespace LeanEval
+namespace GroupTheory
+
+/-!
+# The Ore conjecture
+
+Every element of a finite nonabelian simple group is a commutator; Liebeck, O'Brien,
+Shalev, and Tiep proved this conjecture in 2010.
+
+## References
+
+* [M. W. Liebeck, E. A. O'Brien, A. Shalev, and P. H. Tiep, *The Ore conjecture*](https://ems.press/journals/jems/articles/3979)
+-/
+
+/-- **The Ore conjecture.** Every element of a finite nonabelian simple group is a
+commutator. -/
+@[eval_problem]
+theorem ore_conjecture
+    (G : Type*) [Group G] [Finite G] [IsSimpleGroup G]
+    (hG : ¬ IsMulCommutative G) :
+    commutatorSet G = Set.univ := by
+  sorry
+
+end GroupTheory
+end LeanEval

--- a/manifests/problems/ore_conjecture.toml
+++ b/manifests/problems/ore_conjecture.toml
@@ -1,0 +1,9 @@
+id = "ore_conjecture"
+title = "The Ore conjecture: every element of a finite nonabelian simple group is a commutator"
+test = false
+module = "LeanEval.GroupTheory.OreConjecture"
+holes = ["ore_conjecture"]
+submitter = "Adam Topaz"
+notes = "This is Theorem 1 of Liebeck–O'Brien–Shalev–Tiep, stated using Mathlib's existing finite-group, simple-group, and commutator-set APIs without any trusted helper definitions."
+source = "Martin W. Liebeck, E. A. O'Brien, Aner Shalev, and Pham Huu Tiep, *The Ore conjecture*, Journal of the European Mathematical Society 12 (2010), no. 4, 939–1008, Theorem 1, https://doi.org/10.4171/JEMS/220; https://ems.press/journals/jems/articles/3979."
+informal_solution = "Following Sections 2–7 of the cited paper, apply the classification of finite simple groups and the previously established alternating and sporadic cases, then treat the remaining groups of Lie type. For classical groups, induct on the natural-module dimension: breakable elements decompose into blocks handled by induction, while unbreakable elements have small centralizers and are shown to be commutators using Frobenius's character criterion that the number of solutions to [x,y] = g is governed by the sum ∑χ χ(g)/χ(1), together with bounds forcing that sum to be nonzero. The exceptional groups are reduced through suitable subsystem subgroups and analogous character estimates; the unitary groups require separate character-theoretic matrix equations; and the low-rank base cases are verified from character tables and explicit MAGMA computations."

--- a/manifests/problems/ore_conjecture.toml
+++ b/manifests/problems/ore_conjecture.toml
@@ -4,6 +4,6 @@ test = false
 module = "LeanEval.GroupTheory.OreConjecture"
 holes = ["ore_conjecture"]
 submitter = "Adam Topaz"
-notes = "This is Theorem 1 of Liebeck–O'Brien–Shalev–Tiep, stated using Mathlib's existing finite-group, simple-group, and commutator-set APIs without any trusted helper definitions."
+notes = "This is Theorem 1 of the cited paper."
 source = "Martin W. Liebeck, E. A. O'Brien, Aner Shalev, and Pham Huu Tiep, *The Ore conjecture*, Journal of the European Mathematical Society 12 (2010), no. 4, 939–1008, Theorem 1, https://doi.org/10.4171/JEMS/220; https://ems.press/journals/jems/articles/3979."
-informal_solution = "Following Sections 2–7 of the cited paper, apply the classification of finite simple groups and the previously established alternating and sporadic cases, then treat the remaining groups of Lie type. For classical groups, induct on the natural-module dimension: breakable elements decompose into blocks handled by induction, while unbreakable elements have small centralizers and are shown to be commutators using Frobenius's character criterion that the number of solutions to [x,y] = g is governed by the sum ∑χ χ(g)/χ(1), together with bounds forcing that sum to be nonzero. The exceptional groups are reduced through suitable subsystem subgroups and analogous character estimates; the unitary groups require separate character-theoretic matrix equations; and the low-rank base cases are verified from character tables and explicit MAGMA computations."
+informal_solution = "See the cited paper for the proof."

--- a/manifests/problems/ore_conjecture.toml
+++ b/manifests/problems/ore_conjecture.toml
@@ -1,5 +1,10 @@
 id = "ore_conjecture"
 title = "The Ore conjecture: every element of a finite nonabelian simple group is a commutator"
+group = "formalization-evaluation"
+status = "draft"
+visible = true
+statement_revision = 1
+tags = []
 test = false
 module = "LeanEval.GroupTheory.OreConjecture"
 holes = ["ore_conjecture"]


### PR DESCRIPTION
## Summary

- add the Ore conjecture as a GroupTheory eval problem
- register the problem with the proof by Liebeck, O'Brien, Shalev, and Tiep

The theorem states that every element of a finite nonabelian simple group is a commutator.

## Statement choices

- represent finiteness and simplicity using Mathlib's `Finite` and `IsSimpleGroup` classes
- state nonabelianness as `¬ IsMulCommutative G`
- express the conclusion as `commutatorSet G = Set.univ`

## Validation

- `lake exe lean-eval validate-manifest`
- `lake exe lean-eval check-problem-build`
- `lake exe lean-eval generate --problem ore_conjecture`
- `lake exe lean-eval check-generated-builds --problem ore_conjecture`
- `git diff --check`

The generated workspace is intentionally not committed.