### PR TITLE
fix: resolve .ilean columns as UTF-16 code units

### DIFF
--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -214,10 +214,8 @@ def Source.slice (s : Source) (start endIdx : Nat) : String :=
   let start := min start endIdx
   String.mk (s.toList.drop start |>.take (endIdx - start))
 
-/-- Convert (1-indexed line, 0-indexed codepoint column) into a codepoint
-index in `s`. Mirrors `offset_for_line_column` in
-`scripts/generate_projects.py`. -/
-def Source.offsetForLineColumn (s : Source) (line col : Nat) : IO Nat := do
+/-- The codepoint index at which 1-indexed `line` starts in `s`. -/
+private def Source.lineStartOffset (s : Source) (line : Nat) : IO Nat := do
   if line < 1 then
     throw <| IO.userError s!"Invalid source line {line}"
   let mut currentLine : Nat := 1
@@ -235,7 +233,54 @@ def Source.offsetForLineColumn (s : Source) (line col : Nat) : IO Nat := do
     if !found then
       throw <| IO.userError s!"Source ended before line {line}"
     currentLine := currentLine + 1
-  return idx + col
+  return idx
+
+/-- Convert (1-indexed line, 0-indexed **codepoint** column) into a codepoint
+index in `s`. Mirrors `offset_for_line_column` in
+`scripts/generate_projects.py`.
+
+This is the convention of `Lean.Position`, so it is the one to use for every
+range that reaches us through `findDeclarationRanges?` — that is, everything
+carried on an `ExtractedTheorem`. Ranges read from a `.ilean` use the *other*
+convention; see `Source.offsetForLineUtf16Column`. -/
+def Source.offsetForLineColumn (s : Source) (line col : Nat) : IO Nat := do
+  return (← s.lineStartOffset line) + col
+
+/-- Convert (1-indexed line, 0-indexed **UTF-16 code unit** column) into a
+codepoint index in `s`.
+
+`.ilean` files store LSP ranges, and LSP columns count UTF-16 code units, while
+`Source` is an `Array Char` indexed by codepoint. The two agree only inside the
+Basic Multilingual Plane, and diverge on exactly the characters a Lean corpus is
+likely to contain: the mathematical alphanumerics (`𝓧`, `𝔽`, `𝒞`, `𝔻`, `𝔸`,
+`𝓡`, …) are all outside it and so count twice.
+
+Reading such a column as a codepoint offset runs past the end of its line. A
+declaration's computed range then swallowed the following blank line and the
+opening `/-` of the next comment, leaving an orphaned `-/` that parsed as
+`unexpected token '-'`.
+
+Throws rather than clamping. A column past the end of its line, or one landing
+inside a surrogate pair, means the `.ilean` disagrees with the source being
+resolved against it — a stale build, or a file edited since. Returning the
+nearest plausible offset would truncate a *trusted* declaration while still
+emitting text that looks reasonable. -/
+def Source.offsetForLineUtf16Column (s : Source) (line col : Nat) : IO Nat := do
+  let mut idx ← s.lineStartOffset line
+  let n := s.size
+  let mut units : Nat := 0
+  while units < col do
+    if idx ≥ n || s[idx]! == '\n' then
+      throw <| IO.userError
+        s!"`.ilean` column {col} runs past the end of line {line}; the metadata \
+           is stale relative to the source. Rebuild the module and retry."
+    units := units + (if s[idx]!.val > 0xFFFF then 2 else 1)
+    idx := idx + 1
+  if units != col then
+    throw <| IO.userError
+      s!"`.ilean` column {col} on line {line} lands inside a surrogate pair; \
+         the metadata is stale relative to the source. Rebuild and retry."
+  return idx
 
 /-- Find the first occurrence of `needle` (a `List Char`) in `s` starting at
 `start`, returning the codepoint index where the match starts. -/
@@ -473,7 +518,11 @@ def repoLocalImportModules (root : System.FilePath) (moduleName : String) :
 `[startLine, startColumn, endLine, endColumn]` (`.ilean` records these
 0-indexed; we convert lines to 1-indexed to match `offsetForLineColumn`).
 The range spans the *whole* declaration, doc comment through the end of the
-body, so `(endLine, endColumn)` is the precise end — no heuristic needed. -/
+body, so `(endLine, endColumn)` is the precise end — no heuristic needed.
+
+The columns are LSP columns, counting UTF-16 code units, so they must be
+resolved with `Source.offsetForLineUtf16Column` and never with
+`Source.offsetForLineColumn`. -/
 structure IleanDeclEntry where
   name : String
   startLine : Nat
@@ -1366,8 +1415,9 @@ def loadDeclSpans (root : System.FilePath) (entry : EvalProblemMetadata)
   let declRanges ← loadIleanDeclRanges root entry.moduleName
   let mut startsBuf : Array (String × Nat × Nat) := #[]
   for ileanEntry in declRanges do
-    let off ← sourceSrc.offsetForLineColumn ileanEntry.startLine ileanEntry.startColumn
-    let endOff ← sourceSrc.offsetForLineColumn ileanEntry.endLine ileanEntry.endColumn
+    -- `.ilean` columns are UTF-16, not codepoints; see `IleanDeclEntry`.
+    let off ← sourceSrc.offsetForLineUtf16Column ileanEntry.startLine ileanEntry.startColumn
+    let endOff ← sourceSrc.offsetForLineUtf16Column ileanEntry.endLine ileanEntry.endColumn
     startsBuf := startsBuf.push (ileanEntry.name, off, endOff)
   let starts := startsBuf.qsort (fun a b => a.2.1 < b.2.1)
   let mut spans : Array DeclSpan := #[]

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -196,7 +196,10 @@ def ileanPath (root : System.FilePath) (moduleName : String) : System.FilePath :
 /-! ## Source-as-Array-Char utilities
 
 Source-text manipulation works on `Array Char` so we can use `Nat` indices
-directly. This matches Python's codepoint-indexed string semantics, which the
+directly — that is, `Source` is indexed by *codepoint*. `.ilean` columns are
+UTF-16 code units and so need converting (`Source.offsetForLineUtf16Column`);
+`Lean.Position` columns are already codepoints. This matches Python's
+codepoint-indexed string semantics, which the
 upstream `scripts/generate_projects.py` relies on (e.g. when applying offsets
 from `.ilean`, which records codepoint columns). -/
 
@@ -516,7 +519,8 @@ def repoLocalImportModules (root : System.FilePath) (moduleName : String) :
 
 /-- A declaration's source range from the `.ilean`, as
 `[startLine, startColumn, endLine, endColumn]` (`.ilean` records these
-0-indexed; we convert lines to 1-indexed to match `offsetForLineColumn`).
+0-indexed; we convert lines to 1-indexed, the convention both offset functions
+take).
 The range spans the *whole* declaration, doc comment through the end of the
 body, so `(endLine, endColumn)` is the precise end — no heuristic needed.
 
@@ -1407,12 +1411,11 @@ structure DeclSpan where
   declEnd : Nat
   deriving Inhabited
 
-/-- Load every top-level declaration range from the module's `.ilean`, mapped
-into character-offset spans against `sourceSrc`. Used everywhere the generator
-needs to slice the source by declaration. -/
-def loadDeclSpans (root : System.FilePath) (entry : EvalProblemMetadata)
-    (sourceSrc : Source) : IO (Array DeclSpan) := do
-  let declRanges ← loadIleanDeclRanges root entry.moduleName
+/-- Map `.ilean` declaration entries onto character-offset spans against
+`sourceSrc`. Split out from `loadDeclSpans` so the column-convention routing is
+reachable from tests without a compiled fixture on disk. -/
+def declSpansOfIleanEntries (sourceSrc : Source) (declRanges : Array IleanDeclEntry) :
+    IO (Array DeclSpan) := do
   let mut startsBuf : Array (String × Nat × Nat) := #[]
   for ileanEntry in declRanges do
     -- `.ilean` columns are UTF-16, not codepoints; see `IleanDeclEntry`.
@@ -1428,6 +1431,13 @@ def loadDeclSpans (root : System.FilePath) (entry : EvalProblemMetadata)
       else findTopLevelEndOffset sourceSrc start
     spans := spans.push { name, start, stop, declEnd }
   return spans
+
+/-- Load every top-level declaration range from the module's `.ilean`, mapped
+into character-offset spans against `sourceSrc`. Used everywhere the generator
+needs to slice the source by declaration. -/
+def loadDeclSpans (root : System.FilePath) (entry : EvalProblemMetadata)
+    (sourceSrc : Source) : IO (Array DeclSpan) := do
+  declSpansOfIleanEntries sourceSrc (← loadIleanDeclRanges root entry.moduleName)
 
 /-- Apply a list of `(start, stop, replacement)` edits to `sourceText`. Edits
 are sorted right-to-left and applied in that order so earlier offsets remain

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -560,6 +560,46 @@ def main : IO UInt32 := do
     let block := extractContextUniverses source (some extracted)
     pure <| assertEq "universe line only" block "universe u\n\n"
 
+  -- `.ilean` records LSP ranges, whose columns count UTF-16 code units, while
+  -- `Source` is indexed by codepoint. The two diverge on any character outside
+  -- the BMP — which includes the mathematical alphanumerics (`𝔻`, `𝓧`, `𝔽`, …)
+  -- a Lean corpus is full of. Resolving a UTF-16 column as a codepoint offset
+  -- ran past the end of the line and swallowed the start of the next comment.
+  check "offsetForLineUtf16Column resolves an astral column" passes fails do
+    -- "a𝔻b" is 3 codepoints but 4 UTF-16 units.
+    let src := Source.ofString "a𝔻b\n"
+    let off ← src.offsetForLineUtf16Column 1 4
+    pure <| assertEq "end of line" off 3
+
+  check "offsetForLineUtf16Column counts an astral char as two units" passes fails do
+    let src := Source.ofString "a𝔻b\n"
+    let off ← src.offsetForLineUtf16Column 1 3
+    pure <| assertEq "before b" off 2
+
+  check "offsetForLineColumn still counts codepoints" passes fails do
+    -- The `Lean.Position` convention, unchanged: column 3 is past `b`.
+    let src := Source.ofString "a𝔻b\n"
+    let off ← src.offsetForLineColumn 1 3
+    pure <| assertEq "end of line" off 3
+
+  -- A column past the end of its line means the `.ilean` no longer matches the
+  -- source. Clamping would silently truncate a trusted declaration.
+  check "offsetForLineUtf16Column rejects a column past end of line" passes fails do
+    let src := Source.ofString "a𝔻b\n"
+    let threw ← (try
+      let _ ← src.offsetForLineUtf16Column 1 99
+      pure false
+    catch _ => pure true)
+    pure <| assertEq "threw" threw true
+
+  check "offsetForLineUtf16Column rejects a mid-surrogate column" passes fails do
+    let src := Source.ofString "a𝔻b\n"
+    let threw ← (try
+      let _ ← src.offsetForLineUtf16Column 1 2
+      pure false
+    catch _ => pure true)
+    pure <| assertEq "threw" threw true
+
   let passCount ← passes.get
   let failCount ← fails.get
   IO.println s!"\n{passCount} passed, {failCount} failed."

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -600,6 +600,24 @@ def main : IO UInt32 := do
     catch _ => pure true)
     pure <| assertEq "threw" threw true
 
+  -- The routing itself, not just the two converters: `.ilean` entries must be
+  -- resolved with the UTF-16 converter. Reverting `declSpansOfIleanEntries` to
+  -- `offsetForLineColumn` makes this fail, which the converter-level tests
+  -- above would not catch.
+  check "declSpansOfIleanEntries resolves .ilean columns as UTF-16" passes fails do
+    -- Line 1 is `def 𝔻 := 1` — 10 codepoints, 11 UTF-16 units. An `.ilean`
+    -- range covering it therefore ends at column 11, and must resolve to
+    -- codepoint offset 10.
+    let text := "def 𝔻 := 1\ndef b := 2\n"
+    let src := Source.ofString text
+    let entries : Array IleanDeclEntry := #[
+      { name := "𝔻", startLine := 1, startColumn := 0, endLine := 1, endColumn := 11 },
+      { name := "b", startLine := 2, startColumn := 0, endLine := 2, endColumn := 10 }
+    ]
+    let spans ← declSpansOfIleanEntries src entries
+    let first := spans[0]!
+    pure <| assertEq "first decl text" (Source.slice src first.start first.declEnd) "def 𝔻 := 1"
+
   let passCount ← passes.get
   let failCount ← fails.get
   IO.println s!"\n{passCount} passed, {failCount} failed."


### PR DESCRIPTION
This PR resolves `.ilean` declaration ranges as UTF-16 code units rather than codepoints. `.ilean` files store LSP ranges, whose columns count UTF-16 code units, but `Source.offsetForLineColumn` added the column as a codepoint offset. The two agree only inside the Basic Multilingual Plane, and diverge on exactly the characters a Lean corpus is full of: the mathematical alphanumerics (`𝓧`, `𝔽`, `𝒞`, `𝔻`, `𝔸`, `𝓡`) are all outside it and count twice.

A declaration containing one was therefore sliced too long, by one codepoint per astral character on its last line. In `LeanEval/Physics/BoseGases.lean` the range of `𝓡` ends at column 61 of a line that is 60 codepoints, so the slice ran past the newline; elsewhere a range swallowed the following blank line and the opening `/-` of the next comment, leaving an orphaned `-/` that parsed as `unexpected token '-'`. Nothing failed loudly — the generated workspace simply contained different text from the trusted module, which is the failure mode a scoring pipeline can least afford.

Split the conversion in two so each caller states which convention it means. Ranges from `findDeclarationRanges?` are `Lean.Position`s and stay on `offsetForLineColumn`; the two `.ilean` call sites move to `offsetForLineUtf16Column`, and `IleanDeclEntry` records which to use.

The UTF-16 conversion throws rather than clamping. A column past the end of its line, or one landing inside a surrogate pair, means the `.ilean` disagrees with the source being resolved against it; returning the nearest plausible offset would truncate a trusted declaration while still emitting text that looks reasonable.

Regenerating the whole catalog changes exactly one workspace, `derived_solidification_free_CW_homology`, which gains back a blank line the old over-consumption ate; it still builds. Five regression tests cover astral resolution, the unchanged codepoint convention, and both failure modes.

🤖 Prepared with Claude Code