### PR TITLE
ci: select and validate affected catalog shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,27 @@ jobs:
       - name: Python syntax checks
         run: python -m py_compile scripts/*.py scripts/security_probes/*.py
 
+      # Install the pinned Lean toolchain without building the project. The
+      # dependency selector consumes a graph produced by Lean's header parser;
+      # Python never attempts to parse Lean import syntax.
+      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
+        with:
+          build: false
+          test: false
+          lint: false
+          use-mathlib-cache: false
+          use-github-cache: false
+
+      - name: Export Lean import graph
+        run: |
+          set -euo pipefail
+          mkdir -p .ci/lean/EvalTools
+          lean -R . -o .ci/lean/EvalTools/Markers.olean EvalTools/Markers.lean
+          LEAN_PATH="$PWD/.ci/lean" lean -R . \
+            -o .ci/lean/EvalTools/ModuleCoverage.olean EvalTools/ModuleCoverage.lean
+          LEAN_PATH="$PWD/.ci/lean" lean --run EvalTools/CIImportGraph.lean \
+            > .ci/import-graph.json
+
       - name: Select affected catalog problems
         id: changes
         env:
@@ -53,6 +74,7 @@ jobs:
             --base "$BASE_SHA" \
             --head "$HEAD_SHA" \
             --shards 8 \
+            --import-graph .ci/import-graph.json \
             --github-output "$GITHUB_OUTPUT"
 
   checks:
@@ -122,7 +144,7 @@ jobs:
           lake exe test_check_comparator_installation
 
       - name: Run Python unit tests
-        run: python -m unittest discover -s tests/python -p 'test_*.py'
+        run: python tests/python/test_select_ci_problems.py
 
   security:
     name: Security and scoring smoke tests
@@ -251,6 +273,12 @@ jobs:
       - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
         with:
           use-mathlib-cache: true
+          build: false
+          test: false
+          lint: false
+          # Restoring root-package artifacts could make the warning-sensitive
+          # builds incremental no-ops. Mathlib's cache remains enabled above.
+          use-github-cache: false
 
       - name: Build problem modules without warnings
         env:
@@ -345,6 +373,9 @@ jobs:
       - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
         with:
           use-mathlib-cache: true
+          build: false
+          test: false
+          lint: false
 
       - name: Download problem inventories
         # actions/download-artifact pinned to 3e5f45b2 (= refs/tags/v8.0.1 as of 2026-08-17).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,9 +276,14 @@ jobs:
           build: false
           test: false
           lint: false
-          # Restoring root-package artifacts could make the warning-sensitive
-          # builds incremental no-ops. Mathlib's cache remains enabled above.
-          use-github-cache: false
+
+      - name: Clear cached problem-module artifacts
+        run: |
+          set -euo pipefail
+          artifact_dir=.lake/build/lib/lean/LeanEval
+          if [ -d "$artifact_dir" ]; then
+            find "$artifact_dir" \( -type f -o -type l \) -delete
+          fi
 
       - name: Build problem modules without warnings
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       generated_changed: ${{ steps.changes.outputs.generated_changed }}
       run_checks: ${{ steps.changes.outputs.run_checks }}
       run_catalog: ${{ steps.changes.outputs.run_catalog }}
+      selection_mode: ${{ steps.changes.outputs.selection_mode }}
+      selected_problem_count: ${{ steps.changes.outputs.selected_problem_count }}
+      selected_modules: ${{ steps.changes.outputs.selected_modules }}
+      matrix: ${{ steps.changes.outputs.matrix }}
     steps:
       # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -37,55 +41,19 @@ jobs:
       - name: Python syntax checks
         run: python -m py_compile scripts/*.py scripts/security_probes/*.py
 
-      - name: Classify changed paths
+      - name: Select affected catalog problems
         id: changes
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          source_changed=false
-          generated_changed=false
-          infrastructure_changed=false
-
-          if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
-            source_changed=true
-            generated_changed=true
-            infrastructure_changed=true
-          else
-            mapfile -t changed_files < <(git diff --name-only "$BASE_SHA"..HEAD)
-            for path in "${changed_files[@]}"; do
-              case "$path" in
-                LeanEval/*|EvalTools/*|templates/*|manifests/problems/*|lakefile.toml|lake-manifest.json|lean-toolchain)
-                  source_changed=true
-                  ;;
-                generated/*)
-                  generated_changed=true
-                  ;;
-                .github/workflows/*|.github/actions/*|scripts/*|tests/*)
-                  infrastructure_changed=true
-                  ;;
-              esac
-            done
-          fi
-
-          run_checks=false
-          if [ "$source_changed" = true ] || [ "$generated_changed" = true ] \
-              || [ "$infrastructure_changed" = true ]; then
-            run_checks=true
-          fi
-
-          run_catalog=false
-          if [ "$source_changed" = true ] || [ "$generated_changed" = true ] \
-              || git diff --name-only "$BASE_SHA"..HEAD | grep -qx '.github/workflows/ci.yml'; then
-            run_catalog=true
-          fi
-
-          {
-            echo "source_changed=$source_changed"
-            echo "generated_changed=$generated_changed"
-            echo "run_checks=$run_checks"
-            echo "run_catalog=$run_catalog"
-          } >> "$GITHUB_OUTPUT"
+          python scripts/select_ci_problems.py \
+            --event "$GITHUB_EVENT_NAME" \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --shards 8 \
+            --github-output "$GITHUB_OUTPUT"
 
   checks:
     name: Repository checks
@@ -118,14 +86,10 @@ jobs:
         with:
           use-mathlib-cache: true
 
-      # Run the warning-sensitive build first. Previously validate-manifest
-      # compiled the modules first, so the later warning scan saw an empty
-      # incremental build and could not actually detect warnings.
-      - name: Build problem modules without warnings
-        run: lake exe lean-eval check-problem-build
-
-      - name: Validate manifest
-        run: lake exe lean-eval validate-manifest --assume-modules-built
+      # Module compilation and tagged-declaration inventory now run in the
+      # catalog shards. Keep the cheap whole-repository invariants here.
+      - name: Validate manifest structure and module coverage
+        run: lake exe lean-eval validate-manifest --structure-only
 
       - name: Submission policy smoke check
         run: lake exe lean-eval validate-submission --file generated/two_plus_two/Solution.lean
@@ -156,6 +120,9 @@ jobs:
           lake exe test_generate
           lake exe test_module_coverage
           lake exe test_check_comparator_installation
+
+      - name: Run Python unit tests
+        run: python -m unittest discover -s tests/python -p 'test_*.py'
 
   security:
     name: Security and scoring smoke tests
@@ -252,15 +219,14 @@ jobs:
         run: lake exe lean-eval check-eval-workflow
 
   catalog:
-    name: Generated workspaces (shard ${{ matrix.shard }}/${{ strategy.job-total }})
+    name: Catalog validation (shard ${{ matrix.shard }}/${{ matrix.shard_count }})
     needs: classify
     if: needs.classify.outputs.run_catalog == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+      matrix: ${{ fromJSON(needs.classify.outputs.matrix) }}
     steps:
       - name: Free up disk space
         # jlumbroso/free-disk-space pinned to 54081f13 (= refs/tags/v1.3.1, also main HEAD as of 2026-05-04).
@@ -286,31 +252,36 @@ jobs:
         with:
           use-mathlib-cache: true
 
-      - name: Generate or verify this shard
-        id: shard
+      - name: Build problem modules without warnings
         env:
+          MODULES: ${{ matrix.modules }}
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_COUNT: ${{ strategy.job-total }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -r -a modules <<< "$MODULES"
+          module_args=()
+          for module in "${modules[@]}"; do
+            module_args+=(--module "$module")
+          done
+          lake exe lean-eval check-problem-build "${module_args[@]}"
+          mkdir -p .ci/problem-inventory
+          lake exe lean-eval problem-inventory \
+            ".ci/problem-inventory/$SHARD_INDEX.json" "${module_args[@]}"
+
+      - name: Generate or verify this shard
+        env:
+          PROBLEMS: ${{ matrix.problems }}
           SOURCE_CHANGED: ${{ needs.classify.outputs.source_changed }}
           GENERATED_CHANGED: ${{ needs.classify.outputs.generated_changed }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          mapfile -t all_problems < <(
-            find manifests/problems -maxdepth 1 -type f -name '*.toml' -printf '%f\n' \
-              | sed 's/\.toml$//' | sort
-          )
-          selected=()
-          for i in "${!all_problems[@]}"; do
-            if (( i % SHARD_COUNT == SHARD_INDEX )); then
-              selected+=("${all_problems[$i]}")
-            fi
-          done
+          IFS=',' read -r -a selected <<< "$PROBLEMS"
           if [ "${#selected[@]}" -eq 0 ]; then
             echo "Shard is empty."
             exit 0
           fi
-          printf 'Shard %s: %s\n' "$SHARD_INDEX" "${selected[*]}"
+          printf 'Selected problems: %s\n' "${selected[*]}"
 
           generate_mode="none"
           if [ "$SOURCE_CHANGED" = true ]; then
@@ -349,12 +320,59 @@ jobs:
           done
           lake exe lean-eval check-generated-builds "${build_args[@]}"
 
+      - name: Upload problem inventory
+        # actions/upload-artifact pinned to 043fb46d (= refs/tags/v7.0.1 as of 2026-08-17).
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: problem-inventory-${{ matrix.shard }}
+          path: .ci/problem-inventory/${{ matrix.shard }}.json
+          if-no-files-found: error
+          retention-days: 1
+
+  catalog_inventory:
+    name: Manifest inventory aggregate
+    needs: [classify, catalog]
+    if: needs.classify.outputs.run_catalog == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      # leanprover/lean-action pinned to 38fbc41a (= refs/tags/v1.5.0, also v1 HEAD as of 2026-05-04).
+      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
+        with:
+          use-mathlib-cache: true
+
+      - name: Download problem inventories
+        # actions/download-artifact pinned to 3e5f45b2 (= refs/tags/v8.0.1 as of 2026-08-17).
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: problem-inventory-*
+          path: .ci/problem-inventory
+          merge-multiple: true
+
+      - name: Validate aggregated manifest inventory
+        env:
+          MODULES: ${{ needs.classify.outputs.selected_modules }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -r -a modules <<< "$MODULES"
+          module_args=()
+          for module in "${modules[@]}"; do
+            module_args+=(--module "$module")
+          done
+          lake exe lean-eval validate-manifest \
+            --inventory-dir .ci/problem-inventory "${module_args[@]}"
+
   # Preserve the existing required-check name while making it an aggregate of
   # every parallel branch. A green `verify` now means the entire fan-out passed.
   verify:
     name: verify
     if: always()
-    needs: [classify, checks, security, catalog]
+    needs: [classify, checks, security, catalog, catalog_inventory]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -364,10 +382,12 @@ jobs:
           CHECKS_RESULT: ${{ needs.checks.result }}
           SECURITY_RESULT: ${{ needs.security.result }}
           CATALOG_RESULT: ${{ needs.catalog.result }}
+          CATALOG_INVENTORY_RESULT: ${{ needs.catalog_inventory.result }}
         run: |
           set -euo pipefail
           for result in "$CLASSIFY_RESULT" "$CHECKS_RESULT" \
-              "$SECURITY_RESULT" "$CATALOG_RESULT"; do
+              "$SECURITY_RESULT" "$CATALOG_RESULT" \
+              "$CATALOG_INVENTORY_RESULT"; do
             if [ "$result" != success ] && [ "$result" != skipped ]; then
               echo "A required CI branch ended with: $result" >&2
               exit 1

--- a/EvalTools/CIImportGraph.lean
+++ b/EvalTools/CIImportGraph.lean
@@ -1,0 +1,33 @@
+import EvalTools.ModuleCoverage
+
+open Lean
+
+namespace EvalTools
+
+set_option autoImplicit false
+
+private def sourceToJson (source : ProblemSourceModule) : Json :=
+  Json.mkObj [
+    ("path", source.path),
+    ("module", toString source.name),
+    ("imports", Json.arr (source.imports.map fun name => Json.str (toString name)))
+  ]
+
+/-- Emit the repository-local Lean import graph for the CI selector. Header
+syntax is parsed by Lean itself through `loadProblemSourceModules`. -/
+def runCIImportGraph (root : System.FilePath) : IO UInt32 := do
+  try
+    let sources ← loadProblemSourceModules root
+    IO.println <| Json.compress <| Json.arr (sources.map sourceToJson)
+    return 0
+  catch err =>
+    IO.eprintln err
+    return 1
+
+end EvalTools
+
+def main (args : List String) : IO UInt32 := do
+  unless args.isEmpty do
+    IO.eprintln "ci_import_graph does not accept arguments."
+    return 1
+  EvalTools.runCIImportGraph (← IO.currentDir)

--- a/EvalTools/CheckProblemBuild.lean
+++ b/EvalTools/CheckProblemBuild.lean
@@ -17,10 +17,11 @@ problem modules emit by design.
 
 The separate invocations are intentional: passing the complete catalog to one
 `lake build` lets Lake schedule every independent module at once. -/
-def runCheckProblemBuild (root : System.FilePath) : IO UInt32 := do
+def runCheckProblemBuild (root : System.FilePath)
+    (requestedModules : Array String := #[]) : IO UInt32 := do
   try
     let entries ← loadManifest root
-    let modules := uniqueModules entries
+    let modules ← selectManifestModules entries requestedModules
     let mut disallowed := []
     for moduleName in modules do
       let output ← runCmdCheckedCaptured "lake" #["build", moduleName] root

--- a/EvalTools/Main.lean
+++ b/EvalTools/Main.lean
@@ -21,13 +21,32 @@ def runRootCmd (p : Parsed) : IO UInt32 := do
   p.printHelp
   pure 0
 
+def requestedModules (p : Parsed) : Array String :=
+  match p.flag? "module" with
+  | some flag => flag.as! (Array String)
+  | none => #[]
+
 def runValidateManifestCmd (p : Parsed) : IO UInt32 := do
   let root ← requireRepoRoot
-  EvalTools.runValidateManifest root (modulesBuilt := p.hasFlag "assume-modules-built")
+  let inventoryDir? : Option System.FilePath :=
+    p.flag? "inventory-dir" |>.map fun flag => flag.as! String
+  EvalTools.runValidateManifest root
+    (modulesBuilt := p.hasFlag "assume-modules-built")
+    (structureOnly := p.hasFlag "structure-only") inventoryDir? (requestedModules p)
 
-def runCheckProblemBuildCmd (_ : Parsed) : IO UInt32 := do
+def runCheckProblemBuildCmd (p : Parsed) : IO UInt32 := do
   let root ← requireRepoRoot
-  EvalTools.runCheckProblemBuild root
+  EvalTools.runCheckProblemBuild root (requestedModules p)
+
+def runProblemInventoryCmd (p : Parsed) : IO UInt32 := do
+  let output : String := p.positionalArg! "output" |>.as! String
+  let root ← requireRepoRoot
+  try
+    writeProblemInventory root output (requestedModules p)
+    return 0
+  catch err =>
+    IO.eprintln err
+    return 1
 
 def runGenerateCmd (p : Parsed) : IO UInt32 := do
   let root ← requireRepoRoot
@@ -123,11 +142,28 @@ def validateManifestCmd : Cmd := `[Cli|
 
   FLAGS:
     "assume-modules-built"; "Skip rebuilding problem modules that a preceding check already built."
+    "structure-only"; "Validate manifest syntax, uniqueness, and source-module coverage without collecting inventory."
+    "inventory-dir" : String; "Validate against precomputed per-shard inventory JSON files in this directory."
+    module : Array String; "Restrict precomputed inventory validation to these manifest modules."
 ]
 
 def checkProblemBuildCmd : Cmd := `[Cli|
   "check-problem-build" VIA runCheckProblemBuildCmd;
   "Build the trusted problem modules and fail on Lean warnings or errors."
+
+  FLAGS:
+    module : Array String; "Restrict the warning-sensitive build to these manifest modules."
+]
+
+def problemInventoryCmd : Cmd := `[Cli|
+  "problem-inventory" VIA runProblemInventoryCmd;
+  "Write tagged-declaration inventory JSON for already-built problem modules."
+
+  FLAGS:
+    module : Array String; "Restrict inventory collection to these manifest modules."
+
+  ARGS:
+    "output" : String; "Destination JSON path."
 ]
 
 def generateCmd : Cmd := `[Cli|
@@ -196,6 +232,7 @@ def leanEvalCmd : Cmd := `[Cli|
   SUBCOMMANDS:
     validateManifestCmd;
     checkProblemBuildCmd;
+    problemInventoryCmd;
     generateCmd;
     checkGeneratedBuildsCmd;
     startProblemCmd;
@@ -233,6 +270,7 @@ def coalesceRepeatedFlag (args : List String) (name : String) : List String := I
 def runMain (args : List String) : IO UInt32 := do
   let args := coalesceRepeatedFlag args "--problem"
   let args := coalesceRepeatedFlag args "--file"
+  let args := coalesceRepeatedFlag args "--module"
   leanEvalCmd.validate args
 
 end EvalTools

--- a/EvalTools/Manifest.lean
+++ b/EvalTools/Manifest.lean
@@ -104,9 +104,10 @@ structure ManifestInventoryEntry where
   declarationName : String
   basename : String
   kind : String
-  deriving Inhabited
+  deriving Inhabited, ToJson
 
-private def parseInventoryEntries (payload : String) :
+/-- Parse the JSON emitted by `eval_inventory`. -/
+def parseInventoryEntries (payload : String) :
     Except String (Array ManifestInventoryEntry) := do
   let json ← Json.parse payload
   let arr ← json.getArr?
@@ -120,6 +121,24 @@ private def parseInventoryEntries (payload : String) :
       { module := module, declarationName := declarationName,
         basename := basename, kind := kind }
   return out
+
+/-- Resolve an optional module restriction against the manifest, rejecting
+typos rather than silently producing an incomplete CI shard. -/
+def selectManifestModules (entries : Array EvalProblemMetadata)
+    (requested : Array String) : IO (Array String) := do
+  let available := uniqueModules entries
+  if requested.isEmpty then
+    return available
+  let known := available.foldl (fun set name => set.insert name) ({} : Std.HashSet String)
+  let mut seen : Std.HashSet String := {}
+  let mut selected := #[]
+  for moduleName in requested do
+    unless known.contains moduleName do
+      throw <| IO.userError s!"Requested problem module is not present in the manifest: {moduleName}"
+    unless seen.contains moduleName do
+      seen := seen.insert moduleName
+      selected := selected.push moduleName
+  return selected
 
 /-- Build the Lake targets and run the `eval_inventory` executable over every
 module referenced by `entries`.
@@ -147,14 +166,55 @@ def runInventoryTool (root : System.FilePath) (modules : Array String)
   | .ok entries => pure entries
   | .error err => throw <| IO.userError s!"Problem inventory returned invalid JSON: {err}"
 
-/-- Match Python's `gp.validate_manifest_against_inventory`: ensure every
-manifest hole resolves to exactly one `@[eval_problem]`-tagged declaration,
-and every such declaration appears in the manifest. -/
-def validateManifestAgainstInventory
-    (root : System.FilePath) (entries : Array EvalProblemMetadata)
-    (buildModules : Bool := true) : IO Unit := do
-  let modules := uniqueModules entries
-  let inventory ← runInventoryTool root modules buildModules
+/-- Load and concatenate the per-shard inventory JSON files downloaded by the
+aggregate CI job. -/
+def loadInventoryDirectory (directory : System.FilePath) : IO (Array ManifestInventoryEntry) := do
+  unless ← directory.isDir do
+    throw <| IO.userError s!"Problem inventory directory does not exist: {directory}"
+  let files := (← directory.readDir).qsort fun a b => a.fileName < b.fileName
+  let mut inventory := #[]
+  for file in files do
+    if ← file.path.isDir then
+      throw <| IO.userError s!"Unexpected directory in problem inventory: {file.path}"
+    unless file.path.extension == some "json" do
+      throw <| IO.userError s!"Unexpected non-JSON problem inventory file: {file.path}"
+    let payload ← IO.FS.readFile file.path
+    match parseInventoryEntries payload with
+    | .ok entries => inventory := inventory ++ entries
+    | .error err =>
+        throw <| IO.userError s!"Problem inventory `{file.path}` is invalid: {err}"
+  return inventory
+
+/-- Write the tagged-declaration inventory for `requestedModules`. Problem
+modules must already have been built by the warning-sensitive shard step. -/
+def writeProblemInventory (root output : System.FilePath)
+    (requestedModules : Array String) : IO Unit := do
+  let entries ← loadManifest root
+  let modules ← selectManifestModules entries requestedModules
+  let inventory ← runInventoryTool root modules (buildModules := false)
+  IO.FS.writeFile output (Json.pretty (toJson inventory) ++ "\n")
+
+/-- Validate a manifest against inventory rows already collected by CI shards. -/
+def validateManifestAgainstInventoryEntries
+    (entries : Array EvalProblemMetadata)
+    (inventory : Array ManifestInventoryEntry) : IO Unit := do
+  let expectedModules := uniqueModules entries
+  let inventoriedModules := inventory.foldl
+    (fun set entry => set.insert entry.module) ({} : Std.HashSet String)
+  let missingModules := expectedModules.filter (!inventoriedModules.contains ·)
+  unless missingModules.isEmpty do
+    throw <| IO.userError <|
+      "Problem inventory is missing manifest module(s): "
+        ++ ", ".intercalate missingModules.toList
+  let expectedSet := expectedModules.foldl
+    (fun set moduleName => set.insert moduleName) ({} : Std.HashSet String)
+  let unexpectedModules := inventory.filterMap fun entry =>
+    if expectedSet.contains entry.module then none else some entry.module
+  unless unexpectedModules.isEmpty do
+    let names := unexpectedModules.qsort (· < ·)
+    throw <| IO.userError <|
+      "Problem inventory contains module(s) absent from the manifest: "
+        ++ ", ".intercalate names.toList
   let mut byModule : Std.HashMap String (Array ManifestInventoryEntry) := {}
   for inv in inventory do
     byModule := byModule.insert inv.module
@@ -179,5 +239,15 @@ def validateManifestAgainstInventory
     let joined := ", ".intercalate sorted.toList
     throw <| IO.userError
       s!"Tagged @[eval_problem] declaration(s) are missing from manifests/problems/: {joined}"
+
+/-- Match Python's `gp.validate_manifest_against_inventory`: ensure every
+manifest hole resolves to exactly one `@[eval_problem]`-tagged declaration,
+and every such declaration appears in the manifest. -/
+def validateManifestAgainstInventory
+    (root : System.FilePath) (entries : Array EvalProblemMetadata)
+    (buildModules : Bool := true) : IO Unit := do
+  let modules := uniqueModules entries
+  let inventory ← runInventoryTool root modules buildModules
+  validateManifestAgainstInventoryEntries entries inventory
 
 end EvalTools

--- a/EvalTools/ModuleCoverage.lean
+++ b/EvalTools/ModuleCoverage.lean
@@ -81,6 +81,17 @@ private partial def collectSourceModules (dir : System.FilePath) (relDir : Strin
               imports := header.imports.map (·.module) }
   return out
 
+/-- Load every source module under `LeanEval/`, using Lean's own module-header
+parser to identify imports. This is shared by module-coverage validation and
+the CI dependency selector so they cannot disagree about Lean import syntax. -/
+def loadProblemSourceModules (root : System.FilePath) : IO (Array ProblemSourceModule) := do
+  let sourceRoot := root / problemSourceRelativePath
+  unless ← sourceRoot.isDir do
+    throw <| IO.userError
+      s!"Problem source directory `{sourceRoot}` does not exist or is not a directory."
+  let prefixName := problemSourceRelativePath.toString
+  collectSourceModules sourceRoot prefixName (.str .anonymous prefixName)
+
 /-- Fail unless every `.lean` file under `LeanEval/` is reachable from the
 manifest: either named by some entry's `module` field, or imported (directly or
 transitively) by a module that is.
@@ -93,12 +104,7 @@ This is a header-level check: it parses imports rather than building anything,
 so it costs no build time and runs before the inventory cross-check. -/
 def checkProblemModuleCoverage
     (root : System.FilePath) (entries : Array EvalProblemMetadata) : IO Unit := do
-  let sourceRoot := root / problemSourceRelativePath
-  unless ← sourceRoot.isDir do
-    throw <| IO.userError
-      s!"Problem source directory `{sourceRoot}` does not exist or is not a directory."
-  let prefixName := problemSourceRelativePath.toString
-  let sources ← collectSourceModules sourceRoot prefixName (.str .anonymous prefixName)
+  let sources ← loadProblemSourceModules root
   let known := sources.foldl (fun s source => s.insert source.name) (∅ : Std.HashSet Name)
   let missing := entries.filterMap fun entry =>
     if known.contains (parseModuleName entry.moduleName) then none

--- a/EvalTools/ValidateManifest.lean
+++ b/EvalTools/ValidateManifest.lean
@@ -14,18 +14,39 @@ The coverage check comes first because it is the only one that does not need a
 build, and because the inventory cross-check is blind to modules the manifest
 never names.
 
-`modulesBuilt` is an internal CI optimization for the case where
-`check-problem-build` has just successfully built the same source tree.
+`structureOnly` runs the cheap global checks without importing compiled
+modules. `inventoryDir?` validates JSON collected by parallel CI shards;
+`requestedModules` narrows that validation for dependency-selected PRs.
+`modulesBuilt` remains an optimization for callers using the original
+single-process inventory path after `check-problem-build`.
 
 The Python original also called `gp.validate_hole_shape`, a textual pre-check
 for typos in hole names. That check is purely redundant with the inventory
 cross-check (which goes through the elaborator), so it is dropped here. -/
-def runValidateManifest (root : System.FilePath) (modulesBuilt : Bool := false) : IO UInt32 := do
+def runValidateManifest (root : System.FilePath) (modulesBuilt : Bool := false)
+    (structureOnly : Bool := false) (inventoryDir? : Option System.FilePath := none)
+    (requestedModules : Array String := #[]) : IO UInt32 := do
   try
     let entries ← loadManifest root
     checkProblemModuleCoverage root entries
-    validateManifestAgainstInventory root entries (buildModules := !modulesBuilt)
-    IO.println "Manifest and @[eval_problem] declarations are consistent."
+    if structureOnly then
+      if inventoryDir?.isSome then
+        throw <| IO.userError "--structure-only and --inventory-dir cannot be used together."
+      IO.println "Manifest structure and problem-module coverage are consistent."
+    else
+      match inventoryDir? with
+      | some inventoryDir =>
+          let inventory ← loadInventoryDirectory inventoryDir
+          let modules ← selectManifestModules entries requestedModules
+          let selected := modules.foldl
+            (fun set moduleName => set.insert moduleName) ({} : Std.HashSet String)
+          let selectedEntries := entries.filter fun entry => selected.contains entry.moduleName
+          validateManifestAgainstInventoryEntries selectedEntries inventory
+      | none =>
+          unless requestedModules.isEmpty do
+            throw <| IO.userError "--module requires --inventory-dir."
+          validateManifestAgainstInventory root entries (buildModules := !modulesBuilt)
+      IO.println "Manifest and @[eval_problem] declarations are consistent."
     return 0
   catch err =>
     IO.eprintln err

--- a/scripts/select_ci_problems.py
+++ b/scripts/select_ci_problems.py
@@ -2,11 +2,10 @@
 """Select and shard the catalog work needed for a CI change.
 
 Pull requests validate changed problem modules and every manifest root that
-imports them, transitively.  Changes to shared generator/infrastructure inputs
-are conservative full-catalog sentinels.  Pushes validate the full catalog.
-
-The script deliberately has no third-party dependencies so the classify job
-can run before installing Lean or restoring the Mathlib cache.
+imports them, transitively. Lean itself parses module headers and provides the
+dependency graph consumed here. Changes to shared generator/infrastructure
+inputs are conservative full-catalog sentinels. Pushes validate the full
+catalog.
 """
 
 from __future__ import annotations
@@ -14,6 +13,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import json
+import os
 import pathlib
 import re
 import subprocess
@@ -23,7 +23,6 @@ from collections import defaultdict, deque
 from collections.abc import Iterable, Sequence
 
 
-IMPORT_RE = re.compile(r"^\s*import\s+([^\s]+)\s*(?:--.*)?$")
 PROBLEM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 ZERO_SHA = "0" * 40
 
@@ -73,54 +72,81 @@ def load_problems(root: pathlib.Path) -> tuple[Problem, ...]:
     return tuple(problems)
 
 
-def module_name_for_path(path: pathlib.Path, source_root: pathlib.Path) -> str:
-    relative = path.relative_to(source_root)
-    parts = list(relative.parts)
-    parts[-1] = pathlib.Path(parts[-1]).stem
-    if any("." in part or not part for part in parts):
-        raise ValueError(f"cannot safely derive a Lean module name from {relative}")
-    return ".".join((source_root.name, *parts))
+def load_import_graph(path: pathlib.Path) -> tuple[dict[str, str], dict[str, set[str]]]:
+    """Load the graph emitted by the Lean `ci_import_graph` executable."""
+    try:
+        entries = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot load Lean import graph from {path}: {error}") from error
+    if not isinstance(entries, list):
+        raise ValueError("Lean import graph must be a JSON array")
 
-
-def load_import_graph(root: pathlib.Path) -> tuple[dict[str, str], dict[str, set[str]]]:
-    source_root = root / "LeanEval"
     paths: dict[str, str] = {}
     imports: dict[str, set[str]] = {}
-    for path in sorted(source_root.rglob("*.lean")):
-        module = module_name_for_path(path, source_root)
-        relative = path.relative_to(root).as_posix()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Lean import graph entry {index} must be an object")
+        relative = entry.get("path")
+        module = entry.get("module")
+        imported_modules = entry.get("imports")
+        if (
+            not isinstance(relative, str)
+            or not relative.startswith("LeanEval/")
+            or not relative.endswith(".lean")
+            or any(char in relative for char in "\0\r\n")
+        ):
+            raise ValueError(f"Lean import graph entry {index} has an unsafe path: {relative!r}")
+        if (
+            not isinstance(module, str)
+            or not module.startswith("LeanEval.")
+            or any(char in module for char in "\0\r\n")
+        ):
+            raise ValueError(f"Lean import graph entry {index} has an unsafe module: {module!r}")
+        if not isinstance(imported_modules, list) or not all(
+            isinstance(imported, str) for imported in imported_modules
+        ):
+            raise ValueError(f"Lean import graph entry {index} has invalid imports")
+        if relative in paths:
+            raise ValueError(f"duplicate path in Lean import graph: {relative}")
+        if module in imports:
+            raise ValueError(f"duplicate module in Lean import graph: {module}")
         paths[relative] = module
-        local_imports: set[str] = set()
-        for line in path.read_text(encoding="utf-8").splitlines():
-            if not line.lstrip().startswith("import "):
-                continue
-            match = IMPORT_RE.match(line)
-            if match is None:
-                raise ValueError(f"cannot safely parse import line in {relative}: {line!r}")
-            imported = match.group(1)
-            if imported.startswith("LeanEval."):
-                local_imports.add(imported)
-        imports[module] = local_imports
+        imports[module] = {
+            imported for imported in imported_modules if imported.startswith("LeanEval.")
+        }
     return paths, imports
+
+
+def parse_git_changes(output: bytes) -> tuple[Change, ...]:
+    """Parse `git diff --name-status -z` without Git path quoting."""
+    fields = output.split(b"\0")
+    if not fields or fields[-1] != b"":
+        raise ValueError("git diff output is not NUL terminated")
+    fields.pop()
+    changes: list[Change] = []
+    index = 0
+    while index < len(fields):
+        status = os.fsdecode(fields[index])
+        index += 1
+        path_count = 2 if status.startswith(("C", "R")) else 1
+        if not status or index + path_count > len(fields):
+            raise ValueError(f"unexpected git diff record near status {status!r}")
+        paths = tuple(os.fsdecode(field) for field in fields[index:index + path_count])
+        index += path_count
+        changes.append(Change(status, paths))
+    return tuple(changes)
 
 
 def git_changes(root: pathlib.Path, base: str, head: str) -> tuple[Change, ...]:
     if base == ZERO_SHA:
         return (Change("A", ("<initial-push>",)),)
     result = subprocess.run(
-        ["git", "diff", "--name-status", "--find-renames", f"{base}..{head}"],
+        ["git", "diff", "--name-status", "-z", "--find-renames", f"{base}..{head}"],
         cwd=root,
         check=True,
-        text=True,
         stdout=subprocess.PIPE,
     )
-    changes: list[Change] = []
-    for line in result.stdout.splitlines():
-        fields = line.split("\t")
-        if len(fields) < 2:
-            raise ValueError(f"unexpected git diff record: {line!r}")
-        changes.append(Change(fields[0], tuple(fields[1:])))
-    return tuple(changes)
+    return parse_git_changes(result.stdout)
 
 
 def reverse_dependants(imports: dict[str, set[str]], changed: Iterable[str]) -> set[str]:
@@ -224,13 +250,12 @@ def select(
             changed_source_paths.add(path)
 
     if changed_source_paths:
-        try:
-            path_modules, imports = graph if graph is not None else load_import_graph(root)
-        except ValueError as error:
+        if graph is None:
             return Selection(
-                "full", (f"import graph fallback: {error}",), all_ids, all_modules,
+                "full", ("Lean import graph unavailable",), all_ids, all_modules,
                 source_changed, generated_changed, run_checks,
             )
+        path_modules, imports = graph
         missing = sorted(changed_source_paths - path_modules.keys())
         if missing:
             return Selection(
@@ -318,6 +343,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--base", required=True)
     parser.add_argument("--head", default="HEAD")
     parser.add_argument("--shards", type=int, default=8)
+    parser.add_argument("--import-graph", type=pathlib.Path, required=True)
     parser.add_argument("--github-output", type=pathlib.Path)
     args = parser.parse_args(argv)
     if args.shards <= 0:
@@ -325,7 +351,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     root = args.root.resolve()
     problems = load_problems(root)
     changes = git_changes(root, args.base, args.head)
-    selection = select(root, args.event, changes, problems)
+    graph = load_import_graph(args.import_graph)
+    selection = select(root, args.event, changes, problems, graph)
     matrix = make_matrix(selection, problems, args.shards)
     print(
         f"Catalog selection: {selection.mode}; {len(selection.problems)} problem(s), "

--- a/scripts/select_ci_problems.py
+++ b/scripts/select_ci_problems.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Select and shard the catalog work needed for a CI change.
+
+Pull requests validate changed problem modules and every manifest root that
+imports them, transitively.  Changes to shared generator/infrastructure inputs
+are conservative full-catalog sentinels.  Pushes validate the full catalog.
+
+The script deliberately has no third-party dependencies so the classify job
+can run before installing Lean or restoring the Mathlib cache.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import tomllib
+from collections import defaultdict, deque
+from collections.abc import Iterable, Sequence
+
+
+IMPORT_RE = re.compile(r"^\s*import\s+([^\s]+)\s*(?:--.*)?$")
+PROBLEM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+ZERO_SHA = "0" * 40
+
+
+@dataclasses.dataclass(frozen=True)
+class Problem:
+    id: str
+    module: str
+
+
+@dataclasses.dataclass(frozen=True)
+class Change:
+    status: str
+    paths: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class Selection:
+    mode: str
+    reasons: tuple[str, ...]
+    problems: tuple[str, ...]
+    modules: tuple[str, ...]
+    source_changed: bool
+    generated_changed: bool
+    run_checks: bool
+
+    @property
+    def run_catalog(self) -> bool:
+        return bool(self.problems)
+
+
+def load_problems(root: pathlib.Path) -> tuple[Problem, ...]:
+    problems: list[Problem] = []
+    seen_ids: set[str] = set()
+    for path in sorted((root / "manifests" / "problems").glob("*.toml")):
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        problem_id = data["id"]
+        module = data["module"]
+        if problem_id != path.stem or PROBLEM_ID_RE.fullmatch(problem_id) is None:
+            raise ValueError(f"unsafe or mismatched problem id in {path}: {problem_id!r}")
+        if problem_id in seen_ids:
+            raise ValueError(f"duplicate problem id in CI selector: {problem_id}")
+        if not module.startswith("LeanEval.") or any(char in module for char in ",\r\n"):
+            raise ValueError(f"unsafe problem module in {path}: {module!r}")
+        seen_ids.add(problem_id)
+        problems.append(Problem(id=problem_id, module=module))
+    return tuple(problems)
+
+
+def module_name_for_path(path: pathlib.Path, source_root: pathlib.Path) -> str:
+    relative = path.relative_to(source_root)
+    parts = list(relative.parts)
+    parts[-1] = pathlib.Path(parts[-1]).stem
+    if any("." in part or not part for part in parts):
+        raise ValueError(f"cannot safely derive a Lean module name from {relative}")
+    return ".".join((source_root.name, *parts))
+
+
+def load_import_graph(root: pathlib.Path) -> tuple[dict[str, str], dict[str, set[str]]]:
+    source_root = root / "LeanEval"
+    paths: dict[str, str] = {}
+    imports: dict[str, set[str]] = {}
+    for path in sorted(source_root.rglob("*.lean")):
+        module = module_name_for_path(path, source_root)
+        relative = path.relative_to(root).as_posix()
+        paths[relative] = module
+        local_imports: set[str] = set()
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.lstrip().startswith("import "):
+                continue
+            match = IMPORT_RE.match(line)
+            if match is None:
+                raise ValueError(f"cannot safely parse import line in {relative}: {line!r}")
+            imported = match.group(1)
+            if imported.startswith("LeanEval."):
+                local_imports.add(imported)
+        imports[module] = local_imports
+    return paths, imports
+
+
+def git_changes(root: pathlib.Path, base: str, head: str) -> tuple[Change, ...]:
+    if base == ZERO_SHA:
+        return (Change("A", ("<initial-push>",)),)
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "--find-renames", f"{base}..{head}"],
+        cwd=root,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    changes: list[Change] = []
+    for line in result.stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) < 2:
+            raise ValueError(f"unexpected git diff record: {line!r}")
+        changes.append(Change(fields[0], tuple(fields[1:])))
+    return tuple(changes)
+
+
+def reverse_dependants(imports: dict[str, set[str]], changed: Iterable[str]) -> set[str]:
+    reverse: dict[str, set[str]] = defaultdict(set)
+    for module, dependencies in imports.items():
+        for dependency in dependencies:
+            reverse[dependency].add(module)
+    reached = set(changed)
+    queue = deque(changed)
+    while queue:
+        dependency = queue.popleft()
+        for dependant in reverse.get(dependency, ()):
+            if dependant not in reached:
+                reached.add(dependant)
+                queue.append(dependant)
+    return reached
+
+
+def is_full_catalog_sentinel(path: str) -> bool:
+    return (
+        path.startswith("EvalTools/")
+        or path.startswith("templates/")
+        or path.startswith(".github/actions/")
+        or path == ".github/workflows/ci.yml"
+        or path == "scripts/select_ci_problems.py"
+        or path in {"lakefile.toml", "lake-manifest.json", "lean-toolchain"}
+    )
+
+
+def select(
+    root: pathlib.Path,
+    event: str,
+    changes: Sequence[Change],
+    problems: Sequence[Problem] | None = None,
+    graph: tuple[dict[str, str], dict[str, set[str]]] | None = None,
+) -> Selection:
+    problems = tuple(problems if problems is not None else load_problems(root))
+    by_id = {problem.id: problem for problem in problems}
+    by_module: dict[str, set[str]] = defaultdict(set)
+    for problem in problems:
+        by_module[problem.module].add(problem.id)
+
+    changed_paths = [path for change in changes for path in change.paths]
+    source_changed = any(
+        path.startswith(("LeanEval/", "EvalTools/", "templates/", "manifests/problems/"))
+        or path in {"lakefile.toml", "lake-manifest.json", "lean-toolchain"}
+        for path in changed_paths
+    )
+    generated_changed = any(path.startswith("generated/") for path in changed_paths)
+    infrastructure_changed = any(
+        path.startswith((".github/workflows/", ".github/actions/", "scripts/", "tests/"))
+        for path in changed_paths
+    )
+    run_checks = source_changed or generated_changed or infrastructure_changed
+
+    all_ids = tuple(sorted(by_id))
+    all_modules = tuple(sorted(by_module))
+    if event == "push":
+        return Selection(
+            "full", ("push to main",), all_ids, all_modules,
+            source_changed, generated_changed, run_checks,
+        )
+
+    sentinel_paths = sorted({path for path in changed_paths if is_full_catalog_sentinel(path)})
+    destructive = [
+        change
+        for change in changes
+        if change.status.startswith(("D", "R"))
+        and any(
+            path.startswith(("LeanEval/", "manifests/problems/"))
+            for path in change.paths
+        )
+    ]
+    if sentinel_paths or destructive:
+        reasons = []
+        if sentinel_paths:
+            reasons.append("full-catalog sentinel: " + ", ".join(sentinel_paths))
+        if destructive:
+            reasons.append("deleted or renamed path")
+        return Selection(
+            "full", tuple(reasons), all_ids, all_modules,
+            source_changed, generated_changed, run_checks,
+        )
+
+    selected_ids: set[str] = set()
+    changed_source_paths: set[str] = set()
+    reasons: list[str] = []
+    for path in changed_paths:
+        if path.startswith("manifests/problems/"):
+            if path.endswith(".toml"):
+                problem_id = pathlib.PurePosixPath(path).stem
+                if problem_id in by_id:
+                    selected_ids.add(problem_id)
+                    reasons.append(f"manifest {problem_id}")
+        elif path.startswith("generated/"):
+            parts = pathlib.PurePosixPath(path).parts
+            if len(parts) >= 2 and parts[1] in by_id:
+                selected_ids.add(parts[1])
+                reasons.append(f"generated workspace {parts[1]}")
+        elif path.startswith("LeanEval/") and path.endswith(".lean"):
+            changed_source_paths.add(path)
+
+    if changed_source_paths:
+        try:
+            path_modules, imports = graph if graph is not None else load_import_graph(root)
+        except ValueError as error:
+            return Selection(
+                "full", (f"import graph fallback: {error}",), all_ids, all_modules,
+                source_changed, generated_changed, run_checks,
+            )
+        missing = sorted(changed_source_paths - path_modules.keys())
+        if missing:
+            return Selection(
+                "full", ("changed source missing from graph: " + ", ".join(missing),),
+                all_ids, all_modules, source_changed, generated_changed, run_checks,
+            )
+        changed_modules = {path_modules[path] for path in changed_source_paths}
+        affected_modules = reverse_dependants(imports, changed_modules)
+        affected_roots = affected_modules & by_module.keys()
+        for module in affected_roots:
+            selected_ids.update(by_module[module])
+        reasons.append(
+            f"{len(changed_modules)} changed module(s), {len(affected_roots)} affected manifest root(s)"
+        )
+
+    # Keep all problems sharing a selected module together.  Inventory
+    # validation is module-scoped, so splitting such entries would make tagged
+    # declarations from the other half look untracked.
+    selected_modules = {by_id[problem_id].module for problem_id in selected_ids}
+    for module in selected_modules:
+        selected_ids.update(by_module[module])
+
+    return Selection(
+        "targeted" if selected_ids else "none",
+        tuple(dict.fromkeys(reasons)),
+        tuple(sorted(selected_ids)),
+        tuple(sorted(selected_modules)),
+        source_changed,
+        generated_changed,
+        run_checks,
+    )
+
+
+def make_matrix(selection: Selection, problems: Sequence[Problem], shard_limit: int) -> dict:
+    by_module: dict[str, list[str]] = defaultdict(list)
+    selected = set(selection.problems)
+    for problem in problems:
+        if problem.id in selected:
+            by_module[problem.module].append(problem.id)
+    if not by_module:
+        # GitHub validates a matrix before evaluating the job-level `if`.
+        return {"include": [{"shard": 0, "shard_count": 1, "problems": "", "modules": ""}]}
+
+    shard_count = min(shard_limit, len(by_module))
+    shards: list[list[str]] = [[] for _ in range(shard_count)]
+    weights = [0] * shard_count
+    for module, module_problems in sorted(by_module.items(), key=lambda item: (-len(item[1]), item[0])):
+        shard = min(range(shard_count), key=lambda index: (weights[index], index))
+        shards[shard].append(module)
+        weights[shard] += len(module_problems)
+
+    include = []
+    for index, modules in enumerate(shards):
+        modules.sort()
+        problem_ids = sorted(problem for module in modules for problem in by_module[module])
+        include.append({
+            "shard": index,
+            "shard_count": shard_count,
+            "problems": ",".join(problem_ids),
+            "modules": ",".join(modules),
+        })
+    return {"include": include}
+
+
+def write_github_output(path: pathlib.Path, selection: Selection, matrix: dict) -> None:
+    values = {
+        "source_changed": str(selection.source_changed).lower(),
+        "generated_changed": str(selection.generated_changed).lower(),
+        "run_checks": str(selection.run_checks).lower(),
+        "run_catalog": str(selection.run_catalog).lower(),
+        "selection_mode": selection.mode,
+        "selected_problem_count": str(len(selection.problems)),
+        "selected_modules": ",".join(selection.modules),
+        "matrix": json.dumps(matrix, separators=(",", ":")),
+    }
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path("."))
+    parser.add_argument("--event", choices=("push", "pull_request"), required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--shards", type=int, default=8)
+    parser.add_argument("--github-output", type=pathlib.Path)
+    args = parser.parse_args(argv)
+    if args.shards <= 0:
+        parser.error("--shards must be positive")
+    root = args.root.resolve()
+    problems = load_problems(root)
+    changes = git_changes(root, args.base, args.head)
+    selection = select(root, args.event, changes, problems)
+    matrix = make_matrix(selection, problems, args.shards)
+    print(
+        f"Catalog selection: {selection.mode}; {len(selection.problems)} problem(s), "
+        f"{len(selection.modules)} module(s)"
+    )
+    for reason in selection.reasons:
+        print(f"  - {reason}")
+    if args.github_output is not None:
+        write_github_output(args.github_output, selection, matrix)
+    else:
+        print(json.dumps(matrix, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
+++ b/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
@@ -122,6 +122,25 @@ def main : IO UInt32 := do
       | .ok _ => pure none
       | .error err => pure (some s!"expected success, got {err}")
 
+  check "Lean header parser recognizes module-system import modifiers" passes fails do
+    withFakeRepo
+      #[("LeanEval/Claimed.lean",
+          "module\npublic import LeanEval.Public\npublic meta import LeanEval.Meta\n" ++
+            "meta import LeanEval.MetaOnly\nimport all LeanEval.All\n"),
+        ("LeanEval/Public.lean", "import Mathlib\n"),
+        ("LeanEval/Meta.lean", "import Mathlib\n"),
+        ("LeanEval/MetaOnly.lean", "import Mathlib\n"),
+        ("LeanEval/All.lean", "import Mathlib\n")] fun root => do
+      match ← (loadProblemSourceModules root).toBaseIO with
+      | .error err => pure (some s!"expected success, got {err}")
+      | .ok sources =>
+          match sources.find? (fun source => source.name == `LeanEval.Claimed) with
+          | none => pure (some "LeanEval.Claimed was absent from the source graph")
+          | some claimed =>
+              let localImports := claimed.imports.filter (toString · |>.startsWith "LeanEval.")
+              pure <| assertEq "imports" (moduleNames localImports)
+                (#["LeanEval.Public", "LeanEval.Meta", "LeanEval.MetaOnly", "LeanEval.All"])
+
   check "checkProblemModuleCoverage rejects an unreached module" passes fails do
     withFakeRepo
       #[("LeanEval/Claimed.lean", "import Mathlib\n"),

--- a/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
+++ b/tests/lean/EvalToolsTests/ModuleCoverageTest.lean
@@ -52,6 +52,10 @@ private def problem (id moduleName : String) : EvalProblemMetadata :=
   { id := id, title := id, test := false, moduleName := moduleName,
     holes := #["hole"], submitter := "tester" }
 
+private def inventory (moduleName declarationName : String) : ManifestInventoryEntry :=
+  { module := moduleName, declarationName := declarationName,
+    basename := "hole", kind := "theorem" }
+
 def main : IO UInt32 := do
   let passes ← IO.mkRef 0
   let fails ← IO.mkRef 0
@@ -151,6 +155,30 @@ def main : IO UInt32 := do
       match ← (loadManifest root).toBaseIO with
       | .ok entries => pure <| assertEq "entries" entries.size 0
       | .error err => pure (some s!"expected success, got {err}")
+
+  check "aggregated inventory accepts every manifest module exactly once" passes fails do
+    let entries := #[problem "a" "LeanEval.A", problem "b" "LeanEval.B"]
+    let rows := #[inventory "LeanEval.A" "LeanEval.A.hole",
+      inventory "LeanEval.B" "LeanEval.B.hole"]
+    match ← (validateManifestAgainstInventoryEntries entries rows).toBaseIO with
+    | .ok _ => pure none
+    | .error err => pure (some s!"expected success, got {err}")
+
+  check "aggregated inventory rejects a missing shard module" passes fails do
+    let entries := #[problem "a" "LeanEval.A", problem "b" "LeanEval.B"]
+    let rows := #[inventory "LeanEval.A" "LeanEval.A.hole"]
+    match ← (validateManifestAgainstInventoryEntries entries rows).toBaseIO with
+    | .ok _ => pure (some "expected rejection")
+    | .error err => pure <| assertContains "err" (toString err) "LeanEval.B"
+
+  check "aggregated inventory rejects untracked tagged declarations" passes fails do
+    let entries := #[problem "a" "LeanEval.A"]
+    let rows := #[inventory "LeanEval.A" "LeanEval.A.hole",
+      { module := "LeanEval.A", declarationName := "LeanEval.A.extra",
+        basename := "extra", kind := "theorem" }]
+    match ← (validateManifestAgainstInventoryEntries entries rows).toBaseIO with
+    | .ok _ => pure (some "expected rejection")
+    | .error err => pure <| assertContains "err" (toString err) "LeanEval.A.extra"
 
   -- The `@[eval_problem]` elaborator reads every `*.toml` in the directory,
   -- hidden or not. If `loadManifest` skipped hidden ones, a `.helper.toml`

--- a/tests/python/test_select_ci_problems.py
+++ b/tests/python/test_select_ci_problems.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import pathlib
 import sys
+import tempfile
 import unittest
 
 
@@ -99,6 +101,53 @@ class SelectCIProblemsTest(unittest.TestCase):
                 locations[problem] = shard["shard"]
         self.assertEqual(locations["b"], locations["b_second"])
         self.assertEqual(set(locations), {"a", "b", "b_second", "c"})
+
+    def test_empty_matrix_has_a_placeholder_for_github_validation(self):
+        selection = self.select((Change("M", ("README.md",)),))
+        self.assertEqual(
+            SELECTOR.make_matrix(selection, self.problems, 8),
+            {"include": [
+                {"shard": 0, "shard_count": 1, "problems": "", "modules": ""}
+            ]},
+        )
+
+    def test_nul_git_changes_preserve_unicode_and_rename_paths(self):
+        changes = SELECTOR.parse_git_changes(
+            "M\0LeanEval/Über.lean\0R100\0LeanEval/Old.lean\0"
+            "LeanEval/New.lean\0".encode()
+        )
+        self.assertEqual(
+            changes,
+            (
+                Change("M", ("LeanEval/Über.lean",)),
+                Change("R100", ("LeanEval/Old.lean", "LeanEval/New.lean")),
+            ),
+        )
+
+    def test_nul_git_changes_reject_truncated_records(self):
+        with self.assertRaisesRegex(ValueError, "unexpected git diff record"):
+            SELECTOR.parse_git_changes(b"R100\0LeanEval/Old.lean\0")
+
+    def test_loads_graph_emitted_by_lean(self):
+        payload = [
+            {
+                "path": "LeanEval/A.lean",
+                "module": "LeanEval.A",
+                "imports": ["Mathlib", "LeanEval.Helper"],
+            },
+            {
+                "path": "LeanEval/Helper.lean",
+                "module": "LeanEval.Helper",
+                "imports": [],
+            },
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "import-graph.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            paths, imports = SELECTOR.load_import_graph(path)
+        self.assertEqual(paths["LeanEval/A.lean"], "LeanEval.A")
+        self.assertEqual(imports["LeanEval.A"], {"LeanEval.Helper"})
+        self.assertEqual(imports["LeanEval.Helper"], set())
 
 
 if __name__ == "__main__":

--- a/tests/python/test_select_ci_problems.py
+++ b/tests/python/test_select_ci_problems.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "select_ci_problems", ROOT / "scripts" / "select_ci_problems.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+SELECTOR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SELECTOR
+SPEC.loader.exec_module(SELECTOR)
+
+Change = SELECTOR.Change
+Problem = SELECTOR.Problem
+
+
+class SelectCIProblemsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.problems = (
+            Problem("a", "LeanEval.A"),
+            Problem("b", "LeanEval.B"),
+            Problem("b_second", "LeanEval.B"),
+            Problem("c", "LeanEval.C"),
+        )
+        self.graph = (
+            {
+                "LeanEval/A.lean": "LeanEval.A",
+                "LeanEval/B.lean": "LeanEval.B",
+                "LeanEval/C.lean": "LeanEval.C",
+                "LeanEval/Helper.lean": "LeanEval.Helper",
+            },
+            {
+                "LeanEval.A": {"LeanEval.Helper"},
+                "LeanEval.B": {"LeanEval.A"},
+                "LeanEval.C": set(),
+                "LeanEval.Helper": set(),
+            },
+        )
+
+    def select(self, changes, event="pull_request"):
+        return SELECTOR.select(ROOT, event, changes, self.problems, self.graph)
+
+    def test_changed_helper_selects_transitive_reverse_dependants(self):
+        selection = self.select((Change("M", ("LeanEval/Helper.lean",)),))
+        self.assertEqual(selection.mode, "targeted")
+        self.assertEqual(selection.problems, ("a", "b", "b_second"))
+        self.assertEqual(selection.modules, ("LeanEval.A", "LeanEval.B"))
+
+    def test_shared_module_keeps_all_problems_together(self):
+        selection = self.select((Change("M", ("manifests/problems/b.toml",)),))
+        self.assertEqual(selection.problems, ("b", "b_second"))
+        self.assertEqual(selection.modules, ("LeanEval.B",))
+
+    def test_generated_change_selects_its_problem(self):
+        selection = self.select((Change("M", ("generated/c/Challenge.lean",)),))
+        self.assertEqual(selection.problems, ("c",))
+        self.assertTrue(selection.generated_changed)
+
+    def test_generator_change_is_a_full_catalog_sentinel(self):
+        selection = self.select((Change("M", ("EvalTools/Generate.lean",)),))
+        self.assertEqual(selection.mode, "full")
+        self.assertEqual(selection.problems, ("a", "b", "b_second", "c"))
+
+    def test_deleted_source_falls_back_to_full_catalog(self):
+        selection = self.select((Change("D", ("LeanEval/Helper.lean",)),))
+        self.assertEqual(selection.mode, "full")
+
+    def test_docs_only_change_selects_no_catalog_work(self):
+        selection = self.select((Change("M", ("README.md",)),))
+        self.assertEqual(selection.mode, "none")
+        self.assertFalse(selection.run_catalog)
+
+    def test_deleted_doc_still_selects_no_catalog_work(self):
+        selection = self.select((Change("D", ("docs/old.md",)),))
+        self.assertEqual(selection.mode, "none")
+
+    def test_deleted_generated_file_selects_its_workspace(self):
+        selection = self.select((Change("D", ("generated/c/README.md",)),))
+        self.assertEqual(selection.mode, "targeted")
+        self.assertEqual(selection.problems, ("c",))
+
+    def test_push_always_selects_full_catalog(self):
+        selection = self.select((Change("M", ("README.md",)),), event="push")
+        self.assertEqual(selection.mode, "full")
+        self.assertEqual(len(selection.problems), 4)
+
+    def test_matrix_balances_by_problem_and_preserves_modules(self):
+        selection = self.select((Change("M", ("EvalTools/Generate.lean",)),))
+        matrix = SELECTOR.make_matrix(selection, self.problems, 2)["include"]
+        self.assertEqual(len(matrix), 2)
+        locations = {}
+        for shard in matrix:
+            for problem in shard["problems"].split(","):
+                locations[problem] = shard["shard"]
+        self.assertEqual(locations["b"], locations["b_second"])
+        self.assertEqual(set(locations), {"a", "b", "b_second", "c"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- move warning-sensitive problem-module builds into the existing catalog shards
- clear only cached `LeanEval` compiler outputs before the warning scan, preserving dependency caches while forcing local modules and helpers to rebuild
- emit and aggregate a small tagged-declaration inventory artifact from each shard
- replace the serial repository-wide compile with structural manifest checks and unit tests
- have Lean's own module-header parser export the dependency graph used for changed-module and transitive reverse-import selection
- parse Git's NUL-delimited name-status records so unusual and Unicode paths cannot disappear through quoting
- keep full catalog validation for `main`, generator/toolchain/workflow sentinels, and destructive source/manifest changes
- keep all problems sharing a module in the same balanced shard

## Expected effect

The deployed workflow's remaining critical path is the 34-minute repository-wide warning build; catalog shards finish around 20 minutes. This folds that build into the shard fan-out. Ordinary problem PRs also run only affected roots, while `main` remains a full validation.

## Validation

- full real-catalog warning build across all eight computed shards; no disallowed warnings
- collected eight inventories covering 247 problems / 231 manifest modules and validated their aggregate
- shard balance: 30–31 problems and 28–29 modules per shard
- Lean-produced import graph covers all 240 source modules and handles `public`, `meta`, `public meta`, and `all` imports
- 103 Lean unit tests (16 submission, 62 generation, 17 module/inventory, 8 comparator)
- 14 Python dependency-selector tests, including NUL-delimited Unicode and rename records
- direct Lean checks for every edited module; no warnings
- `lake build lean-eval test_module_coverage`
- `actionlint .github/workflows/ci.yml`
- action pin audit, Python syntax checks, and `git diff --check`
- full GitHub Actions run [32007681365](https://github.com/leanprover/lean-eval/actions/runs/32007681365): success in 30m12s, all 13 checks green, zero annotations
