### PR TITLE
ci: validate global generated catalog state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
       - name: Validate manifest structure and module coverage
         run: lake exe lean-eval validate-manifest --structure-only
 
+      # Source-only changes intentionally leave generated/index.json for the
+      # trusted main regenerator. If a PR touches generated/ itself, however,
+      # its committed global index must be current and it may not add an
+      # unexpected workspace directory.
+      - name: Validate generated index and unexpected directories
+        if: needs.classify.outputs.source_changed != 'true' || needs.classify.outputs.generated_changed == 'true'
+        run: lake exe lean-eval validate-generated-catalog
+
       - name: Submission policy smoke check
         run: lake exe lean-eval validate-submission --file generated/two_plus_two/Solution.lean
 

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -2760,6 +2760,35 @@ def writeOrCheckIndex (root : System.FilePath) (entries : Array OJson) (check : 
   IO.FS.writeFile indexPath content
   return #[]
 
+/-- The `generated/index.json` row determined by one manifest entry. Keep this
+in one place so full generation and the cheap global consistency check cannot
+disagree about the index format. -/
+def generatedIndexEntry (entry : EvalProblemMetadata) : OJson :=
+  ojObj #[
+    ("id", ojStr entry.id),
+    ("title", ojStr entry.title),
+    ("test", ojBool entry.test),
+    ("submitter", ojStr entry.submitter),
+    ("module", ojStr entry.moduleName),
+    ("holes", ojStrArr entry.holes),
+    ("generated_path", ojStr s!"generated/{entry.id}")
+  ]
+
+/-- Check the global generated-tree invariants that per-problem generation
+cannot establish: the index must exactly match the manifest, and every
+generated workspace directory must belong to a manifest problem. This does no
+extraction, module compilation, or workspace generation. -/
+def validateGeneratedCatalog (root : System.FilePath) : IO Unit := do
+  let problems ← loadManifest root
+  let selectedIds : Std.HashSet String :=
+    problems.foldl (fun acc p => acc.insert p.id) {}
+  let mut mismatches ← syncUnknownProblemDirs root selectedIds (check := true)
+  mismatches := mismatches ++
+    (← writeOrCheckIndex root (problems.map generatedIndexEntry) (check := true))
+  if !mismatches.isEmpty then
+    throw <| IO.userError <| "\n".intercalate mismatches.toList
+  IO.println "Generated index is up to date; no unexpected workspace directories exist."
+
 /-! ## Generate orchestrator -/
 
 /-- Main `generate` entry point. Mirrors `scripts/generate_projects.py:generate`. -/
@@ -2786,7 +2815,6 @@ def generate (root : System.FilePath) (selectedProblemId : Option String) (check
   let mathlibDep ← loadRootMathlibDependency root
   buildExtractor root selectedProblems
   let workspaceTest ← loadWorkspaceTestTemplate root
-  let mut indexEntries : Array OJson := #[]
   let mut mismatches : Array String := #[]
   for entry in selectedProblems do
     let mut extracteds : Array ExtractedTheorem := #[]
@@ -2800,17 +2828,9 @@ def generate (root : System.FilePath) (selectedProblemId : Option String) (check
       mismatches := mismatches ++ (← checkWorkspace problemDir relDisplay files)
     else
       writeWorkspace problemDir files
-    indexEntries := indexEntries.push <| ojObj #[
-      ("id", ojStr entry.id),
-      ("title", ojStr entry.title),
-      ("test", ojBool entry.test),
-      ("submitter", ojStr entry.submitter),
-      ("module", ojStr entry.moduleName),
-      ("holes", ojStrArr entry.holes),
-      ("generated_path", ojStr s!"generated/{entry.id}")
-    ]
   if selectedProblemId.isNone then
-    mismatches := mismatches ++ (← writeOrCheckIndex root indexEntries check)
+    mismatches := mismatches ++
+      (← writeOrCheckIndex root (problems.map generatedIndexEntry) check)
   if !mismatches.isEmpty then
     throw <| IO.userError <| "\n".intercalate mismatches.toList
   if check then

--- a/EvalTools/Main.lean
+++ b/EvalTools/Main.lean
@@ -68,6 +68,15 @@ def runGenerateCmd (p : Parsed) : IO UInt32 := do
     IO.eprintln (toString e)
     return 1
 
+def runValidateGeneratedCatalogCmd (_ : Parsed) : IO UInt32 := do
+  let root ← requireRepoRoot
+  try
+    EvalTools.validateGeneratedCatalog root
+    return 0
+  catch e =>
+    IO.eprintln (toString e)
+    return 1
+
 def runCheckGeneratedBuildsCmd (p : Parsed) : IO UInt32 := do
   let problems :=
     match p.flag? "problem" with
@@ -176,6 +185,11 @@ def generateCmd : Cmd := `[Cli|
     check;             "Check whether generated output is up to date without rewriting files."
 ]
 
+def validateGeneratedCatalogCmd : Cmd := `[Cli|
+  "validate-generated-catalog" VIA runValidateGeneratedCatalogCmd;
+  "Validate generated/index.json and reject unexpected generated workspace directories."
+]
+
 def checkGeneratedBuildsCmd : Cmd := `[Cli|
   "check-generated-builds" VIA runCheckGeneratedBuildsCmd;
   "Build generated workspaces to catch breakage in emitted projects."
@@ -234,6 +248,7 @@ def leanEvalCmd : Cmd := `[Cli|
     checkProblemBuildCmd;
     problemInventoryCmd;
     generateCmd;
+    validateGeneratedCatalogCmd;
     checkGeneratedBuildsCmd;
     startProblemCmd;
     checkComparatorInstallationCmd;

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -9,6 +9,10 @@ private def assertEq {α : Type} [BEq α] [Repr α] (label : String)
   if actual == expected then none
   else some s!"{label}: expected {repr expected}, got {repr actual}"
 
+private def assertContains (label haystack needle : String) : Option String :=
+  if (haystack.find? needle).isSome then none
+  else some s!"{label}: expected to contain {repr needle}, got {repr haystack}"
+
 private def check (label : String) (passes fails : IO.Ref Nat)
     (f : IO (Option String)) : IO Unit := do
   match ← f.toBaseIO with
@@ -20,9 +24,68 @@ private def check (label : String) (passes fails : IO.Ref Nat)
       IO.eprintln s!"FAIL: {label} — unexpected exception: {err}"
       fails.modify (· + 1)
 
+private def manifestEntry (id moduleName hole : String) : String :=
+  s!"id = \"{id}\"\n" ++
+  s!"title = \"{id}\"\n" ++
+  "test = false\n" ++
+  s!"module = \"{moduleName}\"\n" ++
+  s!"holes = [\"{hole}\"]\n" ++
+  "submitter = \"tester\"\n"
+
+/-- A minimal generated catalog whose index and directory set agree with its
+two-entry manifest. -/
+private def withGeneratedCatalog
+    (f : System.FilePath → IO (Option String)) : IO (Option String) := do
+  let root ← IO.FS.createTempDir
+  try
+    let manifestDir := root / "manifests" / "problems"
+    let generatedDir := root / "generated"
+    IO.FS.createDirAll manifestDir
+    IO.FS.createDirAll (generatedDir / "alpha")
+    IO.FS.createDirAll (generatedDir / "beta")
+    IO.FS.writeFile (manifestDir / "alpha.toml")
+      (manifestEntry "alpha" "LeanEval.Alpha" "alphaHole")
+    IO.FS.writeFile (manifestDir / "beta.toml")
+      (manifestEntry "beta" "LeanEval.Beta" "betaHole")
+    let problems ← loadManifest root
+    let mismatches ←
+      writeOrCheckIndex root (problems.map generatedIndexEntry) (check := false)
+    if !mismatches.isEmpty then
+      return some s!"fixture index write unexpectedly reported {repr mismatches}"
+    f root
+  finally
+    try IO.FS.removeDirAll root catch _ => pure ()
+
+private def expectErrorContaining (action : IO Unit) (needle : String) :
+    IO (Option String) := do
+  match ← action.toBaseIO with
+  | .ok _ => pure <| some s!"expected failure containing {repr needle}"
+  | .error err => pure <| assertContains "error" (toString err) needle
+
 def main : IO UInt32 := do
   let passes ← IO.mkRef 0
   let fails ← IO.mkRef 0
+
+  check "validateGeneratedCatalog accepts a coherent generated tree" passes fails do
+    withGeneratedCatalog fun root => do
+      validateGeneratedCatalog root
+      pure none
+
+  check "validateGeneratedCatalog rejects a missing index" passes fails do
+    withGeneratedCatalog fun root => do
+      IO.FS.removeFile (root / "generated" / "index.json")
+      expectErrorContaining (validateGeneratedCatalog root) "missing generated/index.json"
+
+  check "validateGeneratedCatalog rejects a stale index" passes fails do
+    withGeneratedCatalog fun root => do
+      IO.FS.writeFile (root / "generated" / "index.json") "[]\n"
+      expectErrorContaining (validateGeneratedCatalog root) "stale generated/index.json"
+
+  check "validateGeneratedCatalog rejects an unexpected workspace directory" passes fails do
+    withGeneratedCatalog fun root => do
+      IO.FS.createDirAll (root / "generated" / "not_in_manifest")
+      expectErrorContaining (validateGeneratedCatalog root)
+        "unexpected generated directory generated/not_in_manifest"
 
   check "parseExtractedTheorem defaults missing hole-dependent dependencies" passes fails do
     let payload :=

--- a/tests/python/test_select_ci_problems.py
+++ b/tests/python/test_select_ci_problems.py
@@ -63,6 +63,13 @@ class SelectCIProblemsTest(unittest.TestCase):
         self.assertEqual(selection.problems, ("c",))
         self.assertTrue(selection.generated_changed)
 
+    def test_generated_index_change_runs_checks_without_a_catalog_shard(self):
+        selection = self.select((Change("M", ("generated/index.json",)),))
+        self.assertEqual(selection.problems, ())
+        self.assertFalse(selection.run_catalog)
+        self.assertTrue(selection.generated_changed)
+        self.assertTrue(selection.run_checks)
+
     def test_generator_change_is_a_full_catalog_sentinel(self):
         selection = self.select((Change("M", ("EvalTools/Generate.lean",)),))
         self.assertEqual(selection.mode, "full")


### PR DESCRIPTION
Adds a cheap Lean-side global generated-catalog check that compares `generated/index.json` with the manifest and rejects unexpected workspace directories. The repository checks job runs it whenever generated files are touched, including index-only and unknown-directory changes that select no catalog shard. Source-only PRs continue to defer index updates to the trusted main regenerator.\n\nThe index row renderer is shared with full generation so the two paths cannot drift. Adds regression tests for valid, missing, stale, and unexpected-directory states, plus selector coverage for `generated/index.json`.\n\nValidation:\n- `lake build lean-eval test_generate test_validate_submission test_module_coverage test_check_comparator_installation`\n- 135 Lean tests across the four executables\n- 15 selector tests\n- `actionlint .github/workflows/ci.yml`\n- action pin audit and `git diff --check`\n\nCurrent upstream main has 297 manifests but a 247-entry index because the latest regeneration generated the missing workspaces but its GitHub App token expired before push. This PR deliberately exposes that stale state without taking on the separate regeneration-auth repair.