### PR TITLE
ci: keep regeneration credentials fresh

### DIFF
--- a/.github/workflows/regenerate-main.yml
+++ b/.github/workflows/regenerate-main.yml
@@ -10,6 +10,7 @@ on:
       - 'EvalTools/**'
       - 'templates/**'
       - 'manifests/problems/**'
+      - '.github/workflows/regenerate-main.yml'
       - 'lakefile.toml'
       - 'lean-toolchain'
   workflow_dispatch:
@@ -25,7 +26,49 @@ jobs:
   regenerate:
     runs-on: ubuntu-latest
     steps:
-      - name: Mint lean-eval-regenerator installation token
+      # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          # The repository is public, and the default token cannot bypass the
+          # main ruleset. Do not persist it over the fresh app credential used
+          # by the final push.
+          persist-credentials: false
+
+      # leanprover/lean-action pinned to 38fbc41a (= refs/tags/v1.5.0, also v1 HEAD as of 2026-05-04).
+      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
+        with:
+          use-mathlib-cache: true
+
+      - name: Regenerate against a stable main
+        # A merge can land during the hour-long full-catalog generation. Repeat
+        # from the new main instead of rebasing stale generated output over it.
+        # Three attempts bound runner use during an unusually busy merge burst.
+        run: |
+          set -euo pipefail
+          max_attempts=3
+          for attempt in $(seq 1 "$max_attempts"); do
+            git fetch origin main
+            git reset --hard origin/main
+            git clean -ffd generated/
+            base_sha=$(git rev-parse HEAD)
+            echo "Regeneration attempt $attempt/$max_attempts at $base_sha"
+            lake exe lean-eval generate
+            git fetch origin main
+            latest_sha=$(git rev-parse origin/main)
+            if [ "$latest_sha" = "$base_sha" ]; then
+              echo "REGEN_BASE_SHA=$base_sha" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "main advanced to $latest_sha; discarding stale output and retrying"
+          done
+          echo "::error::main advanced during all $max_attempts regeneration attempts"
+          exit 1
+
+      # Installation tokens expire after one hour. Full-catalog regeneration
+      # can take longer, so mint the write credential only after that work is
+      # complete instead of at job startup.
+      - name: Mint fresh lean-eval-regenerator installation token
         id: app_token
         # actions/create-github-app-token pinned to bcd2ba49 (= refs/tags/v3.2.0 as of 2026-07-30).
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
@@ -33,33 +76,9 @@ jobs:
           client-id: ${{ secrets.LEAN_EVAL_REGENERATOR_CLIENT_ID }}
           private-key: ${{ secrets.LEAN_EVAL_REGENERATOR_PRIVATE_KEY }}
 
-      # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app_token.outputs.token }}
-          # The commit-and-push step below authenticates through .git/config.
-          persist-credentials: true
-
-      # leanprover/lean-action pinned to 38fbc41a (= refs/tags/v1.5.0, also v1 HEAD as of 2026-05-04).
-      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
-        with:
-          use-mathlib-cache: true
-
-      - name: Re-sync to latest origin/main
-        # Codex finding: regenerate against the freshest source, not whatever
-        # the runner cloned. A merge can land on main between the trigger and
-        # the checkout above; without this, we'd regenerate against stale
-        # source and then push a result that doesn't match HEAD.
-        run: |
-          set -euo pipefail
-          git fetch origin main
-          git reset --hard origin/main
-
-      - name: Regenerate
-        run: lake exe lean-eval generate
-
       - name: Commit and push if changed
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
           if git diff --quiet generated/ \
@@ -69,11 +88,18 @@ jobs:
           fi
           git config user.name  "lean-eval-regenerator[bot]"
           git config user.email "lean-eval-regenerator[bot]@users.noreply.github.com"
+          # Install gh's credential helper for every fetch/pull/push in this
+          # step. GH_TOKEN is the just-minted app installation token.
+          gh auth setup-git
+          git fetch origin main
+          latest_sha=$(git rev-parse origin/main)
+          if [ "$latest_sha" != "$REGEN_BASE_SHA" ]; then
+            echo "::error::main advanced from $REGEN_BASE_SHA to $latest_sha after regeneration; refusing to commit stale output"
+            exit 1
+          fi
           git add generated/
           git commit -m "chore: regenerate generated/ workspaces"
-          # Retry once if a human commit landed during this run.
-          if ! git push origin HEAD:main; then
-            echo "push rejected; rebasing onto latest main and retrying"
-            git pull --rebase origin main
-            git push origin HEAD:main
-          fi
+          # A non-fast-forward means main advanced after the check above. Never
+          # rebase generated output: it was derived from REGEN_BASE_SHA and must
+          # not be attached to a different source tree.
+          git push origin HEAD:main

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -54,12 +54,16 @@ branch protection.
 ### Where used
 
 [`.github/workflows/regenerate-main.yml`](../.github/workflows/regenerate-main.yml),
-in the `Mint lean-eval-regenerator installation token` step, via
+in the `Mint fresh lean-eval-regenerator installation token` step, via
 `actions/create-github-app-token`, pinned to
-`bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0). The token is used both for
-`actions/checkout` (so subsequent `git push` carries the same auth) and
-for the explicit push step that lands the regenerated workspaces on
-`main`.
+`bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0). Because installation
+tokens expire after one hour and a full-catalog regeneration can take longer,
+the workflow checks out the public repository without persisted credentials and
+mints this write token only after regeneration finishes. The final step exposes
+the fresh token to GitHub CLI's Git credential helper for its push to `main`.
+The workflow also verifies that `main` stayed at the source commit used for
+generation, retrying generation from the latest commit when necessary and
+refusing to rebase stale generated output after a push race.
 
 ### Why an app and not `GITHUB_TOKEN`
 
@@ -233,9 +237,9 @@ with a bogus check of the same name.
   `regenerate-main.yml` itself: that workflow's `paths:` filter only
   fires on source changes (`LeanEval/**`, `EvalTools/**`,
   `templates/**`, `manifests/problems/**`, `lakefile.toml`,
-  `lean-toolchain`), and the bot only writes under `generated/`. The
-  bypass doesn't change this; the `paths:` filter is what prevents the
-  loop.
+  `lean-toolchain`, and the workflow file itself), and the bot only writes
+  under `generated/`. The bypass doesn't change this; the `paths:` filter is
+  what prevents the loop.
 
   Other workflows on `main` push events *do* run on regenerator
   commits — most notably `ci.yml`'s `verify` job, which has no


### PR DESCRIPTION
## Summary

- mint the regenerator GitHub App token after the long full-catalog generation, so it is fresh for the push;
- checkout without persisted `GITHUB_TOKEN` credentials and authenticate the final Git operations through `gh` using the app token;
- regenerate against `main` until its source SHA stays stable, and refuse to rebase generated output across a source advance;
- trigger regeneration when this workflow itself changes;
- document the token-lifetime and stale-output invariants in the CI credential runbook.

## Failure addressed

Annals regeneration run 32019802650 completed its 61-minute generation step, then its installation token expired before the push. The preceding regeneration also rebased output derived from `8a07c18` over the later Annals source merge, producing commit `a643dc6` with missing Annals workspaces.

This change fixes both failure modes as workflow invariants rather than manually publishing the generated files.

## Verification

- `python tests/python/test_select_ci_problems.py` — 14 passed
- `python scripts/action_pin_audit.py` — clean
- Python syntax checks — clean
- workflow YAML parses successfully
- isolated `gh auth setup-git` credential-helper check — passed
- token/order/stale-output structural assertions — passed
- `git diff --check` — clean
