### PR TITLE
doc: retract the claim that .lake tampering is structurally impossible

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -176,13 +176,14 @@ So the premise that no persistent child is possible does not hold, and
 unsound argument rather than a demonstrated attack, and note that any
 substituted olean is still replayed through the kernel and
 `external_kernels`. Tracked upstream at
-https://github.com/leanprover/comparator/issues/77, where the proposed
-remedy is for comparator to detect surviving descendants (via
-`PR_SET_CHILD_SUBREAPER`) and fail the comparison rather than trying to
-win the race. Note that the obvious cheaper fixes do not work: copying
-the olean out before exporting, hashing it, or renaming its directory
-all still race a daemon that rewrites in a loop, and `killpg` misses
-exactly the process that called `setsid`.
+https://github.com/leanprover/comparator/issues/77, with a proposed fix
+in https://github.com/leanprover/comparator/pull/78 that runs each
+landrun invocation as PID 1 of a fresh PID namespace, so the kernel
+tears down any survivors before comparator proceeds. Note that the
+obvious cheaper fixes do not work: copying the olean out before
+exporting, hashing it, or renaming its directory all still race a
+daemon that rewrites in a loop, and `killpg` misses exactly the process
+that called `setsid`. Update this section when that PR lands.
 
 This applies to every runner we use today; it has nothing to do with
 any particular kernel. Re-derive it after any landrun, comparator, or
@@ -333,7 +334,8 @@ escaping, the triage gate) are in the submissions repo's `SECURITY.md`.
    `lean`, which is whitelisted. Nothing stops a descendant outliving
    `safeLakeBuild` and racing `safeExport`. No working exploit is known,
    and a substituted olean is still kernel-checked. Tracked at
-   https://github.com/leanprover/comparator/issues/77.
+   https://github.com/leanprover/comparator/issues/77; proposed fix in
+   https://github.com/leanprover/comparator/pull/78.
 3. **`lake env` behaviour across lake versions.** The `lake_env_probe`
    confirms current behaviour. Lake version bumps must re-run it.
 4. **`definition_names` author trap.** Comparator only requires that

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -149,21 +149,44 @@ attacker-controlled olean.
 
 We ran [scripts/security_probes/artifact_tamper_probe.py](scripts/security_probes/artifact_tamper_probe.py)
 on Linux (kernel 6.12 + Lean v4.32.2 + landrun 5ed4a3db + comparator
-71b52ec) on 2026-07-29 and the attack is **structurally impossible at
-the spawn step**. Inside the sandbox, `IO.Process.spawn` succeeds for
-the whitelisted `lean` and `git` binaries; `sh`, `setsid`, `bash`, `cp`,
-`/bin/sh`, and `/usr/bin/env` all return exit 255 ("could not execute
-external process"). Phase B also confirmed by SHA-256 that the
-deliberately distinct prepared olean was not installed. Comparator's
-`safeLakeBuild` only `--rox`-whitelists `leanPrefix` and `gitLocation`;
-landrun denies exec of anything else. The attacker has no way to
-spawn a daemon, so there is nothing to race against `safeExport`.
+71b52ec) on 2026-07-29. Inside the sandbox, `IO.Process.spawn` succeeds
+for the whitelisted `lean` and `git` binaries; `sh`, `setsid`, `bash`,
+`cp`, `/bin/sh`, and `/usr/bin/env` all return exit 255 ("could not
+execute external process"). Phase B confirmed by SHA-256 that the
+deliberately distinct prepared olean was not installed.
 
-This is a strong assumption to depend on. If a future comparator pin
-broadens the executable allowlist (e.g. adds `sh`), or if a Lean
-toolchain change allows the elaborator to spawn binaries by some other
-path, this conclusion needs to be re-derived. Re-run the probe after
-any landrun, comparator, or lean-toolchain pin bump.
+**We previously concluded from this that the attack is structurally
+impossible at the spawn step. That conclusion was wrong** (2026-08-20),
+and the probe result above is what shows it: `lean` spawns successfully.
+`lean` is a general-purpose interpreter, so the daemon does not need
+`sh` or `setsid` — it can be another `lean` running an attacker-written
+`initialize` block. Detaching it needs no external binary either:
+`IO.Process.SpawnArgs` has a native `setsid : Bool` field
+(`Init/System/IO.lean`, v4.32.2). Orphaned children are reparented
+rather than killed when the landrun child exits. Two further holes in
+the same argument: `executablePaths := #[leanPrefix, gitLocation]`
+whitelists exec across the *entire* Lean prefix (`lake`, `clang`,
+`ld.lld`, `leanc`, ...), not just `lean`; and comparator passes `-ldd`,
+which whitelists the dynamic loader, and a permitted loader can load a
+readable ELF that is not itself exec-whitelisted.
+
+So the premise that no persistent child is possible does not hold, and
+`safeExport` has nothing guaranteeing it reads the olean that
+`safeLakeBuild` produced. We have no working exploit, so this is an
+unsound argument rather than a demonstrated attack, and note that any
+substituted olean is still replayed through the kernel and
+`external_kernels`. Tracked upstream at
+https://github.com/leanprover/comparator/issues/77, where the proposed
+remedy is for comparator to detect surviving descendants (via
+`PR_SET_CHILD_SUBREAPER`) and fail the comparison rather than trying to
+win the race. Note that the obvious cheaper fixes do not work: copying
+the olean out before exporting, hashing it, or renaming its directory
+all still race a daemon that rewrites in a loop, and `killpg` misses
+exactly the process that called `setsid`.
+
+This applies to every runner we use today; it has nothing to do with
+any particular kernel. Re-derive it after any landrun, comparator, or
+lean-toolchain pin bump.
 
 ## 4. Trust model for the comparator
 
@@ -304,13 +327,13 @@ escaping, the triage gate) are in the submissions repo's `SECURITY.md`.
    the probe's mock workspace shape, a real false negative is possible.
    Re-run the probe by hand on a clean Linux box after any landrun
    bump.
-2. **Writable-`.lake` self-tampering** (Section 3). Currently neutralised
-   by landrun's exec restriction (only `lean` can be exec'd from inside
-   the sandbox; `sh`/`setsid`/etc. are denied), so the attacker cannot
-   spawn the daemon the attack requires. This depends on comparator's
-   `executablePaths` staying narrow. If a future comparator pin adds
-   `sh` (or similar) to `executablePaths`, re-run `artifact_tamper_probe`
-   and assume the attack is back in play until proven otherwise.
+2. **Writable-`.lake` self-tampering** (Section 3). **Not currently
+   mitigated.** We used to claim landrun's exec restriction ruled out
+   the daemon this attack needs; it does not, because the daemon can be
+   `lean`, which is whitelisted. Nothing stops a descendant outliving
+   `safeLakeBuild` and racing `safeExport`. No working exploit is known,
+   and a substituted olean is still kernel-checked. Tracked at
+   https://github.com/leanprover/comparator/issues/77.
 3. **`lake env` behaviour across lake versions.** The `lake_env_probe`
    confirms current behaviour. Lake version bumps must re-run it.
 4. **`definition_names` author trap.** Comparator only requires that

--- a/scripts/security_probes/artifact_tamper_probe.py
+++ b/scripts/security_probes/artifact_tamper_probe.py
@@ -52,9 +52,9 @@ around landrun, or copying the olean out before export) do not work: a
 daemon rewriting in a loop races the copy just as it raced the export,
 and `killpg` misses a process that called `setsid` itself. The remedy
 under discussion upstream is for comparator to detect surviving
-descendants and fail, rather than to try to win the race. Once a
-mitigation is in place, add a CI assertion that Phase B reports
-REJECTED.
+descendants and fail, rather than to try to win the race; see
+leanprover/comparator#78. Once a mitigation is in place, add a CI
+assertion that Phase B reports REJECTED.
 """
 
 from __future__ import annotations

--- a/scripts/security_probes/artifact_tamper_probe.py
+++ b/scripts/security_probes/artifact_tamper_probe.py
@@ -34,11 +34,27 @@ Phases:
 
   --phase=both (default) Run A then B, report both.
 
-This probe does NOT have a CI mode that asserts "no exploit" by default,
-because Phase B's outcome may motivate landing an upstream comparator
-patch (setsid + killpg around landrun, or copy-out olean before
-export). Once that mitigation is in place, add a CI assertion that
-Phase B reports REJECTED.
+LIMITATION (2026-08-20): the exec-allowlist half of this probe does not
+establish what we once read it as establishing. It shows `sh`, `setsid`,
+`bash`, `cp` and `env` are denied, and we concluded from that that no
+daemon can be spawned. But the probe's own `want_ok` case shows `lean`
+spawning successfully, and `lean` is a general-purpose interpreter: the
+daemon can simply be another `lean`. It needs no external `setsid`
+either, since `IO.Process.SpawnArgs` has a native `setsid : Bool` field.
+Step 2 above should be read as "detaches via `SpawnArgs.setsid`", not as
+requiring the `setsid` binary. Extending this probe to attempt that is
+the obvious next step; see
+https://github.com/leanprover/comparator/issues/77.
+
+This probe does NOT have a CI mode that asserts "no exploit" by default.
+Note also that the mitigations once sketched here (setsid + killpg
+around landrun, or copying the olean out before export) do not work: a
+daemon rewriting in a loop races the copy just as it raced the export,
+and `killpg` misses a process that called `setsid` itself. The remedy
+under discussion upstream is for comparator to detect surviving
+descendants and fail, rather than to try to win the race. Once a
+mitigation is in place, add a CI assertion that Phase B reports
+REJECTED.
 """
 
 from __future__ import annotations
@@ -79,10 +95,11 @@ initialize do
   IO.FS.createDirAll outDir
   -- Marker A: write synchronously from within elaboration.
   IO.FS.writeFile (outDir / "marker-elab") "init-ran\n"
-  -- Probe what binaries the sandbox allows us to exec. If only `lean`
-  -- and `git` work, an attacker's Submission has no way to spawn a
-  -- daemon — the writable-.lake race attack collapses at the exec
-  -- step.
+  -- Probe what binaries the sandbox allows us to exec. NOTE: `lean`
+  -- succeeding below is not a negative result. `lean` is a
+  -- general-purpose interpreter, so an attacker's daemon can be another
+  -- `lean`; this list rules out convenient daemons, not all of them.
+  -- See leanprover/comparator#77.
   let results := #[
     (← tryExec "want_ok"   "lean"   #["--version"]),
     (← tryExec "want_ok"   "git"    #["--version"]),


### PR DESCRIPTION
This PR corrects `SECURITY.md`, which currently tells readers the writable-`.lake` tampering attack is structurally impossible at the spawn step. It is not.

The refutation is in the probe result the section cites. `artifact_tamper_probe` shows `sh`, `setsid`, `bash`, `cp` and `env` denied, and we read that as "no daemon can be spawned". But its `want_ok` case shows `lean` spawning successfully, and `lean` is a general-purpose interpreter, so the daemon can be another `lean` running an attacker-written `initialize` block. It needs no external `setsid` either: `IO.Process.SpawnArgs` has a native `setsid : Bool` field. Two further holes in the same argument: `executablePaths := #[leanPrefix, gitLocation]` whitelists the whole Lean prefix rather than `lean` alone, and `-ldd` whitelists the dynamic loader, which can load a readable ELF that is not itself whitelisted.

Known-risk 2 changes from "currently neutralised" to "not currently mitigated". No working exploit is known and a substituted olean is still kernel-checked, so this is an unsound argument rather than a demonstrated attack, and the text says so. It applies to every runner we use and has nothing to do with any particular kernel.

Also corrects the mitigations the probe's docstring sketches: copy-out and `killpg` both still race a daemon that rewrites in a loop. Tracked upstream at https://github.com/leanprover/comparator/issues/77, where the proposal is to detect surviving descendants and fail rather than try to win the race.

Documentation and comments only.

🤖 Prepared with Claude Code