### PR TITLE
feat(Topology): add Budney–Gabai knotted three-spheres

### DIFF
--- a/LeanEval/Topology/BudneyGabai.lean
+++ b/LeanEval/Topology/BudneyGabai.lean
@@ -1,0 +1,58 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Topology
+
+open scoped ContDiff Manifold
+open Metric (sphere)
+
+/-!
+# Budney--Gabai knotted three-spheres
+
+Corollary 8.6 of Budney and Gabai's *Knotted 3-balls in S^4* states that
+`S^1 × S^3` contains infinitely many isotopy classes of embedded three-spheres
+homotopic to the standard cross-section `{x₀} × S^3`.
+
+Here `S^1` and `S^3` are the unit spheres in Euclidean two- and four-space.
+An isotopy of unparameterized embedded spheres is expressed as a jointly smooth
+one-parameter family of smooth embeddings, with equality of ranges at its
+endpoints. By the smooth isotopy extension theorem, this agrees with ambient
+smooth isotopy. The connected-complement condition records that every sphere is
+nonseparating.
+-/
+
+/-- **Budney--Gabai, Corollary 8.6.** There are infinitely many pairwise smoothly
+non-isotopic, nonseparating embedded three-spheres in `S^1 × S^3`, all homotopic
+to the standard cross-section `{x₀} × S^3`. -/
+@[eval_problem]
+theorem budney_gabai_knotted_three_spheres
+    (x₀ : sphere (0 : EuclideanSpace ℝ (Fin 2)) 1) :
+    ∃ e : ℕ → sphere (0 : EuclideanSpace ℝ (Fin 4)) 1 →
+        sphere (0 : EuclideanSpace ℝ (Fin 2)) 1 ×
+          sphere (0 : EuclideanSpace ℝ (Fin 4)) 1,
+      (∀ n,
+        Manifold.IsSmoothEmbedding
+            (𝓡 3) ((𝓡 1).prod (𝓡 3)) ∞ (e n) ∧
+          IsConnected (Set.range (e n))ᶜ ∧
+          ∃ K : unitInterval × sphere (0 : EuclideanSpace ℝ (Fin 4)) 1 →
+              sphere (0 : EuclideanSpace ℝ (Fin 2)) 1 ×
+                sphere (0 : EuclideanSpace ℝ (Fin 4)) 1,
+            Continuous K ∧
+              (∀ p, K (0, p) = e n p) ∧
+              ∀ p, K (1, p) = (x₀, p)) ∧
+        ∀ i j, i ≠ j →
+          ¬ ∃ H : unitInterval × sphere (0 : EuclideanSpace ℝ (Fin 4)) 1 →
+              sphere (0 : EuclideanSpace ℝ (Fin 2)) 1 ×
+                sphere (0 : EuclideanSpace ℝ (Fin 4)) 1,
+            ContMDiff
+                ((𝓡∂ 1).prod (𝓡 3)) ((𝓡 1).prod (𝓡 3)) ∞ H ∧
+              (∀ t,
+                Manifold.IsSmoothEmbedding
+                  (𝓡 3) ((𝓡 1).prod (𝓡 3)) ∞ (fun p ↦ H (t, p))) ∧
+              Set.range (fun p ↦ H (0, p)) = Set.range (e i) ∧
+              Set.range (fun p ↦ H (1, p)) = Set.range (e j) := by
+  sorry
+
+end Topology
+end LeanEval

--- a/manifests/problems/budney_gabai_knotted_three_spheres.toml
+++ b/manifests/problems/budney_gabai_knotted_three_spheres.toml
@@ -1,0 +1,9 @@
+id = "budney_gabai_knotted_three_spheres"
+title = "Budney--Gabai knotted three-spheres in S¹ × S³"
+test = false
+module = "LeanEval.Topology.BudneyGabai"
+holes = ["budney_gabai_knotted_three_spheres"]
+submitter = "Vasily Ilin"
+notes = "Corollary 8.6: S¹ × S³ contains infinitely many isotopy classes of nonseparating smoothly embedded S³s homotopic to a standard cross-section. The statement uses Mathlib's unit spheres and smooth-manifold API directly. Unparameterized smooth isotopy is encoded by a jointly smooth interval-family of embeddings whose endpoint ranges agree; this is equivalent to ambient smooth isotopy by isotopy extension."
+source = "R. Budney and D. Gabai, 'Knotted 3-balls in S⁴', Corollary 8.6, arXiv:1912.09029v3 (2021), https://arxiv.org/abs/1912.09029."
+informal_solution = "Budney and Gabai construct barbell diffeomorphisms β_{δₖ} for k ≥ 4. Their W₃ invariant proves in Theorem 8.5 that the resulting classes are linearly independent even after quotienting by diffeomorphisms supported in a 4-ball. Applying these diffeomorphisms to the standard cross-section {x₀} × S³ gives nonseparating embedded three-spheres homotopic to the cross-section; isotopy of two such spheres would put the corresponding diffeomorphisms in the same quotient class, contradicting that independence."

--- a/manifests/problems/budney_gabai_knotted_three_spheres.toml
+++ b/manifests/problems/budney_gabai_knotted_three_spheres.toml
@@ -1,5 +1,10 @@
 id = "budney_gabai_knotted_three_spheres"
 title = "Budney--Gabai knotted three-spheres in S¹ × S³"
+group = "formalization-evaluation"
+status = "draft"
+visible = true
+statement_revision = 1
+tags = []
 test = false
 module = "LeanEval.Topology.BudneyGabai"
 holes = ["budney_gabai_knotted_three_spheres"]


### PR DESCRIPTION
## Summary

- add Budney–Gabai Corollary 8.6 as an eval problem
- state the result directly with Mathlib smooth spheres, embeddings, connected complements, map homotopies, and smooth embedding isotopies
- add the manifest with the exact source and the Theorem 8.5 proof route

## Statement verification

Checked against Budney–Gabai, Knotted 3-balls in S⁴, arXiv:1912.09029v3, Corollary 8.6, p. 80:
https://arxiv.org/abs/1912.09029v3

The authors’ later Version 2.61 repeats the corollary unchanged on p. 81:
https://web.math.princeton.edu/facultypapers/Gabai/Knotted.3-Balls.2.61.pdf#page=81

The encoding preserves the source distinctions:

- homotopic means ordinary homotopy of maps, so intermediate maps need not be embeddings
- isotopic means a jointly smooth interval-family whose every slice is a smooth embedding
- endpoint range equality compares unparameterized embedded spheres
- nonseparating means the set-theoretic complement is connected

## Validation

- lake env lean LeanEval/Topology/BudneyGabai.lean
- lake exe lean-eval check-problem-build --module LeanEval.Topology.BudneyGabai
- exhaustive build of every manifest-owned module
- lake exe lean-eval validate-manifest --assume-modules-built
- lake exe lean-eval generate --problem budney_gabai_knotted_three_spheres
- lake exe lean-eval check-generated-builds --problem budney_gabai_knotted_three_spheres