### PR TITLE
fix: make stripProblemMarkers lexer-aware rather than line-oriented

### DIFF
--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -468,16 +468,10 @@ private def Source.plainStringEnd (s : Source) (start : Nat) : Nat := Id.run do
       i := i + 1
   return s.size
 
-/-- Skip a double-quoted string whose `{…}` holes carry terms. `start` must point
-at the opening quote.
-
-A hole may itself hold a string, and that is what a brace-blind reader gets
-wrong: `throwError "{String.intercalate "\n" …}"` would end at the quote before
-`\n`, leaving the rest of the message to be scanned as code. Lean parses a hole
-with the whole extensible term grammar, which brace counting cannot reproduce,
-so a hole that fails to close is treated as running to the end of the source —
-opaque, and therefore inert, rather than resynchronising somewhere arbitrary. -/
-private def Source.interpolatedStringEnd (s : Source) (start : Nat) : Nat := Id.run do
+/-- Skip a double-quoted string reading each `{…}` as a hole carrying a term,
+and return `none` if the literal never closes that way. `start` must point at the
+opening quote. -/
+private def Source.interpolatedStringEnd? (s : Source) (start : Nat) : Option Nat := Id.run do
   let n := s.size
   let mut i := start + 1
   -- One entry per nested construct, innermost last: `true` while reading string
@@ -489,32 +483,38 @@ private def Source.interpolatedStringEnd (s : Source) (start : Nat) : Nat := Id.
       else if s[i]! == '"' then
         modes := modes.pop
         i := i + 1
-        if modes.isEmpty then return i
+        if modes.isEmpty then return some i
       else if s[i]! == '{' then modes := modes.push false; i := i + 1
       else i := i + 1
     else if let some stop := Source.commentEnd? s i then i := max stop (i + 1)
     else if let some stop := Source.rawStringEnd? s i then i := stop
     else if s[i]! == '"' then modes := modes.push true; i := i + 1
     else if s[i]! == '\'' then i := (Source.charLiteralEnd? s i).getD (i + 1)
+    else if s[i]! == '«' then i := Source.quotedIdentifierEnd s i
     else if s[i]! == '{' then modes := modes.push false; i := i + 1
     else if s[i]! == '}' then modes := modes.pop; i := i + 1
     else i := i + 1
-  return n
+  return none
 
 /-- Commands whose string argument Lean parses as an interpolated string even
-though it carries no `!`. -/
+though it carries no `!`. Kept to the one that occurs in this repository:
+`logInfo "{"` and its siblings fall back to an ordinary term, so listing them
+would misread a brace far more often than it would read one right. -/
 private def interpolatedStringCommands : Array String :=
-  #["throwError", "throwErrorAt", "logInfo", "logInfoAt", "logWarning",
-    "logWarningAt", "logError", "logErrorAt", "dbg_trace"]
+  #["throwError"]
 
-/-- True when the string opening at `start` is an interpolated one, so that a
-`{` in it opens a term rather than standing for itself.
+/-- True when the token in front of the string opening at `start` says the
+string interpolates, so that a `{` in it opens a term rather than standing for
+itself: a `!`-suffixed prefix (`s!`, `m!`, `f!`) or one of
+`interpolatedStringCommands`.
 
-Interpolation is introduced by a `!`-suffixed prefix (`s!`, `m!`, `f!`) or by one
-of `interpolatedStringCommands`. Everything else — an ordinary application `f
-"x"`, a literal after `:=` — is plain, and reading its braces as holes would run
-the scanner far past the end of the string: `def left := "{"` and a later `"}"`
-would swallow everything between them. -/
+The test is deliberately one-sided. Lean settles interpolation in the parser, so
+no lookback can be exact — `throwErrorAt stx "…"` interpolates behind an
+argument this does not see, and a user macro taking `interpolatedStr` is
+invisible. Reading braces as holes when they are not is the costlier mistake, as
+it runs the scan past the end of a perfectly ordinary `"{"`, so a string is read
+plainly unless something says otherwise. `Source.declarationFollows` is what
+keeps the remaining misreadings from doing damage. -/
 private def Source.stringIsInterpolated (s : Source) (start : Nat) : Bool := Id.run do
   let mut i := start
   while i > 0 && s[i - 1]!.isWhitespace do
@@ -530,10 +530,14 @@ private def Source.stringIsInterpolated (s : Source) (start : Nat) : Bool := Id.
     token := token.push s[k]!
   return interpolatedStringCommands.contains ((token.splitOn ".").getLast!)
 
-/-- Skip a double-quoted string. `start` must point at the opening quote. -/
+/-- Skip a double-quoted string. `start` must point at the opening quote. An
+interpolated string that never closes as one is read plainly, so a `{` the
+lookback misjudged costs nothing. -/
 private def Source.stringLiteralEnd (s : Source) (start : Nat) : Nat :=
-  if Source.stringIsInterpolated s start then Source.interpolatedStringEnd s start
-  else Source.plainStringEnd s start
+  if Source.stringIsInterpolated s start then
+    (Source.interpolatedStringEnd? s start).getD (Source.plainStringEnd s start)
+  else
+    Source.plainStringEnd s start
 
 /-- If `start` begins a syntax quotation `` `(…) ``, return the codepoint index
 just past its closing parenthesis. What a quotation holds is syntax the
@@ -657,14 +661,66 @@ private def Source.attributeBlockEnd? (s : Source) (start : Nat) : Option Attrib
       | _ => i := i + 1
   return none
 
+/-- Modifiers Lean allows between an attribute block and the keyword that
+introduces the declaration it modifies. -/
+private def declarationModifiers : Array String :=
+  #["private", "protected", "noncomputable", "unsafe", "partial", "nonrec",
+    "scoped", "local", "public", "meta"]
+
+/-- Keywords that introduce a declaration an attribute block can modify. -/
+private def declarationKeywords : Array String :=
+  #["theorem", "lemma", "def", "abbrev", "instance", "example", "axiom",
+    "opaque", "structure", "class", "inductive", "alias", "mutual", "macro",
+    "macro_rules", "elab", "elab_rules", "syntax", "notation", "infix", "infixl",
+    "infixr", "prefix", "postfix", "initialize", "builtin_initialize",
+    "register_simp_attr", "declare_syntax_cat", "instance_reducible"]
+
+/-- True when a declaration follows the attribute block ending at `stop`.
+
+Lean accepts `@[…]` only in front of a declaration, so this is what separates a
+real attribute from the same characters sitting in a string the scanner has
+misread as code. It is the backstop for every way this file's lexer can be wrong
+— an interpolation it did not expect, a syntax extension it cannot know about.
+With it, a misreading costs a marker left in place, which the generated
+workspace reports as `unknown attribute [eval_problem]`; without it, the cost
+would be an edit to somebody's source that nothing announces. -/
+private def Source.declarationFollows (s : Source) (stop : Nat) : Bool := Id.run do
+  let mut i := Source.skipTrivia s stop
+  -- Bounded: a declaration carries only so many modifiers, and looking further
+  -- would be scanning for a keyword rather than corroborating one.
+  for _ in [0 : 8] do
+    if i ≥ s.size then return false
+    if Source.startsWithAt s i "@[".toList then
+      match Source.attributeBlockEnd? s i with
+      | some block => i := Source.skipTrivia s block.stop
+      | none => return false
+    else
+      for keyword in declarationKeywords do
+        if Source.startsWithAt s i keyword.toList && Source.atWordEnd s (i + keyword.length) then
+          return true
+      let mut next := i
+      for modifier in declarationModifiers do
+        if next == i && Source.startsWithAt s i modifier.toList
+            && Source.atWordEnd s (i + modifier.length) then
+          next := Source.skipTrivia s (i + modifier.length)
+      if next == i then return false
+      i := next
+  return false
+
 /-- True when the attribute instance spanning `[start, stop)` is the marker and
 nothing else. Lean lets trivia sit anywhere in the list, so
-`@[/- why -/ eval_problem]` applies the marker just as `@[eval_problem]` does. -/
+`@[/- why -/ eval_problem]` applies the marker just as `@[eval_problem]` does,
+and it accepts the French-quoted spelling `@[«eval_problem»]` as the same name. -/
 private def Source.itemIsMarker (s : Source) (start stop : Nat) : Bool := Id.run do
   let nameStart := min (Source.skipTrivia s start) stop
-  if !(Source.startsWithAt s nameStart evalProblemAttrName.toList) then return false
-  let nameStop := nameStart + evalProblemAttrName.length
-  if nameStop > stop || !(Source.atWordEnd s nameStop) then return false
+  let quoted := Source.startsWithAt s nameStart ("«" ++ evalProblemAttrName ++ "»").toList
+  let nameStop :=
+    if quoted then nameStart + evalProblemAttrName.length + 2
+    else nameStart + evalProblemAttrName.length
+  if !quoted then
+    if !(Source.startsWithAt s nameStart evalProblemAttrName.toList) then return false
+    if !(Source.atWordEnd s nameStop) then return false
+  if nameStop > stop then return false
   return min (Source.skipTrivia s nameStop) stop == stop
 
 /-- True when the attribute instance spanning `[start, stop)` names no attribute
@@ -784,17 +840,33 @@ private def Source.markerItemRemovals (s : Source) (block : AttributeBlock)
     let survivor := block.items[tail - 1]!
     removals := removals.push
       (Source.rewindInlineSpace s survivor.2 survivor.1, block.items[block.items.size - 1]!.2)
-  return removals
+  -- Consecutive markers share the whitespace between them, so their spans can
+  -- meet: `@[eval_problem, eval_problem, simp]` has the first run on to the
+  -- second's name while the second starts at the comma before it. Coalesce.
+  let mut coalesced : Array (Nat × Nat) := #[]
+  for (a, b) in removals do
+    match coalesced.back? with
+    | some (previousStart, previousStop) =>
+      if a ≤ previousStop then
+        coalesced := coalesced.set! (coalesced.size - 1) (previousStart, max previousStop b)
+      else
+        coalesced := coalesced.push (a, b)
+    | none => coalesced := coalesced.push (a, b)
+  return coalesced
 
-/-- If an `import` command occupying the rest of its line begins at `i`, return
-the module it names and the codepoint index just past the command, trailing
-comment included. `none` if anything but trivia follows the module name on the
-line, since then the line is not this command's alone to delete. -/
+/-- If an `import` command begins at `i`, return the module it names and the
+codepoint index just past the command, any comment trailing it on the same line
+included. Trivia may sit anywhere in the command, so `import /- why -/ Foo` and
+an `import` whose module name is on the next line are both read.
+
+`none` if a token other than a comment follows the module name on its line: a
+second command sharing the line is not this one's to delete. That matches what
+`scanHeader` assumes of the header it walks. -/
 private def Source.importAt? (s : Source) (i : Nat) : Option (String × Nat) := Id.run do
   if !(Source.startsWithAt s i "import".toList) then return none
   let mut j := i + "import".length
   if !(Source.atWordEnd s j) then return none
-  j := Source.skipInlineSpace s j
+  j := Source.skipTrivia s j
   let nameStart := j
   while j < s.size &&
       (let c := s[j]!; c.isAlphanum || c == '_' || c == '\'' || c == '.') do
@@ -803,17 +875,19 @@ private def Source.importAt? (s : Source) (i : Nat) : Option (String × Nat) := 
   let mut name := ""
   for k in [nameStart : j] do
     name := name.push s[k]!
-  let lineStop := Source.lineEndAt s j
+  -- Trailing comments belong to the command; a comment may run past the line,
+  -- and then so does the command.
   let mut stop := j
-  while j < lineStop do
-    if s[j]!.isWhitespace then
-      j := j + 1
-    else if let some commentStop := Source.commentEnd? s j then
-      if commentStop > lineStop then return none
+  let mut atEnd := false
+  while !atEnd do
+    j := Source.skipInlineSpace s j
+    match Source.commentEnd? s j with
+    | some commentStop =>
       j := max commentStop (j + 1)
       stop := j
-    else
-      return none
+    | none =>
+      if j < s.size && s[j]! != '\n' then return none
+      atEnd := true
   return some (name, stop)
 
 /-- If an `import` command this pass drops begins at `i`, return the codepoint
@@ -887,7 +961,7 @@ def stripProblemMarkers (source : String) (localImports : Array String := #[]) :
         let survives := (List.range block.items.size).any fun k =>
           let (a, b) := block.items[k]!
           !markers.contains k && !Source.itemIsEmpty s a b
-        if markers.isEmpty then
+        if markers.isEmpty || !Source.declarationFollows s block.stop then
           freshLine := false
           i := block.stop
         else if !survives then

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -565,10 +565,15 @@ contents needs: a hole holding a string, read plainly, puts the hole's text in
 front of the scanner as if it were code. Refusing to strip anything inside the
 span the two readings dispute removes the guess from the answer — whichever
 reading is right, that text was somebody's string or somebody's code, and this
-pass declines to say which. -/
+pass declines to say which.
+
+A reading that never closes disagrees too, and by more than any other: it says
+the literal runs to the end of the input, so that is the span. It costs nothing
+to say so. A string carrying a brace it does not close is what it takes, and
+appending a marker to each of Mathlib's 8312 files strips all 8312. -/
 private def Source.disputedStringEnd? (s : Source) (start : Nat) : Option Nat :=
   match Source.interpolatedStringEnd? s start with
-  | none => none
+  | none => some s.size
   | some interpolated =>
     let plain := Source.plainStringEnd s start
     if interpolated == plain then none else some (max interpolated plain)
@@ -986,7 +991,13 @@ refuses to resolve.
 What is left over is a marker left in place, which the generated workspace
 reports as `unknown attribute [eval_problem]` when it is built. That is the
 failure this is tuned for: exactness here wants the parser, which wants an
-environment, which this signature does not have. -/
+environment, which this signature does not have.
+
+Two ways in remain, both needing a `syntax` declaration to reach: a token
+carrying a `)` closes a quotation early, and a token carrying a `"` or a brace
+can put the two readings of a string back into agreement on the wrong answer.
+Neither is reachable by lexing alone, which is why they are the boundary of what
+this approach can do rather than a bug in it. -/
 def stripProblemMarkers (source : String) (localImports : Array String := #[]) : String :=
   Id.run do
   let s := Source.ofString source

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -403,6 +403,18 @@ private def Source.commentEnd? (s : Source) (start : Nat) : Option Nat :=
   else
     none
 
+/-- Skip whitespace and Lean comments from `start`. Block comments are nested. -/
+def Source.skipTrivia (s : Source) (start : Nat) : Nat := Id.run do
+  let mut i := start
+  while i < s.size do
+    if s[i]!.isWhitespace then
+      i := i + 1
+    else if let some stop := Source.commentEnd? s i then
+      i := max stop (i + 1)
+    else
+      break
+  return i
+
 /-- If `start` begins a raw string literal — `r"…"`, `r#"…"#`, `r##"…"##`, … —
 return the index just past it. Raw strings have no escapes and are closed only
 by a quote followed by as many `#` as opened them. -/
@@ -442,8 +454,8 @@ private def Source.quotedIdentifierEnd (s : Source) (start : Nat) : Nat := Id.ru
     i := i + 1
   return s.size
 
-/-- Skip a double-quoted string, ignoring `{…}` and treating `\x` as one unit.
-`start` must point at the opening quote; the result is `s.size` if the string is
+/-- Skip a double-quoted string in which a brace is just a brace. `start` must
+point at the opening quote; the result is `s.size` if the string is
 unterminated. -/
 private def Source.plainStringEnd (s : Source) (start : Nat) : Nat := Id.run do
   let mut i := start + 1
@@ -456,18 +468,16 @@ private def Source.plainStringEnd (s : Source) (start : Nat) : Nat := Id.run do
       i := i + 1
   return s.size
 
-/-- Skip a double-quoted string, including escapes and the terms of any `{…}`
-interpolation. `start` must point at the opening quote.
+/-- Skip a double-quoted string whose `{…}` holes carry terms. `start` must point
+at the opening quote.
 
-Whether a string interpolates is not decidable from the quote alone —
-`throwError "{f "a"}"` interpolates and `"{a}"` does not — so a brace is read as
-a hole whenever doing so parses. A hole may itself hold a string, which is what
-makes the difference: read brace-blind, `throwError "{String.intercalate "\n" …}"`
-would end its string at the quote before `\n` and the rest of the message would
-be scanned as code. When the interpolation reading runs off the end of the
-source, the brace-blind one is used instead, so a lone `{` in an ordinary string
-costs nothing. -/
-private def Source.stringLiteralEnd (s : Source) (start : Nat) : Nat := Id.run do
+A hole may itself hold a string, and that is what a brace-blind reader gets
+wrong: `throwError "{String.intercalate "\n" …}"` would end at the quote before
+`\n`, leaving the rest of the message to be scanned as code. Lean parses a hole
+with the whole extensible term grammar, which brace counting cannot reproduce,
+so a hole that fails to close is treated as running to the end of the source —
+opaque, and therefore inert, rather than resynchronising somewhere arbitrary. -/
+private def Source.interpolatedStringEnd (s : Source) (start : Nat) : Nat := Id.run do
   let n := s.size
   let mut i := start + 1
   -- One entry per nested construct, innermost last: `true` while reading string
@@ -489,11 +499,68 @@ private def Source.stringLiteralEnd (s : Source) (start : Nat) : Nat := Id.run d
     else if s[i]! == '{' then modes := modes.push false; i := i + 1
     else if s[i]! == '}' then modes := modes.pop; i := i + 1
     else i := i + 1
-  return Source.plainStringEnd s start
+  return n
+
+/-- Commands whose string argument Lean parses as an interpolated string even
+though it carries no `!`. -/
+private def interpolatedStringCommands : Array String :=
+  #["throwError", "throwErrorAt", "logInfo", "logInfoAt", "logWarning",
+    "logWarningAt", "logError", "logErrorAt", "dbg_trace"]
+
+/-- True when the string opening at `start` is an interpolated one, so that a
+`{` in it opens a term rather than standing for itself.
+
+Interpolation is introduced by a `!`-suffixed prefix (`s!`, `m!`, `f!`) or by one
+of `interpolatedStringCommands`. Everything else — an ordinary application `f
+"x"`, a literal after `:=` — is plain, and reading its braces as holes would run
+the scanner far past the end of the string: `def left := "{"` and a later `"}"`
+would swallow everything between them. -/
+private def Source.stringIsInterpolated (s : Source) (start : Nat) : Bool := Id.run do
+  let mut i := start
+  while i > 0 && s[i - 1]!.isWhitespace do
+    i := i - 1
+  let tokenEnd := i
+  while i > 0 &&
+      (let c := s[i - 1]!; c.isAlphanum || c == '_' || c == '\'' || c == '.' || c == '!') do
+    i := i - 1
+  if i == tokenEnd then return false
+  if s[tokenEnd - 1]! == '!' then return true
+  let mut token := ""
+  for k in [i : tokenEnd] do
+    token := token.push s[k]!
+  return interpolatedStringCommands.contains ((token.splitOn ".").getLast!)
+
+/-- Skip a double-quoted string. `start` must point at the opening quote. -/
+private def Source.stringLiteralEnd (s : Source) (start : Nat) : Nat :=
+  if Source.stringIsInterpolated s start then Source.interpolatedStringEnd s start
+  else Source.plainStringEnd s start
+
+/-- If `start` begins a syntax quotation `` `(…) ``, return the codepoint index
+just past its closing parenthesis. What a quotation holds is syntax the
+declaration *builds*, not syntax applied to it, so an `@[eval_problem]` inside
+one belongs to the macro's output and must survive. -/
+private def Source.quotationEnd? (s : Source) (start : Nat) : Option Nat := Id.run do
+  if s[start]? != some '`' || s[start + 1]? != some '(' then return none
+  let mut i := start + 2
+  let mut depth : Nat := 1
+  while i < s.size do
+    if let some stop := Source.commentEnd? s i then i := max stop (i + 1)
+    else if let some stop := Source.rawStringEnd? s i then i := stop
+    else if s[i]! == '"' then i := Source.stringLiteralEnd s i
+    else if s[i]! == '\'' then i := (Source.charLiteralEnd? s i).getD (i + 1)
+    else if s[i]! == '«' then i := Source.quotedIdentifierEnd s i
+    else if s[i]! == '(' then depth := depth + 1; i := i + 1
+    else if s[i]! == ')' then
+      depth := depth - 1
+      i := i + 1
+      if depth == 0 then return some i
+    else i := i + 1
+  return some s.size
 
 /-- If `start` begins a lexeme whose interior must not be read as code — a line
-or block comment, a string, raw string or character literal, or a French-quoted
-identifier — return the codepoint index just past it; `none` for ordinary code.
+or block comment, a string, raw string or character literal, a French-quoted
+identifier, or a syntax quotation — return the codepoint index just past it;
+`none` for ordinary code.
 
 The result is always strictly greater than `start`, so a scanner can step to it
 unconditionally. An unterminated lexeme ends at `s.size`. -/
@@ -502,6 +569,7 @@ def Source.opaqueLexemeEnd? (s : Source) (start : Nat) : Option Nat := Id.run do
   let stop? : Option Nat :=
     Source.commentEnd? s start |>.orElse fun _ =>
     Source.rawStringEnd? s start |>.orElse fun _ =>
+    Source.quotationEnd? s start |>.orElse fun _ =>
       match s[start]! with
       | '"' => some (Source.stringLiteralEnd s start)
       | '\'' => Source.charLiteralEnd? s start
@@ -544,29 +612,6 @@ def scanHeader (source : Source) : Nat × Nat := Id.run do
 def importPreludeLength (source : Source) : Nat :=
   (scanHeader source).1
 
-/-- True if the line's trimmed content is `import EvalTools.Markers`, allowing
-arbitrary intra-line whitespace between `import` and the module name (the
-Python regex was `\s+`, not a single space). -/
-private def isEvalToolsMarkersImport (stripped : String) : Bool := Id.run do
-  if !(stripped.startsWith "import") then return false
-  let after := (stripped.drop "import".length).toString
-  if after.isEmpty then return false
-  if !after.toList.head!.isWhitespace then return false
-  return after.trimAscii.toString == "EvalTools.Markers"
-
-/-- True if the line is `import <m>` for some module `m` in `locals`, allowing
-arbitrary intra-line whitespace between `import` and the module name. Used to
-drop imports of repo-local modules whose declarations are inlined into
-`ChallengeDeps`, so the generated workspace files don't import the (absent)
-`LeanEval` library. -/
-private def isLocalImport (stripped : String) (locals : Array String) : Bool := Id.run do
-  if !(stripped.startsWith "import") then return false
-  let after := (stripped.drop "import".length).toString
-  if after.isEmpty then return false
-  if !after.toList.head!.isWhitespace then return false
-  let modName := ((after.trimAscii.toString.splitOn " ").head!).trimAscii.toString
-  return locals.contains modName
-
 /-- The name of the marker attribute, as it is spelled in source. -/
 private def evalProblemAttrName : String := "eval_problem"
 
@@ -574,7 +619,9 @@ private def evalProblemAttrName : String := "eval_problem"
 private structure AttributeBlock where
   /-- Codepoint index just past the closing `]`. -/
   stop : Nat
-  /-- Codepoint spans of the comma-separated attribute instances, untrimmed. -/
+  /-- Codepoint spans of the comma-separated attribute instances. Each runs from
+  just after the previous separator to the separator or `]` that ends it, so it
+  carries whatever trivia the author wrote around the attribute. -/
   items : Array (Nat × Nat)
 
 /-- Parse the attribute block opening at `start`, which must point at `@[`.
@@ -609,6 +656,22 @@ private def Source.attributeBlockEnd? (s : Source) (start : Nat) : Option Attrib
         i := i + 1
       | _ => i := i + 1
   return none
+
+/-- True when the attribute instance spanning `[start, stop)` is the marker and
+nothing else. Lean lets trivia sit anywhere in the list, so
+`@[/- why -/ eval_problem]` applies the marker just as `@[eval_problem]` does. -/
+private def Source.itemIsMarker (s : Source) (start stop : Nat) : Bool := Id.run do
+  let nameStart := min (Source.skipTrivia s start) stop
+  if !(Source.startsWithAt s nameStart evalProblemAttrName.toList) then return false
+  let nameStop := nameStart + evalProblemAttrName.length
+  if nameStop > stop || !(Source.atWordEnd s nameStop) then return false
+  return min (Source.skipTrivia s nameStop) stop == stop
+
+/-- True when the attribute instance spanning `[start, stop)` names no attribute
+at all. Lean rejects `@[simp,]`, but the stripper should not turn such a block
+into `@[]` and call it progress. -/
+private def Source.itemIsEmpty (s : Source) (start stop : Nat) : Bool :=
+  Source.skipTrivia s start ≥ stop
 
 /-- True when `s[start:stop)` is entirely whitespace. -/
 private def Source.isBlankRange (s : Source) (start stop : Nat) : Bool := Id.run do
@@ -653,10 +716,6 @@ private def Source.blankEatingSpan (s : Source) (start stop floor : Nat) : Nat �
     let next := Source.lineEndAt s b
     if !Source.isBlankRange s b next then break
     b := next
-  -- A deletion running to an unterminated last line takes the newline that
-  -- introduced it rather than leaving the file ending in a blank line.
-  if b == s.size && b > a && s[b - 1]! != '\n' && a > floor && s[a - 1]! == '\n' then
-    a := a - 1
   return (a, b)
 
 /-- Codepoint index of the first character at or after `start` that is neither a
@@ -664,6 +723,13 @@ space nor a tab. -/
 private def Source.skipInlineSpace (s : Source) (start : Nat) : Nat := Id.run do
   let mut i := start
   while i < s.size && (s[i]! == ' ' || s[i]! == '\t') do
+    i := i + 1
+  return i
+
+/-- Codepoint index of the first non-whitespace character at or after `start`. -/
+private def Source.skipWhitespace (s : Source) (start : Nat) : Nat := Id.run do
+  let mut i := start
+  while i < s.size && s[i]!.isWhitespace do
     i := i + 1
   return i
 
@@ -675,8 +741,8 @@ private def Source.rewindInlineSpace (s : Source) (start floor : Nat) : Nat := I
     i := i - 1
   return i
 
-/-- The span to delete to remove the attribute block at `[start, stop)` when no
-attribute in it survives. -/
+/-- The span to delete to remove the marker text at `[start, stop)` — a whole
+attribute block, or an import command — from the source around it. -/
 private def Source.markerRemoval (s : Source) (start stop floor : Nat) : Nat × Nat :=
   let blankBefore := Source.isBlankRange s (Source.lineStartAt s start) start
   let blankAfter := Source.isBlankRange s stop (Source.lineEndAt s stop)
@@ -691,12 +757,75 @@ private def Source.markerRemoval (s : Source) (start stop floor : Nat) : Nat × 
     -- gap after it go, leaving any indentation in place.
     (start, Source.skipInlineSpace s stop)
 
-/-- True when an `import` command that this pass drops begins at `i`, which must
-be the first non-whitespace position on its line. -/
-private def Source.isStrippedImportAt (s : Source) (i : Nat) (locals : Array String) : Bool :=
-  Source.startsWithAt s i "import".toList &&
-    (let line := (Source.slice s i (Source.lineEndAt s i)).trimAscii.toString
-     isEvalToolsMarkersImport line || isLocalImport line locals)
+/-- The spans to delete to remove the attribute instances at indices `markers`
+from `block`, given that at least one instance survives.
+
+Each removal takes a separating comma with it: the one after the instance where
+there is a later survivor, and otherwise the one before it, so exactly as many
+commas go as instances. Everything else is left as the author wrote it —
+reprinting the survivors instead would drop the line break after a comment among
+them and so comment out the closing `]`. -/
+private def Source.markerItemRemovals (s : Source) (block : AttributeBlock)
+    (markers : List Nat) : Array (Nat × Nat) := Id.run do
+  -- The instances from `tail` on are all markers, so they share the one comma
+  -- in front of them; those before it each take the comma that follows.
+  let mut tail := block.items.size
+  while tail > 0 && markers.contains (tail - 1) do
+    tail := tail - 1
+  let mut removals : Array (Nat × Nat) := #[]
+  for k in markers do
+    if k < tail then
+      -- Up to the next instance's first character, so its indentation goes too.
+      -- Only whitespace: a comment there introduces the instance that survives.
+      removals := removals.push (block.items[k]!.1, Source.skipWhitespace s (block.items[k]!.2 + 1))
+  if tail < block.items.size then
+    -- Back over the spaces before the comma, but not over a line break: that
+    -- break may be what ends a comment in the instance before it.
+    let survivor := block.items[tail - 1]!
+    removals := removals.push
+      (Source.rewindInlineSpace s survivor.2 survivor.1, block.items[block.items.size - 1]!.2)
+  return removals
+
+/-- If an `import` command occupying the rest of its line begins at `i`, return
+the module it names and the codepoint index just past the command, trailing
+comment included. `none` if anything but trivia follows the module name on the
+line, since then the line is not this command's alone to delete. -/
+private def Source.importAt? (s : Source) (i : Nat) : Option (String × Nat) := Id.run do
+  if !(Source.startsWithAt s i "import".toList) then return none
+  let mut j := i + "import".length
+  if !(Source.atWordEnd s j) then return none
+  j := Source.skipInlineSpace s j
+  let nameStart := j
+  while j < s.size &&
+      (let c := s[j]!; c.isAlphanum || c == '_' || c == '\'' || c == '.') do
+    j := j + 1
+  if j == nameStart then return none
+  let mut name := ""
+  for k in [nameStart : j] do
+    name := name.push s[k]!
+  let lineStop := Source.lineEndAt s j
+  let mut stop := j
+  while j < lineStop do
+    if s[j]!.isWhitespace then
+      j := j + 1
+    else if let some commentStop := Source.commentEnd? s j then
+      if commentStop > lineStop then return none
+      j := max commentStop (j + 1)
+      stop := j
+    else
+      return none
+  return some (name, stop)
+
+/-- If an `import` command this pass drops begins at `i`, return the codepoint
+index just past it. `freshLine` records that only trivia precedes `i` on its
+line, which is where an `import` is a command rather than a stray identifier. -/
+private def strippedImportStop? (s : Source) (i : Nat) (freshLine : Bool)
+    (locals : Array String) : Option Nat :=
+  if !freshLine then none
+  else match Source.importAt? s i with
+    | some (name, stop) =>
+      if name == "EvalTools.Markers" || locals.contains name then some stop else none
+    | none => none
 
 /-- Strip `@[eval_problem]` attributes, `import EvalTools.Markers` lines, and
 `import <m>` lines for each repo-local module `m` in `localImports` from
@@ -710,34 +839,41 @@ position Lean accepts it and nowhere else:
 * the attribute may share its line with the declaration
   (`@[eval_problem] theorem foo …`) or with a prefix command
   (`set_option autoImplicit false in @[eval_problem] theorem foo …`);
-* it may span several lines;
+* it may span several lines, and may carry trivia (`@[/- why -/ eval_problem]`);
 * its list is split on commas at bracket depth zero, and closed by the first
   `]` at that depth, so `@[eval_problem, deprecated "use foo] instead"]` and
   `@[eval_problem, simp [a, b]]` keep their siblings intact;
-* text inside a string literal or a comment is never mistaken for code, so a
-  multiline string containing `@[eval_problem]` or `import EvalTools.Markers`
-  survives verbatim. -/
+* siblings are spliced out of the source rather than reprinted, so a comment
+  among them keeps the line break that terminates it;
+* text inside a string literal, a comment or a syntax quotation is never
+  mistaken for code, so neither a multiline string containing
+  `@[eval_problem]` nor a macro building one is touched.
+
+A deleted line leaves the newline that introduced it, so stripping the last
+line of a file does not run the one before it into the end of the text. -/
 def stripProblemMarkers (source : String) (localImports : Array String := #[]) : String :=
   Id.run do
   let s := Source.ofString source
   let n := s.size
-  -- `(start, stop, replacement)` triples, in increasing order and disjoint.
-  let mut edits : Array (Nat × Nat × String) := #[]
+  -- Codepoint spans to delete, in increasing order and disjoint.
+  let mut edits : Array (Nat × Nat) := #[]
   -- End of the last edit, so no later deletion reaches back over it.
   let mut floor : Nat := 0
   let mut i : Nat := 0
-  -- Whether only whitespace precedes `i` on its line — an `import` is a command
-  -- only there.
+  -- Whether only trivia precedes `i` on its line — an `import` is a command
+  -- only there, though a comment may sit in front of it.
   let mut freshLine := true
   while i < n do
-    if let some lexemeEnd := Source.opaqueLexemeEnd? s i then
+    if let some commentEnd := Source.commentEnd? s i then
+      i := max commentEnd (i + 1)
+    else if let some lexemeEnd := Source.opaqueLexemeEnd? s i then
       freshLine := false
       i := lexemeEnd
-    else if freshLine && Source.isStrippedImportAt s i localImports then
-      let (a, b) := Source.blankEatingSpan s i i floor
-      edits := edits.push (a, b, "")
+    else if let some importStop := strippedImportStop? s i freshLine localImports then
+      let (a, b) := Source.markerRemoval s i importStop floor
+      edits := edits.push (a, b)
       floor := b
-      freshLine := true
+      freshLine := b > 0 && s[b - 1]! == '\n'
       i := b
     else if Source.startsWithAt s i "@[".toList then
       match Source.attributeBlockEnd? s i with
@@ -745,31 +881,34 @@ def stripProblemMarkers (source : String) (localImports : Array String := #[]) :
         freshLine := false
         i := i + 2
       | some block =>
-        let items := block.items.map fun (a, b) => (Source.slice s a b).trimAscii.toString
-        if !items.contains evalProblemAttrName then
+        let markers := (List.range block.items.size).filter fun k =>
+          let (a, b) := block.items[k]!
+          Source.itemIsMarker s a b
+        let survives := (List.range block.items.size).any fun k =>
+          let (a, b) := block.items[k]!
+          !markers.contains k && !Source.itemIsEmpty s a b
+        if markers.isEmpty then
           freshLine := false
           i := block.stop
+        else if !survives then
+          let (a, b) := Source.markerRemoval s i block.stop floor
+          edits := edits.push (a, b)
+          floor := b
+          freshLine := b > 0 && s[b - 1]! == '\n'
+          i := b
         else
-          let kept := items.filter fun item => item != evalProblemAttrName && !item.isEmpty
-          if kept.isEmpty then
-            let (a, b) := Source.markerRemoval s i block.stop floor
-            edits := edits.push (a, b, "")
-            floor := b
-            freshLine := b > 0 && s[b - 1]! == '\n'
-            i := b
-          else
-            edits := edits.push (i, block.stop, "@[" ++ ", ".intercalate kept.toList ++ "]")
-            floor := block.stop
-            freshLine := false
-            i := block.stop
+          edits := edits ++ Source.markerItemRemovals s block markers
+          floor := block.stop
+          freshLine := false
+          i := block.stop
     else
       if s[i]! == '\n' then freshLine := true
       else if !s[i]!.isWhitespace then freshLine := false
       i := i + 1
   let mut parts : Array String := #[]
   let mut pos : Nat := 0
-  for (a, b, replacement) in edits do
-    parts := parts.push (Source.slice s pos a) |>.push replacement
+  for (a, b) in edits do
+    parts := parts.push (Source.slice s pos a)
     pos := b
   return String.join (parts.push (Source.slice s pos n)).toList
 
@@ -1195,21 +1334,6 @@ def Source.findTheoremHeader (s : Source) (start : Nat) (name : String) : Option
         return some endPos
     i := i + 1
   return none
-
-/-- Skip whitespace and Lean comments from `start`. Block comments are nested. -/
-def Source.skipTrivia (s : Source) (start : Nat) : Nat := Id.run do
-  let mut i := start
-  while i < s.size do
-    if s[i]!.isWhitespace then
-      i := i + 1
-    else if Source.startsWithAt s i "--".toList then
-      while i < s.size && s[i]! != '\n' do
-        i := i + 1
-    else if Source.startsWithAt s i "/-".toList then
-      i := blockCommentEnd s i
-    else
-      break
-  return i
 
 /-- Locate the body marker of an eval-problem theorem without assuming the
 literal spelling `:= by`. Candidates inside comments, strings, and brackets are

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -670,29 +670,33 @@ private def declarationModifiers : Array String :=
 /-- Keywords that introduce a declaration an attribute block can modify. -/
 private def declarationKeywords : Array String :=
   #["theorem", "lemma", "def", "abbrev", "instance", "example", "axiom",
-    "opaque", "structure", "class", "inductive", "alias", "mutual", "macro",
-    "macro_rules", "elab", "elab_rules", "syntax", "notation", "infix", "infixl",
-    "infixr", "prefix", "postfix", "initialize", "builtin_initialize",
-    "register_simp_attr", "declare_syntax_cat", "instance_reducible"]
+    "opaque", "structure", "class", "inductive", "coinductive", "alias",
+    "mutual", "macro", "macro_rules", "elab", "elab_rules", "syntax", "notation",
+    "infix", "infixl", "infixr", "prefix", "postfix", "initialize",
+    "builtin_initialize", "register_simp_attr", "register_option",
+    "declare_syntax_cat", "irreducible_def", "instance_reducible"]
 
 /-- True when a declaration follows the attribute block ending at `stop`.
 
-Lean accepts `@[…]` only in front of a declaration, so this is what separates a
-real attribute from the same characters sitting in a string the scanner has
-misread as code. It is the backstop for every way this file's lexer can be wrong
-— an interpolation it did not expect, a syntax extension it cannot know about.
-With it, a misreading costs a marker left in place, which the generated
-workspace reports as `unknown attribute [eval_problem]`; without it, the cost
-would be an edit to somebody's source that nothing announces. -/
+Lean accepts `@[…]` only in front of a declaration, so this corroborates the
+scanner's reading against the grammar: text that merely looks like the marker,
+in a string the scanner has misread as code, is not usually followed by one.
+
+Read together with the command-position test in `stripProblemMarkers`, this is
+what bounds the damage every remaining way this file's lexer can be wrong — an
+interpolation it did not expect, a syntax extension it cannot know about. Both
+tests are on text, so neither is sound the way the parser would be; what they
+buy is that a misreading costs a marker left in place, which the generated
+workspace reports as `unknown attribute [eval_problem]`, rather than an edit to
+somebody's source that nothing announces. An unlisted declaration keyword costs
+the same, which is why erring towards a longer list is right. -/
 private def Source.declarationFollows (s : Source) (stop : Nat) : Bool := Id.run do
   let mut i := Source.skipTrivia s stop
-  -- Bounded: a declaration carries only so many modifiers, and looking further
-  -- would be scanning for a keyword rather than corroborating one.
-  for _ in [0 : 8] do
-    if i ≥ s.size then return false
+  while i < s.size do
     if Source.startsWithAt s i "@[".toList then
+      -- Lean allows any number of attribute blocks in front of a declaration.
       match Source.attributeBlockEnd? s i with
-      | some block => i := Source.skipTrivia s block.stop
+      | some block => i := Source.skipTrivia s (max block.stop (i + 1))
       | none => return false
     else
       for keyword in declarationKeywords do
@@ -704,7 +708,7 @@ private def Source.declarationFollows (s : Source) (stop : Nat) : Bool := Id.run
             && Source.atWordEnd s (i + modifier.length) then
           next := Source.skipTrivia s (i + modifier.length)
       if next == i then return false
-      i := next
+      i := max next (i + 1)
   return false
 
 /-- True when the attribute instance spanning `[start, stop)` is the marker and
@@ -875,19 +879,28 @@ private def Source.importAt? (s : Source) (i : Nat) : Option (String × Nat) := 
   let mut name := ""
   for k in [nameStart : j] do
     name := name.push s[k]!
-  -- Trailing comments belong to the command; a comment may run past the line,
-  -- and then so does the command.
+  -- A comment closing on the same line trails the import and goes with it. One
+  -- that runs past the line is left alone, and a doc comment always is: `import
+  -- Foo /-- … -/` documents the declaration after it, not the import.
+  let lineStop := Source.lineEndAt s j
   let mut stop := j
   let mut atEnd := false
   while !atEnd do
-    j := Source.skipInlineSpace s j
-    match Source.commentEnd? s j with
-    | some commentStop =>
-      j := max commentStop (j + 1)
-      stop := j
-    | none =>
-      if j < s.size && s[j]! != '\n' then return none
+    let next := Source.skipInlineSpace s j
+    if Source.startsWithAt s next "/--".toList || Source.startsWithAt s next "/-!".toList then
+      -- Documents the declaration after it, not the import; the command ends
+      -- at the module name and the comment stays where the author put it.
       atEnd := true
+    else match Source.commentEnd? s next with
+      | some commentStop =>
+        if commentStop > lineStop then
+          atEnd := true
+        else
+          j := max commentStop (next + 1)
+          stop := j
+      | none =>
+        if next < s.size && s[next]! != '\n' then return none
+        atEnd := true
   return some (name, stop)
 
 /-- If an `import` command this pass drops begins at `i`, return the codepoint
@@ -924,7 +937,16 @@ position Lean accepts it and nowhere else:
   `@[eval_problem]` nor a macro building one is touched.
 
 A deleted line leaves the newline that introduced it, so stripping the last
-line of a file does not run the one before it into the end of the text. -/
+line of a file does not run the one before it into the end of the text.
+
+Lexing Lean without its parser cannot be exact — whether a `{` in a string opens
+an interpolation hole is settled by the grammar, and the grammar is extensible.
+So a marker is stripped only where the surrounding text corroborates that it is
+one: in command position, and in front of a declaration. Both tests are still on
+text and neither is sound the way the parser would be, but between them they
+make the cost of a misreading a marker left in place — which the generated
+workspace reports as `unknown attribute [eval_problem]` — rather than an edit to
+somebody's source that nothing announces. -/
 def stripProblemMarkers (source : String) (localImports : Array String := #[]) : String :=
   Id.run do
   let s := Source.ofString source
@@ -937,32 +959,44 @@ def stripProblemMarkers (source : String) (localImports : Array String := #[]) :
   -- Whether only trivia precedes `i` on its line — an `import` is a command
   -- only there, though a comment may sit in front of it.
   let mut freshLine := true
+  -- Whether a command could begin at `i`: at the head of its line, after the
+  -- `in` of a prefix command, or after an attribute block. Only there does
+  -- `@[…]` modify a declaration, so only there is it a marker to strip.
+  let mut commandStart := true
   while i < n do
     if let some commentEnd := Source.commentEnd? s i then
       i := max commentEnd (i + 1)
     else if let some lexemeEnd := Source.opaqueLexemeEnd? s i then
       freshLine := false
+      commandStart := false
       i := lexemeEnd
     else if let some importStop := strippedImportStop? s i freshLine localImports then
       let (a, b) := Source.markerRemoval s i importStop floor
       edits := edits.push (a, b)
       floor := b
       freshLine := b > 0 && s[b - 1]! == '\n'
+      commandStart := freshLine
       i := b
     else if Source.startsWithAt s i "@[".toList then
+      freshLine := false
       match Source.attributeBlockEnd? s i with
       | none =>
-        freshLine := false
+        commandStart := false
         i := i + 2
       | some block =>
-        let markers := (List.range block.items.size).filter fun k =>
-          let (a, b) := block.items[k]!
-          Source.itemIsMarker s a b
+        let markers :=
+          if commandStart && Source.declarationFollows s block.stop then
+            (List.range block.items.size).filter fun k =>
+              let (a, b) := block.items[k]!
+              Source.itemIsMarker s a b
+          else
+            []
         let survives := (List.range block.items.size).any fun k =>
           let (a, b) := block.items[k]!
           !markers.contains k && !Source.itemIsEmpty s a b
-        if markers.isEmpty || !Source.declarationFollows s block.stop then
-          freshLine := false
+        -- Another attribute block may follow this one.
+        commandStart := true
+        if markers.isEmpty then
           i := block.stop
         else if !survives then
           let (a, b) := Source.markerRemoval s i block.stop floor
@@ -973,11 +1007,21 @@ def stripProblemMarkers (source : String) (localImports : Array String := #[]) :
         else
           edits := edits ++ Source.markerItemRemovals s block markers
           floor := block.stop
-          freshLine := false
           i := block.stop
+    else if Source.startsWithAt s i "in".toList && Source.atWordStart s i
+        && Source.atWordEnd s (i + 2) then
+      -- The `in` of `open … in`, `set_option … in`, `include … in`: what
+      -- follows begins a command, so an attribute may sit there.
+      freshLine := false
+      commandStart := true
+      i := i + 2
     else
-      if s[i]! == '\n' then freshLine := true
-      else if !s[i]!.isWhitespace then freshLine := false
+      if s[i]! == '\n' then
+        freshLine := true
+        commandStart := true
+      else if !s[i]!.isWhitespace then
+        freshLine := false
+        commandStart := false
       i := i + 1
   let mut parts : Array String := #[]
   let mut pos : Nat := 0

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -370,6 +370,145 @@ def blockCommentEnd (source : Source) (start : Nat) : Nat := Id.run do
       i := i + 1
   return n
 
+/-! ## Lexical scanning
+
+Anything that walks Lean source looking for a particular character — a `]`
+closing an attribute, a `:=` introducing a body — has to know which occurrences
+are code and which sit inside a comment or a literal. `Source.opaqueLexemeEnd?`
+is the single place that knows how to step over the latter. -/
+
+/-- Word boundary at codepoint index `i`: index is past-the-end, at position
+0, or preceded by a non-word char. -/
+def Source.atWordStart (s : Source) (i : Nat) : Bool :=
+  i == 0 || (
+    let c := s[i - 1]!
+    !(c.isAlphanum || c == '_' || c == '\''))
+
+def Source.atWordEnd (s : Source) (i : Nat) : Bool :=
+  i ≥ s.size || (
+    let c := s[i]!
+    !(c.isAlphanum || c == '_' || c == '\''))
+
+/-- If `start` begins a line or block comment, return the codepoint index just
+past it. Block comments nest; an unterminated comment ends at `s.size`. -/
+private def Source.commentEnd? (s : Source) (start : Nat) : Option Nat :=
+  if Source.startsWithAt s start "--".toList then
+    some <| Id.run do
+      let mut i := start
+      while i < s.size && s[i]! != '\n' do
+        i := i + 1
+      return i
+  else if Source.startsWithAt s start "/-".toList then
+    some (blockCommentEnd s start)
+  else
+    none
+
+/-- If `start` begins a raw string literal — `r"…"`, `r#"…"#`, `r##"…"##`, … —
+return the index just past it. Raw strings have no escapes and are closed only
+by a quote followed by as many `#` as opened them. -/
+private def Source.rawStringEnd? (s : Source) (start : Nat) : Option Nat := Id.run do
+  if s[start]? != some 'r' || !Source.atWordStart s start then return none
+  let mut hashes : Nat := 0
+  let mut i := start + 1
+  while i < s.size && s[i]! == '#' do
+    hashes := hashes + 1
+    i := i + 1
+  if s[i]? != some '"' then return none
+  i := i + 1
+  while i < s.size do
+    if s[i]! == '"' then
+      let mut j := i + 1
+      let mut seen : Nat := 0
+      while seen < hashes && s[j]? == some '#' do
+        seen := seen + 1
+        j := j + 1
+      if seen == hashes then return some j
+    i := i + 1
+  return some s.size
+
+/-- If `start` begins a character literal, return its end. Apostrophes used in
+identifiers are rejected by requiring a closing quote in the literal shape. -/
+private def Source.charLiteralEnd? (s : Source) (start : Nat) : Option Nat :=
+  if start + 2 < s.size && s[start + 2]! == '\'' then some (start + 3)
+  else if start + 3 < s.size && s[start + 1]! == '\\' && s[start + 3]! == '\'' then
+    some (start + 4)
+  else none
+
+/-- Skip a French-quoted identifier such as `«a := by»`. -/
+private def Source.quotedIdentifierEnd (s : Source) (start : Nat) : Nat := Id.run do
+  let mut i := start + 1
+  while i < s.size do
+    if s[i]! == '»' then return i + 1
+    i := i + 1
+  return s.size
+
+/-- Skip a double-quoted string, ignoring `{…}` and treating `\x` as one unit.
+`start` must point at the opening quote; the result is `s.size` if the string is
+unterminated. -/
+private def Source.plainStringEnd (s : Source) (start : Nat) : Nat := Id.run do
+  let mut i := start + 1
+  while i < s.size do
+    if s[i]! == '\\' then
+      i := min (i + 2) s.size
+    else if s[i]! == '"' then
+      return i + 1
+    else
+      i := i + 1
+  return s.size
+
+/-- Skip a double-quoted string, including escapes and the terms of any `{…}`
+interpolation. `start` must point at the opening quote.
+
+Whether a string interpolates is not decidable from the quote alone —
+`throwError "{f "a"}"` interpolates and `"{a}"` does not — so a brace is read as
+a hole whenever doing so parses. A hole may itself hold a string, which is what
+makes the difference: read brace-blind, `throwError "{String.intercalate "\n" …}"`
+would end its string at the quote before `\n` and the rest of the message would
+be scanned as code. When the interpolation reading runs off the end of the
+source, the brace-blind one is used instead, so a lone `{` in an ordinary string
+costs nothing. -/
+private def Source.stringLiteralEnd (s : Source) (start : Nat) : Nat := Id.run do
+  let n := s.size
+  let mut i := start + 1
+  -- One entry per nested construct, innermost last: `true` while reading string
+  -- characters, `false` while reading the term inside an interpolation hole.
+  let mut modes : Array Bool := #[true]
+  while i < n do
+    if modes.back! then
+      if s[i]! == '\\' then i := min (i + 2) n
+      else if s[i]! == '"' then
+        modes := modes.pop
+        i := i + 1
+        if modes.isEmpty then return i
+      else if s[i]! == '{' then modes := modes.push false; i := i + 1
+      else i := i + 1
+    else if let some stop := Source.commentEnd? s i then i := max stop (i + 1)
+    else if let some stop := Source.rawStringEnd? s i then i := stop
+    else if s[i]! == '"' then modes := modes.push true; i := i + 1
+    else if s[i]! == '\'' then i := (Source.charLiteralEnd? s i).getD (i + 1)
+    else if s[i]! == '{' then modes := modes.push false; i := i + 1
+    else if s[i]! == '}' then modes := modes.pop; i := i + 1
+    else i := i + 1
+  return Source.plainStringEnd s start
+
+/-- If `start` begins a lexeme whose interior must not be read as code — a line
+or block comment, a string, raw string or character literal, or a French-quoted
+identifier — return the codepoint index just past it; `none` for ordinary code.
+
+The result is always strictly greater than `start`, so a scanner can step to it
+unconditionally. An unterminated lexeme ends at `s.size`. -/
+def Source.opaqueLexemeEnd? (s : Source) (start : Nat) : Option Nat := Id.run do
+  if start ≥ s.size then return none
+  let stop? : Option Nat :=
+    Source.commentEnd? s start |>.orElse fun _ =>
+    Source.rawStringEnd? s start |>.orElse fun _ =>
+      match s[start]! with
+      | '"' => some (Source.stringLiteralEnd s start)
+      | '\'' => Source.charLiteralEnd? s start
+      | '«' => some (Source.quotedIdentifierEnd s start)
+      | _ => none
+  return stop?.map (max · (start + 1))
+
 /-- Return `(endOfLastImport, bodyStart)` as codepoint indices in `source`.
 Comments and whitespace are treated as header trivia, including nested block
 comments. Thus comments before or between imports are included in
@@ -428,54 +567,211 @@ private def isLocalImport (stripped : String) (locals : Array String) : Bool := 
   let modName := ((after.trimAscii.toString.splitOn " ").head!).trimAscii.toString
   return locals.contains modName
 
-/-- Strip `@[eval_problem]` attributes, `import EvalTools.Markers` lines,
-and `import <m>` lines for each repo-local module `m` in `localImports` from
-`source`. Blank lines immediately before and after a stripped line are also
-dropped — mirroring the greedy `\s*` runs that bracket the attribute in
-Python's `_strip_problem_markers` regex.
+/-- The name of the marker attribute, as it is spelled in source. -/
+private def evalProblemAttrName : String := "eval_problem"
 
-The attribute need not occupy the whole line: `@[eval_problem] theorem foo ...`
-is stripped down to `theorem foo ...`, keeping the declaration on its line. -/
-def stripProblemMarkers (source : String) (localImports : Array String := #[]) : String := Id.run do
-  let lines := source.splitOn "\n"
-  let mut out : Array String := #[]
-  let mut eatBlanks := false
-  for line in lines do
-    let stripped := line.trimAscii.toString
-    if stripped.startsWith "@[" then
-      -- Split at the first `]`. Anything after it is a declaration sharing the
-      -- line with the attribute; rejoining with `]` restores later brackets.
-      match (stripped.drop 2).toString.splitOn "]" with
-      | attrText :: tail@(_ :: _) =>
-        let trailing := ("]".intercalate tail).trimAscii.toString
-        let attrs := attrText.splitOn ","
-        let keptAttrs := attrs.map (fun a => a.trimAscii.toString) |>.filter (fun a => a != "eval_problem")
-        if keptAttrs.length != attrs.length then
-          let indent := String.mk (line.toList.take (line.length - line.trimAsciiStart.toString.length))
-          if !keptAttrs.isEmpty then
-            let kept := indent ++ "@[" ++ ", ".intercalate keptAttrs ++ "]"
-            out := out.push (if trailing.isEmpty then kept else kept ++ " " ++ trailing)
-            eatBlanks := false
-          else if !trailing.isEmpty then
-            out := out.push (indent ++ trailing)
-            eatBlanks := false
+/-- A parsed `@[…]` attribute block. -/
+private structure AttributeBlock where
+  /-- Codepoint index just past the closing `]`. -/
+  stop : Nat
+  /-- Codepoint spans of the comma-separated attribute instances, untrimmed. -/
+  items : Array (Nat × Nat)
+
+/-- Parse the attribute block opening at `start`, which must point at `@[`.
+
+The closing `]` and the separating commas are recognised only at bracket depth
+zero and outside comments and literals, so neither `deprecated "use foo] bar"`
+nor `simp [a, b]` can end the block or split its list early.
+
+`none` if the block is unterminated. -/
+private def Source.attributeBlockEnd? (s : Source) (start : Nat) : Option AttributeBlock :=
+  Id.run do
+  let n := s.size
+  let mut i := start + 2
+  let mut itemStart := i
+  let mut items : Array (Nat × Nat) := #[]
+  let mut depth : Nat := 0
+  while i < n do
+    if let some lexemeEnd := Source.opaqueLexemeEnd? s i then
+      i := lexemeEnd
+    else
+      match s[i]! with
+      | '[' | '(' | '{' | '⟨' => depth := depth + 1; i := i + 1
+      | ')' | '}' | '⟩' => depth := depth - 1; i := i + 1
+      | ']' =>
+        if depth == 0 then
+          return some { stop := i + 1, items := items.push (itemStart, i) }
+        depth := depth - 1; i := i + 1
+      | ',' =>
+        if depth == 0 then
+          items := items.push (itemStart, i)
+          itemStart := i + 1
+        i := i + 1
+      | _ => i := i + 1
+  return none
+
+/-- True when `s[start:stop)` is entirely whitespace. -/
+private def Source.isBlankRange (s : Source) (start stop : Nat) : Bool := Id.run do
+  let mut i := start
+  while i < min stop s.size do
+    if !s[i]!.isWhitespace then return false
+    i := i + 1
+  return true
+
+/-- Codepoint index at which the line containing `i` begins. -/
+private def Source.lineStartAt (s : Source) (i : Nat) : Nat := Id.run do
+  let mut j := min i s.size
+  while j > 0 && s[j - 1]! != '\n' do
+    j := j - 1
+  return j
+
+/-- Codepoint index just past the newline that ends the line containing `i`, or
+`s.size` if that line is unterminated. -/
+private def Source.lineEndAt (s : Source) (i : Nat) : Nat := Id.run do
+  let mut j := min i s.size
+  while j < s.size do
+    j := j + 1
+    if s[j - 1]! == '\n' then return j
+  return s.size
+
+/-- The span to delete for text at `[start, stop)` that has nothing but
+whitespace for company on its lines: those whole lines, together with the blank
+lines bracketing them. This is what makes a marker on a line of its own leave
+no gap behind.
+
+`floor` bounds how far back the span may reach, so a deletion can never eat
+into text an earlier deletion already claimed. -/
+private def Source.blankEatingSpan (s : Source) (start stop floor : Nat) : Nat × Nat :=
+  Id.run do
+  let mut a := max floor (Source.lineStartAt s start)
+  while a > floor do
+    let previous := max floor (Source.lineStartAt s (a - 1))
+    if !Source.isBlankRange s previous a then break
+    a := previous
+  let mut b := Source.lineEndAt s stop
+  while b < s.size do
+    let next := Source.lineEndAt s b
+    if !Source.isBlankRange s b next then break
+    b := next
+  -- A deletion running to an unterminated last line takes the newline that
+  -- introduced it rather than leaving the file ending in a blank line.
+  if b == s.size && b > a && s[b - 1]! != '\n' && a > floor && s[a - 1]! == '\n' then
+    a := a - 1
+  return (a, b)
+
+/-- Codepoint index of the first character at or after `start` that is neither a
+space nor a tab. -/
+private def Source.skipInlineSpace (s : Source) (start : Nat) : Nat := Id.run do
+  let mut i := start
+  while i < s.size && (s[i]! == ' ' || s[i]! == '\t') do
+    i := i + 1
+  return i
+
+/-- Codepoint index of the first character at or before `start`, and not before
+`floor`, that is preceded by neither a space nor a tab. -/
+private def Source.rewindInlineSpace (s : Source) (start floor : Nat) : Nat := Id.run do
+  let mut i := start
+  while i > floor && (s[i - 1]! == ' ' || s[i - 1]! == '\t') do
+    i := i - 1
+  return i
+
+/-- The span to delete to remove the attribute block at `[start, stop)` when no
+attribute in it survives. -/
+private def Source.markerRemoval (s : Source) (start stop floor : Nat) : Nat × Nat :=
+  let blankBefore := Source.isBlankRange s (Source.lineStartAt s start) start
+  let blankAfter := Source.isBlankRange s stop (Source.lineEndAt s stop)
+  if blankBefore && blankAfter then
+    Source.blankEatingSpan s start stop floor
+  else if blankAfter then
+    -- A prefix command such as `include x in` precedes the marker and the line
+    -- ends with it, so the space that separated the two goes as well.
+    (Source.rewindInlineSpace s start floor, Source.skipInlineSpace s stop)
+  else
+    -- The declaration shares the line with the marker: only the marker and the
+    -- gap after it go, leaving any indentation in place.
+    (start, Source.skipInlineSpace s stop)
+
+/-- True when an `import` command that this pass drops begins at `i`, which must
+be the first non-whitespace position on its line. -/
+private def Source.isStrippedImportAt (s : Source) (i : Nat) (locals : Array String) : Bool :=
+  Source.startsWithAt s i "import".toList &&
+    (let line := (Source.slice s i (Source.lineEndAt s i)).trimAscii.toString
+     isEvalToolsMarkersImport line || isLocalImport line locals)
+
+/-- Strip `@[eval_problem]` attributes, `import EvalTools.Markers` lines, and
+`import <m>` lines for each repo-local module `m` in `localImports` from
+`source`. Where a stripped marker occupied whole lines, the blank lines
+immediately before and after it are dropped too — mirroring the greedy `\s*`
+runs that bracketed the attribute in Python's `_strip_problem_markers` regex.
+
+The scan is lexical rather than line-oriented, so it sees the marker in every
+position Lean accepts it and nowhere else:
+
+* the attribute may share its line with the declaration
+  (`@[eval_problem] theorem foo …`) or with a prefix command
+  (`set_option autoImplicit false in @[eval_problem] theorem foo …`);
+* it may span several lines;
+* its list is split on commas at bracket depth zero, and closed by the first
+  `]` at that depth, so `@[eval_problem, deprecated "use foo] instead"]` and
+  `@[eval_problem, simp [a, b]]` keep their siblings intact;
+* text inside a string literal or a comment is never mistaken for code, so a
+  multiline string containing `@[eval_problem]` or `import EvalTools.Markers`
+  survives verbatim. -/
+def stripProblemMarkers (source : String) (localImports : Array String := #[]) : String :=
+  Id.run do
+  let s := Source.ofString source
+  let n := s.size
+  -- `(start, stop, replacement)` triples, in increasing order and disjoint.
+  let mut edits : Array (Nat × Nat × String) := #[]
+  -- End of the last edit, so no later deletion reaches back over it.
+  let mut floor : Nat := 0
+  let mut i : Nat := 0
+  -- Whether only whitespace precedes `i` on its line — an `import` is a command
+  -- only there.
+  let mut freshLine := true
+  while i < n do
+    if let some lexemeEnd := Source.opaqueLexemeEnd? s i then
+      freshLine := false
+      i := lexemeEnd
+    else if freshLine && Source.isStrippedImportAt s i localImports then
+      let (a, b) := Source.blankEatingSpan s i i floor
+      edits := edits.push (a, b, "")
+      floor := b
+      freshLine := true
+      i := b
+    else if Source.startsWithAt s i "@[".toList then
+      match Source.attributeBlockEnd? s i with
+      | none =>
+        freshLine := false
+        i := i + 2
+      | some block =>
+        let items := block.items.map fun (a, b) => (Source.slice s a b).trimAscii.toString
+        if !items.contains evalProblemAttrName then
+          freshLine := false
+          i := block.stop
+        else
+          let kept := items.filter fun item => item != evalProblemAttrName && !item.isEmpty
+          if kept.isEmpty then
+            let (a, b) := Source.markerRemoval s i block.stop floor
+            edits := edits.push (a, b, "")
+            floor := b
+            freshLine := b > 0 && s[b - 1]! == '\n'
+            i := b
           else
-            while out.size > 0 && out[out.size - 1]!.trimAscii.toString.isEmpty do
-              out := out.pop
-            eatBlanks := true
-          continue
-      | _ => pure ()
-    if isEvalToolsMarkersImport stripped || isLocalImport stripped localImports then
-      -- Drop blank lines we already pushed that immediately precede this
-      -- marker line; the Python regex's leading `^\s*` consumes them too.
-      while out.size > 0 && out[out.size - 1]!.trimAscii.toString.isEmpty do
-        out := out.pop
-      eatBlanks := true
-      continue
-    if eatBlanks && stripped.isEmpty then continue
-    eatBlanks := false
-    out := out.push line
-  return "\n".intercalate out.toList
+            edits := edits.push (i, block.stop, "@[" ++ ", ".intercalate kept.toList ++ "]")
+            floor := block.stop
+            freshLine := false
+            i := block.stop
+    else
+      if s[i]! == '\n' then freshLine := true
+      else if !s[i]!.isWhitespace then freshLine := false
+      i := i + 1
+  let mut parts : Array String := #[]
+  let mut pos : Nat := 0
+  for (a, b, replacement) in edits do
+    parts := parts.push (Source.slice s pos a) |>.push replacement
+    pos := b
+  return String.join (parts.push (Source.slice s pos n)).toList
 
 /-- Find the offset (codepoint index) of the first top-level `end ...` line at
 or after `start`. Returns `source.size` if none found. Mirrors
@@ -880,18 +1176,6 @@ def lastComponentStr (name : String) : String :=
   | some s => s
   | none => name
 
-/-- Word boundary at codepoint index `i`: index is past-the-end, at position
-0, or preceded by a non-word char. -/
-def Source.atWordStart (s : Source) (i : Nat) : Bool :=
-  i == 0 || (
-    let c := s[i - 1]!
-    !(c.isAlphanum || c == '_' || c == '\''))
-
-def Source.atWordEnd (s : Source) (i : Nat) : Bool :=
-  i ≥ s.size || (
-    let c := s[i]!
-    !(c.isAlphanum || c == '_' || c == '\''))
-
 /-- Find the first occurrence of `theorem <name>` (with word boundaries) at or
 after `start`, returning the codepoint index just past the name. Mirrors the
 header regex in `extract_statement_text`. -/
@@ -927,35 +1211,6 @@ def Source.skipTrivia (s : Source) (start : Nat) : Nat := Id.run do
       break
   return i
 
-/-- Skip a double-quoted string, including escaped characters. `start` must
-point at the opening quote. -/
-private def Source.stringLiteralEnd (s : Source) (start : Nat) : Nat := Id.run do
-  let mut i := start + 1
-  while i < s.size do
-    if s[i]! == '\\' then
-      i := min (i + 2) s.size
-    else if s[i]! == '"' then
-      return i + 1
-    else
-      i := i + 1
-  return s.size
-
-/-- If `start` begins a character literal, return its end. Apostrophes used in
-identifiers are rejected by requiring a closing quote in the literal shape. -/
-private def Source.charLiteralEnd? (s : Source) (start : Nat) : Option Nat :=
-  if start + 2 < s.size && s[start + 2]! == '\'' then some (start + 3)
-  else if start + 3 < s.size && s[start + 1]! == '\\' && s[start + 3]! == '\'' then
-    some (start + 4)
-  else none
-
-/-- Skip a French-quoted identifier such as `«a := by»`. -/
-private def Source.quotedIdentifierEnd (s : Source) (start : Nat) : Nat := Id.run do
-  let mut i := start + 1
-  while i < s.size do
-    if s[i]! == '»' then return i + 1
-    i := i + 1
-  return s.size
-
 /-- Locate the body marker of an eval-problem theorem without assuming the
 literal spelling `:= by`. Candidates inside comments, strings, and brackets are
 ignored, so a default binder value such as `(h : P := by tac)` cannot be
@@ -989,19 +1244,8 @@ def Source.findTheoremBodyMarker (s : Source) (start : Nat) : Option TheoremBody
   let mut tacticMarker : Option Nat := none
   let mut tacticMarkers := 0
   while i < s.size do
-    if Source.startsWithAt s i "--".toList then
-      while i < s.size && s[i]! != '\n' do
-        i := i + 1
-    else if Source.startsWithAt s i "/-".toList then
-      i := blockCommentEnd s i
-    else if s[i]! == '"' then
-      i := Source.stringLiteralEnd s i
-    else if s[i]! == '\'' then
-      match Source.charLiteralEnd? s i with
-      | some literalEnd => i := literalEnd
-      | none => i := i + 1
-    else if s[i]! == '«' then
-      i := Source.quotedIdentifierEnd s i
+    if let some lexemeEnd := Source.opaqueLexemeEnd? s i then
+      i := lexemeEnd
     else if s[i]! == '(' then roundDepth := roundDepth + 1; i := i + 1
     else if s[i]! == ')' then roundDepth := roundDepth - 1; i := i + 1
     else if s[i]! == '[' then squareDepth := squareDepth + 1; i := i + 1

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -468,34 +468,6 @@ private def Source.plainStringEnd (s : Source) (start : Nat) : Nat := Id.run do
       i := i + 1
   return s.size
 
-/-- Skip a double-quoted string reading each `{…}` as a hole carrying a term,
-and return `none` if the literal never closes that way. `start` must point at the
-opening quote. -/
-private def Source.interpolatedStringEnd? (s : Source) (start : Nat) : Option Nat := Id.run do
-  let n := s.size
-  let mut i := start + 1
-  -- One entry per nested construct, innermost last: `true` while reading string
-  -- characters, `false` while reading the term inside an interpolation hole.
-  let mut modes : Array Bool := #[true]
-  while i < n do
-    if modes.back! then
-      if s[i]! == '\\' then i := min (i + 2) n
-      else if s[i]! == '"' then
-        modes := modes.pop
-        i := i + 1
-        if modes.isEmpty then return some i
-      else if s[i]! == '{' then modes := modes.push false; i := i + 1
-      else i := i + 1
-    else if let some stop := Source.commentEnd? s i then i := max stop (i + 1)
-    else if let some stop := Source.rawStringEnd? s i then i := stop
-    else if s[i]! == '"' then modes := modes.push true; i := i + 1
-    else if s[i]! == '\'' then i := (Source.charLiteralEnd? s i).getD (i + 1)
-    else if s[i]! == '«' then i := Source.quotedIdentifierEnd s i
-    else if s[i]! == '{' then modes := modes.push false; i := i + 1
-    else if s[i]! == '}' then modes := modes.pop; i := i + 1
-    else i := i + 1
-  return none
-
 /-- Commands whose string argument Lean parses as an interpolated string even
 though it carries no `!`. Kept to the one that occurs in this repository:
 `logInfo "{"` and its siblings fall back to an ordinary term, so listing them
@@ -529,6 +501,51 @@ private def Source.stringIsInterpolated (s : Source) (start : Nat) : Bool := Id.
   for k in [i : tokenEnd] do
     token := token.push s[k]!
   return interpolatedStringCommands.contains ((token.splitOn ".").getLast!)
+
+/-- What the scanner in `Source.interpolatedStringEnd?` is reading: the term
+inside an interpolation hole, a string whose braces open further holes, or a
+string whose braces stand for themselves. -/
+private inductive StringScanMode where
+  | hole
+  | interpolated
+  | plain
+  deriving BEq, Inhabited
+
+/-- Skip a double-quoted string reading each `{…}` as a hole carrying a term,
+and return `none` if the literal never closes that way. `start` must point at the
+opening quote.
+
+A string opened inside a hole carries holes of its own only if it is itself
+interpolated: in `s!"{f "a{b"}"` the inner literal's brace stands for itself, and
+reading it as a hole would leave the outer string looking unterminated. -/
+private def Source.interpolatedStringEnd? (s : Source) (start : Nat) : Option Nat := Id.run do
+  let n := s.size
+  let mut i := start + 1
+  -- One entry per nested construct, innermost last.
+  let mut modes : Array StringScanMode := #[.interpolated]
+  while i < n do
+    let mode := modes.back!
+    if mode != .hole then
+      if s[i]! == '\\' then i := min (i + 2) n
+      else if s[i]! == '"' then
+        modes := modes.pop
+        i := i + 1
+        if modes.isEmpty then return some i
+      else if s[i]! == '{' && mode == .interpolated then
+        modes := modes.push .hole
+        i := i + 1
+      else i := i + 1
+    else if let some stop := Source.commentEnd? s i then i := max stop (i + 1)
+    else if let some stop := Source.rawStringEnd? s i then i := stop
+    else if s[i]! == '"' then
+      modes := modes.push (if Source.stringIsInterpolated s i then .interpolated else .plain)
+      i := i + 1
+    else if s[i]! == '\'' then i := (Source.charLiteralEnd? s i).getD (i + 1)
+    else if s[i]! == '«' then i := Source.quotedIdentifierEnd s i
+    else if s[i]! == '{' then modes := modes.push .hole; i := i + 1
+    else if s[i]! == '}' then modes := modes.pop; i := i + 1
+    else i := i + 1
+  return none
 
 /-- Skip a double-quoted string. `start` must point at the opening quote. An
 interpolated string that never closes as one is read plainly, so a `{` the

--- a/EvalTools/Generate.lean
+++ b/EvalTools/Generate.lean
@@ -539,6 +539,23 @@ private def Source.stringLiteralEnd (s : Source) (start : Nat) : Nat :=
   else
     Source.plainStringEnd s start
 
+/-- If the string opening at `start` is one whose two readings disagree about
+where it ends, return the further of the two.
+
+That disagreement is the whole of what `Source.stringIsInterpolated` has to
+guess at, and it is what every way this scanner can be made to edit string
+contents needs: a hole holding a string, read plainly, puts the hole's text in
+front of the scanner as if it were code. Refusing to strip anything inside the
+span the two readings dispute removes the guess from the answer — whichever
+reading is right, that text was somebody's string or somebody's code, and this
+pass declines to say which. -/
+private def Source.disputedStringEnd? (s : Source) (start : Nat) : Option Nat :=
+  match Source.interpolatedStringEnd? s start with
+  | none => none
+  | some interpolated =>
+    let plain := Source.plainStringEnd s start
+    if interpolated == plain then none else some (max interpolated plain)
+
 /-- If `start` begins a syntax quotation `` `(…) ``, return the codepoint index
 just past its closing parenthesis. What a quotation holds is syntax the
 declaration *builds*, not syntax applied to it, so an `@[eval_problem]` inside
@@ -941,12 +958,18 @@ line of a file does not run the one before it into the end of the text.
 
 Lexing Lean without its parser cannot be exact — whether a `{` in a string opens
 an interpolation hole is settled by the grammar, and the grammar is extensible.
-So a marker is stripped only where the surrounding text corroborates that it is
-one: in command position, and in front of a declaration. Both tests are still on
-text and neither is sound the way the parser would be, but between them they
-make the cost of a misreading a marker left in place — which the generated
-workspace reports as `unknown attribute [eval_problem]` — rather than an edit to
-somebody's source that nothing announces. -/
+Three things keep that inexactness from editing somebody's string. A marker is
+stripped only in command position and only in front of a declaration; and no
+span two readings of a string literal disagree about is stripped from at all.
+The first two are tests on text, which a string can reproduce; the third is not
+a test on the marker but on how the scanner came to be looking at it, and
+reaching marker-shaped text inside a literal takes exactly the disagreement it
+refuses to resolve.
+
+What is left over is a marker left in place, which the generated workspace
+reports as `unknown attribute [eval_problem]` when it is built. That is the
+failure this is tuned for: exactness here wants the parser, which wants an
+environment, which this signature does not have. -/
 def stripProblemMarkers (source : String) (localImports : Array String := #[]) : String :=
   Id.run do
   let s := Source.ofString source
@@ -963,14 +986,22 @@ def stripProblemMarkers (source : String) (localImports : Array String := #[]) :
   -- `in` of a prefix command, or after an attribute block. Only there does
   -- `@[…]` modify a declaration, so only there is it a marker to strip.
   let mut commandStart := true
+  -- End of the furthest span two readings of a string literal disagree about.
+  -- Nothing inside one is stripped: the scanner does not know whether it is
+  -- looking at code or at the contents of somebody's string.
+  let mut disputedUntil : Nat := 0
   while i < n do
     if let some commentEnd := Source.commentEnd? s i then
       i := max commentEnd (i + 1)
     else if let some lexemeEnd := Source.opaqueLexemeEnd? s i then
+      if s[i]! == '"' then
+        if let some disputedEnd := Source.disputedStringEnd? s i then
+          disputedUntil := max disputedUntil disputedEnd
       freshLine := false
       commandStart := false
       i := lexemeEnd
-    else if let some importStop := strippedImportStop? s i freshLine localImports then
+    else if let some importStop :=
+        strippedImportStop? s i (freshLine && i ≥ disputedUntil) localImports then
       let (a, b) := Source.markerRemoval s i importStop floor
       edits := edits.push (a, b)
       floor := b
@@ -984,8 +1015,9 @@ def stripProblemMarkers (source : String) (localImports : Array String := #[]) :
         commandStart := false
         i := i + 2
       | some block =>
+        let inCommandPosition := commandStart && i ≥ disputedUntil
         let markers :=
-          if commandStart && Source.declarationFollows s block.stop then
+          if inCommandPosition && Source.declarationFollows s block.stop then
             (List.range block.items.size).filter fun k =>
               let (a, b) := block.items[k]!
               Source.itemIsMarker s a b
@@ -994,8 +1026,9 @@ def stripProblemMarkers (source : String) (localImports : Array String := #[]) :
         let survives := (List.range block.items.size).any fun k =>
           let (a, b) := block.items[k]!
           !markers.contains k && !Source.itemIsEmpty s a b
-        -- Another attribute block may follow this one.
-        commandStart := true
+        -- Another attribute block may follow this one — but only where this one
+        -- was itself at the head of a command.
+        commandStart := inCommandPosition
         if markers.isEmpty then
           i := block.stop
         else if !survives then

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -536,6 +536,14 @@ def main : IO UInt32 := do
       "    \"{String.append \"prefix\n@[eval_problem] theorem\" \"suffix\"}\"\n"
     pure <| assertEq "message verbatim" (stripProblemMarkers source) source
 
+  -- A string opened inside a hole carries holes of its own only if it is itself
+  -- interpolated. Reading the inner `"{)"` as one leaves the outer string
+  -- looking unterminated, and the scan resumes in the middle of it.
+  check "stripProblemMarkers keeps a plain string's brace inside a hole" passes fails do
+    let source := "def quoted := s!\"{String.append \"{)\" \"\n" ++
+      "@[eval_problem] theorem target : True := trivial\n\"}\"\n"
+    pure <| assertEq "message verbatim" (stripProblemMarkers source) source
+
   check "stripProblemMarkers keeps a marker a string puts behind an `in`" passes fails do
     let source := "def f (stx : Syntax) : CoreM Nat := do\n" ++
       "  throwErrorAt stx\n" ++

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -515,6 +515,34 @@ def main : IO UInt32 := do
       "    \"{String.intercalate \"\\n\" [\"@[eval_problem]\"]}\"\n"
     pure <| assertEq "message verbatim" (stripProblemMarkers source) source
 
+  -- The declaration test is on text, so a string can spell out a declaration
+  -- too. Command position is the other half: what precedes the marker here is
+  -- `prefix`, so no command can begin at it.
+  check "stripProblemMarkers keeps a marker a string spells out in full" passes fails do
+    let source := "def f (stx : Syntax) : CoreM Nat := do\n" ++
+      "  throwErrorAt stx\n" ++
+      "    \"{String.append \"prefix @[eval_problem] theorem\" \"suffix\"}\"\n"
+    pure <| assertEq "message verbatim" (stripProblemMarkers source) source
+
+  check "stripProblemMarkers keeps an attribute out of command position" passes fails do
+    let source := "def d := 1 @[eval_problem] theorem target : True := trivial\n"
+    pure <| assertEq "left verbatim" (stripProblemMarkers source) source
+
+  -- Lean allows any number of attribute blocks in front of a declaration.
+  check "stripProblemMarkers looks past a run of attribute blocks" passes fails do
+    let source := "@[eval_problem]\n@[simp]\n@[simp]\n@[simp]\n@[simp]\n@[simp]\n" ++
+      "@[simp]\n@[simp]\n@[simp]\ntheorem target : True := trivial\n"
+    pure <| assertEq "marker gone" (stripProblemMarkers source)
+      "@[simp]\n@[simp]\n@[simp]\n@[simp]\n@[simp]\n@[simp]\n@[simp]\n@[simp]\ntheorem target : True := trivial\n"
+
+  -- Lean gives the doc comment to `documented`, so the import goes and the
+  -- comment stays.
+  check "stripProblemMarkers keeps a doc comment trailing an import" passes fails do
+    let source := "import EvalTools.Markers /--\nBelongs to documented.\n-/\n" ++
+      "theorem documented : True := trivial\n"
+    pure <| assertEq "comment kept" (stripProblemMarkers source)
+      "/--\nBelongs to documented.\n-/\ntheorem documented : True := trivial\n"
+
   check "stripProblemMarkers reads a quoted identifier inside a hole" passes fails do
     let source := "def «{» := \"x\"\ndef note := s!\"{«{»}\"\n" ++
       "@[eval_problem] theorem target : True := trivial\n"

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -398,6 +398,71 @@ def main : IO UInt32 := do
     pure <| assertEq "sibling attribute kept inline"
       ((stripped.find? "@[simp] theorem target").isSome) true
 
+  -- The remaining marker-stripping cases are
+  -- https://github.com/leanprover/lean-eval/issues/544: forms of legal Lean
+  -- that the line-oriented stripper got wrong. Each asserts the whole output,
+  -- because the failure mode is a surviving `@[eval_problem]` — and
+  -- `import EvalTools.Markers` is stripped either way, so the workspace only
+  -- reports it much later as `unknown attribute [eval_problem]`.
+
+  check "stripProblemMarkers closes the attribute past a bracket in a string" passes fails do
+    let source := "@[eval_problem, deprecated \"use foo] instead\"]\ntheorem target : True := trivial\n"
+    pure <| assertEq "sibling kept whole" (stripProblemMarkers source)
+      "@[deprecated \"use foo] instead\"]\ntheorem target : True := trivial\n"
+
+  check "stripProblemMarkers splits the attribute list outside nested syntax" passes fails do
+    let source := "@[eval_problem, simp [a, b]] theorem target : True := trivial\n"
+    pure <| assertEq "nested list kept whole" (stripProblemMarkers source)
+      "@[simp [a, b]] theorem target : True := trivial\n"
+
+  check "stripProblemMarkers sees an attribute behind a prefix command" passes fails do
+    let source := "set_option autoImplicit false in @[eval_problem] theorem target :\n" ++
+      "    True := trivial\n"
+    pure <| assertEq "prefix command kept" (stripProblemMarkers source)
+      "set_option autoImplicit false in theorem target :\n    True := trivial\n"
+
+  check "stripProblemMarkers sees an attribute behind a block comment" passes fails do
+    let source := "/- note -/ @[eval_problem] theorem target : True := trivial\n"
+    pure <| assertEq "comment kept" (stripProblemMarkers source)
+      "/- note -/ theorem target : True := trivial\n"
+
+  check "stripProblemMarkers handles an attribute block spanning lines" passes fails do
+    let source := "namespace Demo\n\n@[eval_problem,\n  simp]\ntheorem target : True := trivial\n"
+    pure <| assertEq "block collapsed to its survivor" (stripProblemMarkers source)
+      "namespace Demo\n\n@[simp]\ntheorem target : True := trivial\n"
+
+  -- Every attribute in the block goes, so the whole span goes with the blank
+  -- line that preceded it — the behaviour a single-line marker has always had.
+  check "stripProblemMarkers eats the blank line before a multi-line block" passes fails do
+    let source := "namespace Demo\n\n@[\n  eval_problem\n]\ntheorem target : True := trivial\n"
+    pure <| assertEq "span and blank line gone" (stripProblemMarkers source)
+      "namespace Demo\ntheorem target : True := trivial\n"
+
+  -- `stripProblemMarkers` runs over whole file bodies, not just declaration
+  -- prefixes, so a string literal's contents are in its path.
+  check "stripProblemMarkers leaves a multiline string alone" passes fails do
+    let source := "def note : String :=\n  \"first\n@[eval_problem]\nimport EvalTools.Markers\nlast\"\n" ++
+      "\n@[eval_problem]\ntheorem target : True := trivial\n"
+    pure <| assertEq "string contents verbatim" (stripProblemMarkers source)
+      "def note : String :=\n  \"first\n@[eval_problem]\nimport EvalTools.Markers\nlast\"\ntheorem target : True := trivial\n"
+
+  check "stripProblemMarkers leaves a comment alone" passes fails do
+    let source := "-- @[eval_problem]\n/- @[eval_problem] -/\n@[eval_problem]\ntheorem target : True := trivial\n"
+    pure <| assertEq "comments verbatim" (stripProblemMarkers source)
+      "-- @[eval_problem]\n/- @[eval_problem] -/\ntheorem target : True := trivial\n"
+
+  -- A hole inside an interpolated string may itself hold a string, so reading
+  -- the outer string brace-blind would end it early and scan the rest as code.
+  check "stripProblemMarkers reads through an interpolated string" passes fails do
+    let source := "def note : String := s!\"{String.intercalate \"\\n\" [\"@[eval_problem]\"]}\"\n" ++
+      "\n@[eval_problem]\ntheorem target : True := trivial\n"
+    pure <| assertEq "interpolation verbatim" (stripProblemMarkers source)
+      "def note : String := s!\"{String.intercalate \"\\n\" [\"@[eval_problem]\"]}\"\ntheorem target : True := trivial\n"
+
+  check "stripProblemMarkers keeps an unterminated attribute block" passes fails do
+    let source := "@[eval_problem, simp\ntheorem target : True := trivial\n"
+    pure <| assertEq "left verbatim" (stripProblemMarkers source) source
+
   check "injectAfterImports honors a narrow fallback header" passes fails do
     let source := "namespace Demo\n\ndef target : Nat := 1\n\nend Demo\n"
     let injected := injectAfterImports source "import Submission\n"

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -502,6 +502,45 @@ def main : IO UInt32 := do
     let source := "@[eval_problem, simp\ntheorem target : True := trivial\n"
     pure <| assertEq "left verbatim" (stripProblemMarkers source) source
 
+  -- Lean only accepts `@[…]` in front of a declaration, and that is the
+  -- backstop for every way this lexer can be wrong about a string: the marker
+  -- text in a message is not followed by one, so it stays.
+  check "stripProblemMarkers keeps an attribute no declaration follows" passes fails do
+    let source := "def note : String :=\n  \"which @[eval_problem] does not allow.\"\n"
+    pure <| assertEq "left verbatim" (stripProblemMarkers source) source
+
+  check "stripProblemMarkers keeps a marker behind an unclassifiable interpolation" passes fails do
+    let source := "def f (stx : Syntax) : CoreM Nat := do\n" ++
+      "  throwErrorAt stx\n" ++
+      "    \"{String.intercalate \"\\n\" [\"@[eval_problem]\"]}\"\n"
+    pure <| assertEq "message verbatim" (stripProblemMarkers source) source
+
+  check "stripProblemMarkers reads a quoted identifier inside a hole" passes fails do
+    let source := "def «{» := \"x\"\ndef note := s!\"{«{»}\"\n" ++
+      "@[eval_problem] theorem target : True := trivial\n"
+    pure <| assertEq "marker still found" (stripProblemMarkers source)
+      "def «{» := \"x\"\ndef note := s!\"{«{»}\"\ntheorem target : True := trivial\n"
+
+  check "stripProblemMarkers strips the quoted spelling of the marker" passes fails do
+    let source := "@[«eval_problem», simp] theorem target : True := trivial\n"
+    pure <| assertEq "sibling kept" (stripProblemMarkers source)
+      "@[simp] theorem target : True := trivial\n"
+
+  check "stripProblemMarkers strips two markers from one list" passes fails do
+    let source := "@[eval_problem, eval_problem, simp]\ntheorem target : True := trivial\n"
+    pure <| assertEq "both gone" (stripProblemMarkers source)
+      "@[simp]\ntheorem target : True := trivial\n"
+
+  check "stripProblemMarkers strips an import broken across lines" passes fails do
+    let source := "import\n  EvalTools.Markers\n@[eval_problem] theorem target : True := trivial\n"
+    pure <| assertEq "both gone" (stripProblemMarkers source)
+      "theorem target : True := trivial\n"
+
+  check "stripProblemMarkers strips an import with a comment inside it" passes fails do
+    let source := "import /- why -/ EvalTools.Markers\ntheorem target : True := trivial\n"
+    pure <| assertEq "import gone" (stripProblemMarkers source)
+      "theorem target : True := trivial\n"
+
   -- Regression for the shared lexeme scanner: a brace in an ordinary string
   -- must not hide the `:=` that introduces the body.
   check "extractStatementText sees past braces in a plain string" passes fails do

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -467,10 +467,12 @@ def main : IO UInt32 := do
     let source := "def left := \"{\"\n@[eval_problem] theorem target : True := trivial\ndef right := \"}\"\n"
     pure <| assertEq "left verbatim" (stripProblemMarkers source) source
 
-  check "stripProblemMarkers strips past a brace no later quote balances" passes fails do
+  -- A reading that never closes disagrees too, and by more than any other, so
+  -- the dispute runs to the end of the input. It takes a string carrying a
+  -- brace it does not close, which no file in Mathlib does.
+  check "stripProblemMarkers declines past a brace nothing closes" passes fails do
     let source := "def left := \"{\"\n@[eval_problem] theorem target : True := trivial\n"
-    pure <| assertEq "marker gone" (stripProblemMarkers source)
-      "def left := \"{\"\ntheorem target : True := trivial\n"
+    pure <| assertEq "left verbatim" (stripProblemMarkers source) source
 
   -- Reprinting the survivors would drop the newline that ends the comment and
   -- so comment out the closing `]`.
@@ -542,6 +544,14 @@ def main : IO UInt32 := do
   check "stripProblemMarkers keeps a plain string's brace inside a hole" passes fails do
     let source := "def quoted := s!\"{String.append \"{)\" \"\n" ++
       "@[eval_problem] theorem target : True := trivial\n\"}\"\n"
+    pure <| assertEq "message verbatim" (stripProblemMarkers source) source
+
+  -- The converse mistake, on syntax the lookback cannot classify: `dbg_trace`
+  -- takes an interpolated string, and the raw string inside it leaves the
+  -- interpolated reading unterminated. That is a dispute, not a licence.
+  check "stripProblemMarkers keeps a marker behind an unterminated reading" passes fails do
+    let source := "def quoted := s!\"{dbg_trace \"{String.length r#\"{)\"#}\n" ++
+      "@[eval_problem] theorem target : True := trivial\n\"; \"fixed\"}\"\n"
     pure <| assertEq "message verbatim" (stripProblemMarkers source) source
 
   check "stripProblemMarkers keeps a marker a string puts behind an `in`" passes fails do

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -459,9 +459,55 @@ def main : IO UInt32 := do
     pure <| assertEq "interpolation verbatim" (stripProblemMarkers source)
       "def note : String := s!\"{String.intercalate \"\\n\" [\"@[eval_problem]\"]}\"\ntheorem target : True := trivial\n"
 
+  -- The converse of the case above: a brace in a string that does not
+  -- interpolate is just a brace. Reading it as a hole would run the scan on to
+  -- the next `}` and hide every marker in between.
+  check "stripProblemMarkers treats a brace in a plain string as a brace" passes fails do
+    let source := "def left := \"{\"\n@[eval_problem] theorem target : True := trivial\ndef right := \"}\"\n"
+    pure <| assertEq "marker still found" (stripProblemMarkers source)
+      "def left := \"{\"\ntheorem target : True := trivial\ndef right := \"}\"\n"
+
+  -- Reprinting the survivors would drop the newline that ends the comment and
+  -- so comment out the closing `]`.
+  check "stripProblemMarkers keeps a comment among the surviving attributes" passes fails do
+    let source := "@[simp -- explanation\n, eval_problem]\ntheorem target : True := trivial\n"
+    pure <| assertEq "comment kept terminated" (stripProblemMarkers source)
+      "@[simp -- explanation\n]\ntheorem target : True := trivial\n"
+
+  -- The marker inside a quotation is syntax the macro builds, not an attribute
+  -- applied to the macro.
+  check "stripProblemMarkers leaves a syntax quotation alone" passes fails do
+    let source := "macro \"mkProblem\" n:ident : command =>\n" ++
+      "  `(@[eval_problem] theorem $n : True := trivial)\n"
+    pure <| assertEq "quotation verbatim" (stripProblemMarkers source) source
+
+  check "stripProblemMarkers strips a marker carrying trivia" passes fails do
+    let source := "@[eval_problem /- why -/, simp]\ntheorem target : True := trivial\n"
+    pure <| assertEq "marker recognised" (stripProblemMarkers source)
+      "@[simp]\ntheorem target : True := trivial\n"
+
+  check "stripProblemMarkers strips an import with a trailing comment" passes fails do
+    let source := "import EvalTools.Markers /- why -/\n@[eval_problem] theorem target : True := trivial\n"
+    pure <| assertEq "import and marker gone" (stripProblemMarkers source)
+      "theorem target : True := trivial\n"
+
+  -- `@[simp,]` is not legal Lean, but rewriting it to `@[]` would replace one
+  -- error with a less obvious one.
+  check "stripProblemMarkers does not leave an empty attribute block" passes fails do
+    let source := "namespace Demo\n\n@[eval_problem,\n  ]\ntheorem target : True := trivial\n"
+    pure <| assertEq "whole block gone" (stripProblemMarkers source)
+      "namespace Demo\ntheorem target : True := trivial\n"
+
   check "stripProblemMarkers keeps an unterminated attribute block" passes fails do
     let source := "@[eval_problem, simp\ntheorem target : True := trivial\n"
     pure <| assertEq "left verbatim" (stripProblemMarkers source) source
+
+  -- Regression for the shared lexeme scanner: a brace in an ordinary string
+  -- must not hide the `:=` that introduces the body.
+  check "extractStatementText sees past braces in a plain string" passes fails do
+    let statement ← extractStatementText "demo" "Demo.lean"
+      "theorem target : \"{\" = \"{\" := by\n  simpa using (show \"}\" = \"}\" from rfl)" "target"
+    pure <| assertEq "statement recovered" statement ": \"{\" = \"{\""
 
   check "injectAfterImports honors a narrow fallback header" passes fails do
     let source := "namespace Demo\n\ndef target : Nat := 1\n\nend Demo\n"

--- a/tests/lean/EvalToolsTests/GenerateTest.lean
+++ b/tests/lean/EvalToolsTests/GenerateTest.lean
@@ -459,13 +459,18 @@ def main : IO UInt32 := do
     pure <| assertEq "interpolation verbatim" (stripProblemMarkers source)
       "def note : String := s!\"{String.intercalate \"\\n\" [\"@[eval_problem]\"]}\"\ntheorem target : True := trivial\n"
 
-  -- The converse of the case above: a brace in a string that does not
-  -- interpolate is just a brace. Reading it as a hole would run the scan on to
-  -- the next `}` and hide every marker in between.
-  check "stripProblemMarkers treats a brace in a plain string as a brace" passes fails do
+  -- A brace in a string that does not interpolate is just a brace, and one in a
+  -- hole is not. Between `"{"` and a later `"}"` the two readings disagree
+  -- about what is string and what is code, so this declines to strip rather
+  -- than guess — the marker survives into the workspace build, which says so.
+  check "stripProblemMarkers declines a marker between disputed braces" passes fails do
     let source := "def left := \"{\"\n@[eval_problem] theorem target : True := trivial\ndef right := \"}\"\n"
-    pure <| assertEq "marker still found" (stripProblemMarkers source)
-      "def left := \"{\"\ntheorem target : True := trivial\ndef right := \"}\"\n"
+    pure <| assertEq "left verbatim" (stripProblemMarkers source) source
+
+  check "stripProblemMarkers strips past a brace no later quote balances" passes fails do
+    let source := "def left := \"{\"\n@[eval_problem] theorem target : True := trivial\n"
+    pure <| assertEq "marker gone" (stripProblemMarkers source)
+      "def left := \"{\"\ntheorem target : True := trivial\n"
 
   -- Reprinting the survivors would drop the newline that ends the comment and
   -- so comment out the closing `]`.
@@ -515,18 +520,27 @@ def main : IO UInt32 := do
       "    \"{String.intercalate \"\\n\" [\"@[eval_problem]\"]}\"\n"
     pure <| assertEq "message verbatim" (stripProblemMarkers source) source
 
-  -- The declaration test is on text, so a string can spell out a declaration
-  -- too. Command position is the other half: what precedes the marker here is
-  -- `prefix`, so no command can begin at it.
+  -- Both corroborating tests are on text, and a string can spell out whatever
+  -- text it likes: command position, sibling attributes, a declaration keyword.
+  -- What saves this is that reaching the marker at all takes a hole read as
+  -- plain text, and the span that hole disputes is not stripped from.
   check "stripProblemMarkers keeps a marker a string spells out in full" passes fails do
     let source := "def f (stx : Syntax) : CoreM Nat := do\n" ++
       "  throwErrorAt stx\n" ++
       "    \"{String.append \"prefix @[eval_problem] theorem\" \"suffix\"}\"\n"
     pure <| assertEq "message verbatim" (stripProblemMarkers source) source
 
-  check "stripProblemMarkers keeps an attribute out of command position" passes fails do
-    let source := "def d := 1 @[eval_problem] theorem target : True := trivial\n"
-    pure <| assertEq "left verbatim" (stripProblemMarkers source) source
+  check "stripProblemMarkers keeps a marker a string puts at a line head" passes fails do
+    let source := "def f (stx : Syntax) : CoreM Nat := do\n" ++
+      "  throwErrorAt stx\n" ++
+      "    \"{String.append \"prefix\n@[eval_problem] theorem\" \"suffix\"}\"\n"
+    pure <| assertEq "message verbatim" (stripProblemMarkers source) source
+
+  check "stripProblemMarkers keeps a marker a string puts behind an `in`" passes fails do
+    let source := "def f (stx : Syntax) : CoreM Nat := do\n" ++
+      "  throwErrorAt stx\n" ++
+      "    \"{String.append \"prefix in @[eval_problem] theorem\" \"suffix\"}\"\n"
+    pure <| assertEq "message verbatim" (stripProblemMarkers source) source
 
   -- Lean allows any number of attribute blocks in front of a declaration.
   check "stripProblemMarkers looks past a run of attribute blocks" passes fails do


### PR DESCRIPTION
This PR replaces the line-oriented marker stripper in `EvalTools/Generate.lean` with a scanner that walks the whole source, tracking line and block comments, string, raw-string and character literals, French-quoted identifiers, syntax quotations and bracket depth. The marker is now recognised in every position Lean accepts it: sharing a line with its declaration or with a prefix command such as `include x in` or `set_option … in`, spanning several lines, carrying trivia as in `@[/- why -/ eval_problem]`, spelled `«eval_problem»`, or carrying siblings whose arguments contain a `]` or a `,`. Surviving siblings are spliced out of the source rather than reprinted, so a comment among them keeps the line break that terminates it. Imports are parsed the same way, so one broken across lines or carrying a comment is recognised, while a doc comment trailing an import stays with the declaration it documents.

Lexing Lean without its parser cannot be exact: whether a `{` in a string opens an interpolation hole is settled by the grammar, and the grammar is extensible. Three things keep that inexactness from editing somebody's string. A marker is stripped only in command position and only in front of a declaration; and no span the two readings of a string literal disagree about is stripped from at all. The first two are tests on text, which a string can reproduce; the third is not a test on the marker but on how the scanner came to be looking at it, and reaching marker-shaped text inside a literal takes exactly the disagreement it declines to resolve. What is left over is a marker left in place, which the generated workspace reports as `unknown attribute [eval_problem]` when it is built.

`Source.opaqueLexemeEnd?` is the one place that knows how to step over a comment or a literal; `Source.findTheoremBodyMarker` now uses it in place of its own copy.

Nothing in the catalog exercises any of this today, so a differential check against the old implementation over every `.lean` file in `LeanEval/`, `EvalTools/`, `tests/`, `generated/` and `templates/` — in both shapes the generator passes in, with and without local-import stripping — reports no change in output.

Closes #544.

🤖 Prepared with Claude Code