### PR TITLE
Add ten newly merged problems to v1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -148,6 +148,14 @@ result.
 
 ## 2. The v1 problem set
 
+> **Maintainer amendment, 2026-08-21.** The original v1 publication selected
+> 118 members under the rule below. The maintainer subsequently authorized ten
+> newly merged problems to be added, producing an effective set of 128. This
+> decision supersedes the statements below that v1 can never receive additions.
+> Existing members still cannot be removed or replaced; the exception is
+> recorded as an append-only, dated amendment with exact PR and merge-commit
+> provenance.
+
 The current catalog grew by accretion. v1 is the first named frozen set in
 the formalization evaluation group: a curated subset that stays fixed, so
 that results are comparable over a meaningful window.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The one-file-per-problem layout means two PRs adding distinct problems
 never conflict on the manifest.
 
 See [Catalog metadata](docs/catalog-metadata.md) for lifecycle history, the tag
-registry, immutable named sets, and the deterministic v1 evidence tool.
+registry, append-only named sets, and the deterministic v1 evidence tool.
 
 The manifest is the only entry point CI has into `LeanEval/`, so a module
 no manifest names is never built. `validate-manifest` therefore rejects any

--- a/audits/v1/amendment-2026-08-21.json
+++ b/audits/v1/amendment-2026-08-21.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "set_id": "v1",
+  "amendment_id": "2026-08-21-newly-merged-problems",
+  "effective_date": "2026-08-21",
+  "authorization": "Explicit maintainer request in the implementation session on 2026-08-21.",
+  "previous_member_count": 118,
+  "added_member_count": 10,
+  "effective_member_count": 128,
+  "source_catalog_commit": "e772fc05aa1533d8370e5ca7e27bcb75595aafae",
+  "additions": [
+    {
+      "problem_id": "budney_gabai_knotted_three_spheres",
+      "statement_revision": 1,
+      "pull_request": 538,
+      "merge_commit": "a58d1a25c40c00b2847e0d593ed6fceaaca931b7"
+    },
+    {
+      "problem_id": "dimitrov",
+      "statement_revision": 1,
+      "pull_request": 479,
+      "merge_commit": "5c02c50963d0e84cc188180c5a83cd768a03262a"
+    },
+    {
+      "problem_id": "direct_summand",
+      "statement_revision": 1,
+      "pull_request": 513,
+      "merge_commit": "6191e7da43d95e2ea3a4a8076cf00d6db6cc4a05"
+    },
+    {
+      "problem_id": "einsiedler_katok_lindenstrauss",
+      "statement_revision": 1,
+      "pull_request": 515,
+      "merge_commit": "92541832ba1d24520ae144440e84cafce5417bc4"
+    },
+    {
+      "problem_id": "faltings",
+      "statement_revision": 1,
+      "pull_request": 191,
+      "merge_commit": "2f9397a184120ded9e6a6bfda828a222ccd9f211"
+    },
+    {
+      "problem_id": "four_manifold_not_smooth",
+      "statement_revision": 1,
+      "pull_request": 523,
+      "merge_commit": "f58d72e65abef64b759ca72938d8600ef822873c"
+    },
+    {
+      "problem_id": "klartag_packing",
+      "statement_revision": 1,
+      "pull_request": 522,
+      "merge_commit": "2365dfdb9462aed880620d55b3a3355198c3fc81"
+    },
+    {
+      "problem_id": "newlander_nirenberg",
+      "statement_revision": 1,
+      "pull_request": 549,
+      "merge_commit": "e772fc05aa1533d8370e5ca7e27bcb75595aafae"
+    },
+    {
+      "problem_id": "nikolov_segal",
+      "statement_revision": 1,
+      "pull_request": 526,
+      "merge_commit": "d0e716619b98294ecf4ba43072ea8d493a0f4e82"
+    },
+    {
+      "problem_id": "ore_conjecture",
+      "statement_revision": 1,
+      "pull_request": 527,
+      "merge_commit": "c4fa24c6b61dcd60abc8fc4fb950b3e780eb0bfc"
+    }
+  ]
+}

--- a/docs/catalog-metadata.md
+++ b/docs/catalog-metadata.md
@@ -46,9 +46,12 @@ Allowed reason categories are `initial`,
 ## Named sets
 
 Files in `manifests/sets/` list exact `(problem_id, statement_revision)` pairs.
-Once `frozen = true`, comparison with the CI base revision makes membership
-immutable. Corrections and retractions therefore remain visible historically
-and are represented through lifecycle metadata rather than deleting members.
+Once `frozen = true`, comparison with the CI base revision prevents deleting,
+unfreezing, removing or replacing members, or rewriting prior amendment
+records. Schema-2 sets may make an exceptional addition only through a new,
+later-dated amendment that names the exact added pairs and its authorization.
+Corrections and retractions remain visible historically and are represented
+through lifecycle metadata rather than deleting members.
 
 ## v1 evidence
 

--- a/docs/v1-set.md
+++ b/docs/v1-set.md
@@ -1,23 +1,32 @@
 # LeanEval v1 set
 
-The frozen `v1` set contains 118 exact problem statement revisions. Membership
-was selected mechanically on 2026-08-20 from results commit
-`269c4dc9e3d264fe6b06e7d5d2fd1b0d86ac17e4`:
+The published `v1` set initially contained 118 exact problem statement
+revisions. Membership was selected mechanically on 2026-08-20 from results
+commit `269c4dc9e3d264fe6b06e7d5d2fd1b0d86ac17e4`:
 
 - catalog group `formalization-evaluation`;
 - `visible = true`;
 - fewer than three accepted result records; and
 - zero accepted records whose submitted source was public.
 
-There are no manual additions or exclusions. The two software-verification
-drafts are not candidates because they belong to the separate
-`software-verification` group. The complete 299-problem evidence is checked in
+There were no manual additions or exclusions in that initial selection. The
+two software-verification drafts were not candidates because they belong to
+the separate `software-verification` group. The complete 299-problem evidence is checked in
 as [`selection-2026-08-20.json`](../audits/v1/selection-2026-08-20.json) and a
 human-readable [Markdown table](../audits/v1/selection-2026-08-20.md). The JSON
 evidence SHA-256 is
 `336be9fcafa4730cd0daf4598d30ae10104c3f733a08aeef48ae2357a2518817`.
 
-The set is published with `frozen = true`. Catalog validation prevents later
-deletion, unfreezing, or membership changes after this commit reaches `main`.
-Lifecycle corrections remain possible through the append-only problem history
-without changing the frozen `(problem_id, statement_revision)` pairs.
+On 2026-08-21, the maintainer explicitly amended v1 to add ten newly merged
+evaluation problems at statement revision 1. The effective set therefore has
+128 members. The machine-readable amendment record, including the ten PRs and
+merge commits, is
+[`amendment-2026-08-21.json`](../audits/v1/amendment-2026-08-21.json).
+This amendment does not retroactively alter the original 118-member selection
+evidence.
+
+The set remains published with `frozen = true`. Catalog validation prevents
+deletion, unfreezing, removal or replacement of a member, and rewriting an
+existing amendment. Any exceptional addition requires a later-dated,
+append-only amendment naming the exact `(problem_id, statement_revision)`
+pairs and its authorization.

--- a/manifests/sets/README.md
+++ b/manifests/sets/README.md
@@ -3,7 +3,7 @@
 Each `<id>.toml` file defines a versioned set of problem statement revisions.
 Set IDs use lowercase kebab-case. A draft set may change while `frozen = false`.
 After a set is published with `frozen = true`, CI prevents deletion, unfreezing,
-or any change to its `(problem_id, statement_revision)` membership.
+member removal or replacement, and rewriting previous amendment records.
 
 ```toml
 schema_version = 1
@@ -16,3 +16,30 @@ members = [
 ```
 
 A frozen set must also specify a canonical `published_at = "YYYY-MM-DD"`.
+
+Schema 2 supports exceptional, explicitly authorized additions without
+rewriting the original freeze. `initial_member_count` records the published
+size. Each later addition appears in the effective `members` array and exactly
+once in a dated, append-only amendment:
+
+```toml
+schema_version = 2
+id = "v1"
+title = "LeanEval v1"
+frozen = true
+published_at = "2026-08-20"
+initial_member_count = 1
+members = [
+  { problem_id = "example", statement_revision = 1 },
+  { problem_id = "later-example", statement_revision = 1 },
+]
+
+[[amendments]]
+id = "2026-08-21-add-later-example"
+effective_date = "2026-08-21"
+reason = "Explicit maintainer addition."
+authorization = "Maintainer decision recorded in issue 123."
+additions = [
+  { problem_id = "later-example", statement_revision = 1 },
+]
+```

--- a/manifests/sets/v1.toml
+++ b/manifests/sets/v1.toml
@@ -1,8 +1,9 @@
-schema_version = 1
+schema_version = 2
 id = "v1"
 title = "LeanEval v1"
 frozen = true
 published_at = "2026-08-20"
+initial_member_count = 118
 members = [
   { problem_id = "annals_absolute_profinite_rigidity", statement_revision = 1 },
   { problem_id = "annals_algebraic_integers", statement_revision = 1 },
@@ -59,6 +60,7 @@ members = [
   { problem_id = "bakerWustholz_linearForms_logs", statement_revision = 1 },
   { problem_id = "bender_suzuki", statement_revision = 1 },
   { problem_id = "bourgain_polynomial_ergodic", statement_revision = 1 },
+  { problem_id = "budney_gabai_knotted_three_spheres", statement_revision = 1 },
   { problem_id = "cdt_linearIndependent", statement_revision = 1 },
   { problem_id = "cerf_gamma_four", statement_revision = 1 },
   { problem_id = "chen_theorem", statement_revision = 1 },
@@ -66,13 +68,18 @@ members = [
   { problem_id = "conway_knot_not_smoothly_slice", statement_revision = 1 },
   { problem_id = "conway_knot_topologically_slice", statement_revision = 1 },
   { problem_id = "derived_solidification_free_CW_homology", statement_revision = 1 },
+  { problem_id = "dimitrov", statement_revision = 1 },
+  { problem_id = "direct_summand", statement_revision = 1 },
   { problem_id = "duffin_schaeffer", statement_revision = 1 },
   { problem_id = "e8_irrep_tensor_square_decomp", statement_revision = 1 },
+  { problem_id = "einsiedler_katok_lindenstrauss", statement_revision = 1 },
   { problem_id = "equichordal_point_unique", statement_revision = 1 },
   { problem_id = "erdos_unit_distance_conjecture_false", statement_revision = 1 },
   { problem_id = "exists_topologically_slice_not_smoothly_slice", statement_revision = 1 },
+  { problem_id = "faltings", statement_revision = 1 },
   { problem_id = "fermat_last_theorem", statement_revision = 1 },
   { problem_id = "five_transitive_card_classification", statement_revision = 1 },
+  { problem_id = "four_manifold_not_smooth", statement_revision = 1 },
   { problem_id = "friedlander_iwaniec", statement_revision = 1 },
   { problem_id = "gorenstein_walter", statement_revision = 1 },
   { problem_id = "green_tao", statement_revision = 1 },
@@ -82,6 +89,7 @@ members = [
   { problem_id = "hSpace_sphere_iff", statement_revision = 1 },
   { problem_id = "jacobian_challenge_alggeo", statement_revision = 1 },
   { problem_id = "kepler_conjecture", statement_revision = 1 },
+  { problem_id = "klartag_packing", statement_revision = 1 },
   { problem_id = "kollar_lieblich_olsson_sawin", statement_revision = 1 },
   { problem_id = "linnik", statement_revision = 1 },
   { problem_id = "mandelbar_not_path_connected", statement_revision = 1 },
@@ -92,6 +100,9 @@ members = [
   { problem_id = "milnor_exotic_sphere_seven", statement_revision = 1 },
   { problem_id = "mostow_rigidity", statement_revision = 1 },
   { problem_id = "neukirch_uchida", statement_revision = 1 },
+  { problem_id = "newlander_nirenberg", statement_revision = 1 },
+  { problem_id = "nikolov_segal", statement_revision = 1 },
+  { problem_id = "ore_conjecture", statement_revision = 1 },
   { problem_id = "pardon_torus_knot_distortion", statement_revision = 1 },
   { problem_id = "pi_sphere_infinite_iff", statement_revision = 1 },
   { problem_id = "pi6_sphere_three_mulEquiv_zmod_twelve", statement_revision = 1 },
@@ -122,4 +133,23 @@ members = [
   { problem_id = "weinstein_conjecture_dim3", statement_revision = 1 },
   { problem_id = "whitney_embedding", statement_revision = 1 },
   { problem_id = "zhang_bounded_prime_gaps", statement_revision = 1 },
+]
+
+[[amendments]]
+id = "2026-08-21-newly-merged-problems"
+effective_date = "2026-08-21"
+reason = "Add newly merged evaluation problems to v1 by explicit maintainer decision."
+authorization = "Maintainer request recorded in the implementation session on 2026-08-21."
+evidence = "audits/v1/amendment-2026-08-21.json"
+additions = [
+  { problem_id = "budney_gabai_knotted_three_spheres", statement_revision = 1 },
+  { problem_id = "dimitrov", statement_revision = 1 },
+  { problem_id = "direct_summand", statement_revision = 1 },
+  { problem_id = "einsiedler_katok_lindenstrauss", statement_revision = 1 },
+  { problem_id = "faltings", statement_revision = 1 },
+  { problem_id = "four_manifold_not_smooth", statement_revision = 1 },
+  { problem_id = "klartag_packing", statement_revision = 1 },
+  { problem_id = "newlander_nirenberg", statement_revision = 1 },
+  { problem_id = "nikolov_segal", statement_revision = 1 },
+  { problem_id = "ore_conjecture", statement_revision = 1 },
 ]

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate LeanEval catalog metadata and immutable named sets."""
+"""Validate LeanEval catalog metadata and append-only named sets."""
 
 from __future__ import annotations
 
@@ -189,16 +189,18 @@ def load_sets(
             named_set = tomllib.loads(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, tomllib.TOMLDecodeError) as error:
             raise CatalogError(f"cannot read named set {path}: {error}") from error
-        if named_set.get("schema_version") != 1:
-            raise CatalogError(f"{path}: schema_version must be 1")
+        schema_version = named_set.get("schema_version")
+        if schema_version not in {1, 2}:
+            raise CatalogError(f"{path}: schema_version must be 1 or 2")
         set_id = _string(named_set.get("id"), f"{path}: id")
         if set_id != path.stem or TAG_RE.fullmatch(set_id) is None:
             raise CatalogError(f"{path}: id must be lowercase kebab-case and match the filename")
         _string(named_set.get("title"), f"{path}: title")
         if type(named_set.get("frozen")) is not bool:
             raise CatalogError(f"{path}: frozen must be a boolean")
+        published_at = ""
         if "published_at" in named_set:
-            _date(named_set["published_at"], f"{path}: published_at")
+            published_at = _date(named_set["published_at"], f"{path}: published_at")
         if named_set["frozen"] and "published_at" not in named_set:
             raise CatalogError(f"{path}: a frozen set requires published_at")
         members = _array(named_set.get("members"), f"{path}: members")
@@ -216,6 +218,74 @@ def load_sets(
             if key in seen:
                 raise CatalogError(f"{path}: duplicate member {problem_id}@{revision}")
             seen.add(key)
+
+        amendments = _array(named_set.get("amendments", []), f"{path}: amendments")
+        if schema_version == 1 and amendments:
+            raise CatalogError(f"{path}: amendments require schema_version 2")
+        if amendments and named_set["frozen"] is not True:
+            raise CatalogError(f"{path}: only a frozen set may have amendments")
+        amended_members: set[tuple[str, int]] = set()
+        amendment_ids: set[str] = set()
+        previous_date = published_at
+        for amendment_index, raw_amendment in enumerate(amendments):
+            label = f"{path}: amendments[{amendment_index}]"
+            amendment = _table(raw_amendment, label)
+            amendment_id = _string(amendment.get("id"), f"{label}.id")
+            if TAG_RE.fullmatch(amendment_id) is None:
+                raise CatalogError(f"{label}.id must be lowercase kebab-case")
+            if amendment_id in amendment_ids:
+                raise CatalogError(f"{path}: duplicate amendment id {amendment_id!r}")
+            amendment_ids.add(amendment_id)
+            effective_date = _date(
+                amendment.get("effective_date"), f"{label}.effective_date"
+            )
+            if effective_date <= previous_date:
+                raise CatalogError(
+                    f"{path}: amendment dates must increase strictly after publication"
+                )
+            previous_date = effective_date
+            _string(amendment.get("reason"), f"{label}.reason")
+            _string(amendment.get("authorization"), f"{label}.authorization")
+            if "evidence" in amendment:
+                evidence = pathlib.PurePosixPath(
+                    _string(amendment["evidence"], f"{label}.evidence")
+                )
+                if evidence.is_absolute() or ".." in evidence.parts:
+                    raise CatalogError(f"{label}.evidence must be a safe repository path")
+                if not (root / evidence).is_file():
+                    raise CatalogError(f"{label}.evidence does not exist: {evidence}")
+            additions = _array(amendment.get("additions"), f"{label}.additions")
+            if not additions:
+                raise CatalogError(f"{label}.additions must not be empty")
+            for addition_index, raw_addition in enumerate(additions):
+                addition_label = f"{label}.additions[{addition_index}]"
+                addition = _table(raw_addition, addition_label)
+                problem_id = _string(
+                    addition.get("problem_id"), f"{addition_label}.problem_id"
+                )
+                revision = _integer(
+                    addition.get("statement_revision"),
+                    f"{addition_label}.statement_revision",
+                )
+                key = (problem_id, revision)
+                if key not in seen:
+                    raise CatalogError(
+                        f"{addition_label}: addition is not an effective set member"
+                    )
+                if key in amended_members:
+                    raise CatalogError(
+                        f"{path}: member {problem_id}@{revision} is amended more than once"
+                    )
+                amended_members.add(key)
+
+        if schema_version == 2:
+            initial_member_count = _integer(
+                named_set.get("initial_member_count"), f"{path}: initial_member_count"
+            )
+            if len(seen) != initial_member_count + len(amended_members):
+                raise CatalogError(
+                    f"{path}: effective membership must equal initial_member_count plus amendments"
+                )
         sets[set_id] = named_set
     return sets
 
@@ -234,7 +304,7 @@ def compare_with_base(
     problems: Mapping[str, Mapping[str, object]],
     sets: Mapping[str, Mapping[str, object]],
 ) -> None:
-    """Enforce lifecycle monotonicity and membership of already-frozen sets."""
+    """Enforce lifecycle monotonicity and append-only frozen-set amendments."""
     problem_paths = _git(root, "ls-tree", "-r", "--name-only", base_ref, "--", "manifests/problems")
     for relative in sorted(path for path in problem_paths.splitlines() if path.endswith(".toml")):
         raw = tomllib.loads(_git(root, "show", f"{base_ref}:{relative}"))
@@ -271,6 +341,10 @@ def compare_with_base(
             raise CatalogError(f"{relative}: a frozen set may not be deleted")
         if current.get("frozen") is not True:
             raise CatalogError(f"{relative}: a frozen set may not be unfrozen")
+        if "initial_member_count" in old and (
+            current.get("initial_member_count") != old["initial_member_count"]
+        ):
+            raise CatalogError(f"{relative}: initial_member_count is immutable")
         old_members = {
             (member.get("problem_id"), member.get("statement_revision"))
             for member in old.get("members", [])
@@ -279,8 +353,27 @@ def compare_with_base(
             (member.get("problem_id"), member.get("statement_revision"))
             for member in current.get("members", [])
         }
-        if old_members != new_members:
-            raise CatalogError(f"{relative}: membership of a frozen set may not change")
+        removed_members = old_members - new_members
+        if removed_members:
+            raise CatalogError(
+                f"{relative}: members of a frozen set may not be removed or replaced"
+            )
+
+        old_amendments = old.get("amendments", [])
+        new_amendments = current.get("amendments", [])
+        if new_amendments[:len(old_amendments)] != old_amendments:
+            raise CatalogError(f"{relative}: frozen-set amendments are append-only")
+        appended_amendments = new_amendments[len(old_amendments):]
+        declared_additions = {
+            (member.get("problem_id"), member.get("statement_revision"))
+            for amendment in appended_amendments
+            for member in amendment.get("additions", [])
+        }
+        added_members = new_members - old_members
+        if declared_additions != added_members:
+            raise CatalogError(
+                f"{relative}: every frozen-set addition requires one new amendment record"
+            )
 
 
 def validate(root: pathlib.Path, base_ref: str | None = None) -> tuple[int, int, int]:
@@ -295,7 +388,7 @@ def validate(root: pathlib.Path, base_ref: str | None = None) -> tuple[int, int,
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=pathlib.Path, default=pathlib.Path("."))
-    parser.add_argument("--base-ref", help="Git ref used to enforce immutable frozen sets")
+    parser.add_argument("--base-ref", help="Git ref used to enforce append-only frozen sets")
     args = parser.parse_args()
     try:
         problem_count, tag_count, set_count = validate(args.root.resolve(), args.base_ref)

--- a/tests/python/test_validate_catalog.py
+++ b/tests/python/test_validate_catalog.py
@@ -39,6 +39,12 @@ holes = ["alpha"]
 submitter = "tester"
 """
 
+BETA_PROBLEM = PROBLEM.replace('id = "alpha"', 'id = "beta"').replace(
+    'title = "Alpha"', 'title = "Beta"'
+).replace('module = "LeanEval.Alpha"', 'module = "LeanEval.Beta"').replace(
+    'holes = ["alpha"]', 'holes = ["beta"]'
+)
+
 
 class ValidateCatalogTest(unittest.TestCase):
     def make_catalog(self, problem: str = PROBLEM, named_set: str | None = None):
@@ -116,7 +122,122 @@ members = [{ problem_id = "alpha", statement_revision = 1 }]
                 'members = [{ problem_id = "alpha", statement_revision = 1 }]',
                 "members = []",
             ), encoding="utf-8")
-            with self.assertRaisesRegex(VALIDATOR.CatalogError, "membership of a frozen set"):
+            with self.assertRaisesRegex(VALIDATOR.CatalogError, "may not be removed or replaced"):
+                VALIDATOR.validate(root, "HEAD")
+
+    def test_frozen_set_accepts_an_explicit_append_only_amendment(self):
+        named_set = """\
+schema_version = 1
+id = "v1"
+title = "LeanEval v1"
+frozen = true
+published_at = "2026-08-20"
+members = [{ problem_id = "alpha", statement_revision = 1 }]
+"""
+        temporary, root = self.make_catalog(named_set=named_set)
+        with temporary:
+            (root / "manifests" / "problems" / "beta.toml").write_text(
+                BETA_PROBLEM, encoding="utf-8"
+            )
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=test", "-c", "user.email=test@example.com",
+                 "commit", "-qm", "base"],
+                cwd=root,
+                check=True,
+            )
+            (root / "manifests" / "sets" / "v1.toml").write_text("""\
+schema_version = 2
+id = "v1"
+title = "LeanEval v1"
+frozen = true
+published_at = "2026-08-20"
+initial_member_count = 1
+members = [
+  { problem_id = "alpha", statement_revision = 1 },
+  { problem_id = "beta", statement_revision = 1 },
+]
+
+[[amendments]]
+id = "2026-08-21-add-beta"
+effective_date = "2026-08-21"
+reason = "Explicit maintainer addition."
+authorization = "Maintainer decision in issue 1."
+additions = [{ problem_id = "beta", statement_revision = 1 }]
+""", encoding="utf-8")
+            self.assertEqual(VALIDATOR.validate(root, "HEAD"), (2, 1, 1))
+
+    def test_frozen_set_addition_without_an_amendment_is_rejected(self):
+        named_set = """\
+schema_version = 1
+id = "v1"
+title = "LeanEval v1"
+frozen = true
+published_at = "2026-08-20"
+members = [{ problem_id = "alpha", statement_revision = 1 }]
+"""
+        temporary, root = self.make_catalog(named_set=named_set)
+        with temporary:
+            (root / "manifests" / "problems" / "beta.toml").write_text(
+                BETA_PROBLEM, encoding="utf-8"
+            )
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=test", "-c", "user.email=test@example.com",
+                 "commit", "-qm", "base"],
+                cwd=root,
+                check=True,
+            )
+            path = root / "manifests" / "sets" / "v1.toml"
+            path.write_text(named_set.replace(
+                'members = [{ problem_id = "alpha", statement_revision = 1 }]',
+                'members = [{ problem_id = "alpha", statement_revision = 1 }, '
+                '{ problem_id = "beta", statement_revision = 1 }]',
+            ), encoding="utf-8")
+            with self.assertRaisesRegex(VALIDATOR.CatalogError, "requires one new amendment"):
+                VALIDATOR.validate(root, "HEAD")
+
+    def test_existing_frozen_set_amendment_cannot_be_rewritten(self):
+        named_set = """\
+schema_version = 2
+id = "v1"
+title = "LeanEval v1"
+frozen = true
+published_at = "2026-08-20"
+initial_member_count = 1
+members = [
+  { problem_id = "alpha", statement_revision = 1 },
+  { problem_id = "beta", statement_revision = 1 },
+]
+
+[[amendments]]
+id = "2026-08-21-add-beta"
+effective_date = "2026-08-21"
+reason = "Explicit maintainer addition."
+authorization = "Maintainer decision in issue 1."
+additions = [{ problem_id = "beta", statement_revision = 1 }]
+"""
+        temporary, root = self.make_catalog(named_set=named_set)
+        with temporary:
+            (root / "manifests" / "problems" / "beta.toml").write_text(
+                BETA_PROBLEM, encoding="utf-8"
+            )
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(
+                ["git", "-c", "user.name=test", "-c", "user.email=test@example.com",
+                 "commit", "-qm", "base"],
+                cwd=root,
+                check=True,
+            )
+            path = root / "manifests" / "sets" / "v1.toml"
+            path.write_text(named_set.replace(
+                'reason = "Explicit maintainer addition."',
+                'reason = "Rewritten rationale."',
+            ), encoding="utf-8")
+            with self.assertRaisesRegex(VALIDATOR.CatalogError, "amendments are append-only"):
                 VALIDATOR.validate(root, "HEAD")
 
     def test_status_history_must_end_at_current_status(self):


### PR DESCRIPTION
## Summary

- add ten explicitly requested, newly merged evaluation problems to the frozen v1 set
- preserve the original mechanical 118-member selection as immutable evidence
- introduce schema-v2 append-only amendments for exceptional additions to frozen named sets
- record exact PR and merge-commit provenance in a machine-readable audit

The effective v1 membership is now **128**: the original 118 plus:

- #191 `faltings`
- #479 `dimitrov`
- #513 `direct_summand`
- #515 `einsiedler_katok_lindenstrauss`
- #522 `klartag_packing`
- #523 `four_manifold_not_smooth`
- #526 `nikolov_segal`
- #527 `ore_conjecture`
- #538 `budney_gabai_knotted_three_spheres`
- #549 `newlander_nirenberg`

## Validation

- `python3 -Wd -m unittest discover -s tests/python -p 'test_*.py' -v` — 28 passed
- `python3 scripts/validate_catalog.py --base-ref origin/main` — 309 problems, one named set, valid
- exact assertion: 118 initial + 10 unique amended members = 128; set/audit additions match
- `git diff --check`

D7/results migration is intentionally untouched.
