### PR TITLE
feat(Geometry): add the Newlander-Nirenberg theorem

### DIFF
--- a/LeanEval/Geometry/NewlanderNirenberg.lean
+++ b/LeanEval/Geometry/NewlanderNirenberg.lean
@@ -1,0 +1,96 @@
+import Mathlib
+import EvalTools.Markers
+
+namespace LeanEval
+namespace Geometry
+namespace NewlanderNirenberg
+
+/-!
+# The Newlander–Nirenberg theorem
+
+An almost complex structure whose Nijenhuis tensor vanishes is integrable:
+near every point there are local coordinates in which the structure is the
+standard one on `ℂⁿ`.
+
+The content is local, so as with Darboux's theorem the statement lives on
+an open set `U ⊆ ℝ^{2n}`. An almost complex structure on `U` is a smooth field
+`J : U → End(ℝ^{2n})` with `J² = -1`; its Nijenhuis tensor is
+
+  `N(V, W) = [JV, JW] - J[JV, W] - J[V, JW] - [V, W]`,
+
+written with mathlib's `VectorField.lieBracket`. Because `N` is tensorial it
+is enough to test it on globally smooth vector fields. The conclusion produces
+a holomorphic coordinate chart: a local diffeomorphism `φ` onto an open subset
+of `ℂⁿ` whose differential is complex linear, `dφ ∘ J = i · dφ`. Transition
+maps between two such charts are then automatically biholomorphic, so the
+charts make `U` a complex manifold inducing `J`.
+
+mathlib has the Lie bracket of vector fields, `ContDiffOn`, `fderiv`,
+`EuclideanSpace` and `OpenPartialHomeomorph`, but no almost complex
+structures, no Nijenhuis tensor, and no Newlander–Nirenberg theorem. No
+formalization of the theorem was found in any other proof assistant.
+-/
+
+open Set
+open scoped ContDiff
+
+/-- The model space `ℝ^{2n}` carrying the almost complex structure. -/
+abbrev E (n : ℕ) := EuclideanSpace ℝ (Fin (2 * n))
+
+/-- The **Nijenhuis tensor** of a field of endomorphisms `J` on `ℝ^{2n}`,
+evaluated on two vector fields `V`, `W` at a point:
+
+  `N(V, W) = [JV, JW] - J[JV, W] - J[V, JW] - [V, W]`.
+
+For an almost complex structure the last term is `J²[V, W]`, so this is the
+usual torsion of `J`. When `U` is open and `IsAlmostComplexOn J U` holds, the
+expression is `C^∞(U)`-bilinear in `V` and `W` on `U`: the terms involving the
+derivatives of `V` and `W` cancel using `J² = -1`, so the value at a point of
+`U` depends only on `V x`, `W x` and the derivative of `J` there. -/
+noncomputable def nijenhuis {n : ℕ} (J : E n → E n →L[ℝ] E n)
+    (V W : E n → E n) (x : E n) : E n :=
+  VectorField.lieBracket ℝ (fun y ↦ J y (V y)) (fun y ↦ J y (W y)) x
+    - J x (VectorField.lieBracket ℝ (fun y ↦ J y (V y)) W x)
+    - J x (VectorField.lieBracket ℝ V (fun y ↦ J y (W y)) x)
+    - VectorField.lieBracket ℝ V W x
+
+/-- `J` is an **almost complex structure** on an open set `U ⊆ ℝ^{2n}` if it
+is a smooth field of endomorphisms on `U` squaring to `-1`. -/
+def IsAlmostComplexOn {n : ℕ} (J : E n → E n →L[ℝ] E n) (U : Set (E n)) : Prop :=
+  ContDiffOn ℝ ∞ J U ∧ ∀ x ∈ U, ∀ v : E n, J x (J x v) = -v
+
+/-- The Nijenhuis tensor of `J` vanishes on `U`. This is stated for all
+globally smooth vector fields, which is the textbook hypothesis. Whenever `U`
+is open and `IsAlmostComplexOn J U` holds it is equivalent to the pointwise
+condition: the tensor is bilinear over functions, and constant vector fields
+already realize every pair of tangent vectors. -/
+def NijenhuisVanishesOn {n : ℕ} (J : E n → E n →L[ℝ] E n) (U : Set (E n)) : Prop :=
+  ∀ V W : E n → E n, ContDiff ℝ ∞ V → ContDiff ℝ ∞ W →
+    ∀ x ∈ U, nijenhuis J V W x = 0
+
+/-- **The Newlander–Nirenberg theorem.** An almost complex structure with
+vanishing Nijenhuis tensor is integrable. Formally: for every `x` in an open
+set `U ⊆ ℝ^{2n}` carrying such a structure `J` there is a smooth local
+diffeomorphism `φ` (an `OpenPartialHomeomorph`, smooth in both directions)
+from a neighbourhood of `x` inside `U` onto an open subset of `ℂⁿ` whose
+differential is complex linear:
+
+  `dφ_y (J y v) = i · dφ_y v`.
+
+Such charts are holomorphic coordinates for `J`. -/
+@[eval_problem]
+theorem newlander_nirenberg {n : ℕ} {U : Set (E n)} (_hU : IsOpen U)
+    (J : E n → E n →L[ℝ] E n) (_hJ : IsAlmostComplexOn J U)
+    (_hN : NijenhuisVanishesOn J U) {x : E n} (_hx : x ∈ U) :
+    ∃ φ : OpenPartialHomeomorph (E n) (EuclideanSpace ℂ (Fin n)),
+      x ∈ φ.source ∧ φ.source ⊆ U ∧
+      ContDiffOn ℝ ∞ (φ : E n → EuclideanSpace ℂ (Fin n)) φ.source ∧
+      ContDiffOn ℝ ∞ (φ.symm : EuclideanSpace ℂ (Fin n) → E n) φ.target ∧
+      ∀ y ∈ φ.source, ∀ v : E n,
+        fderiv ℝ (φ : E n → EuclideanSpace ℂ (Fin n)) y (J y v)
+          = Complex.I • fderiv ℝ (φ : E n → EuclideanSpace ℂ (Fin n)) y v := by
+  sorry
+
+end NewlanderNirenberg
+end Geometry
+end LeanEval

--- a/manifests/problems/newlander_nirenberg.toml
+++ b/manifests/problems/newlander_nirenberg.toml
@@ -1,0 +1,13 @@
+id = "newlander_nirenberg"
+title = "Newlander–Nirenberg theorem"
+group = "formalization-evaluation"
+status = "draft"
+visible = true
+statement_revision = 1
+tags = []
+module = "LeanEval.Geometry.NewlanderNirenberg"
+holes = ["newlander_nirenberg"]
+submitter = "Kim Morrison"
+notes = "An almost complex structure with vanishing Nijenhuis tensor admits holomorphic coordinates. The content is local, so the statement lives on an open U ⊆ ℝ^{2n}, mirroring the local Darboux problem: J is a smooth field of endomorphisms with J² = -1, the Nijenhuis tensor N(V,W) = [JV,JW] - J[JV,W] - J[V,JW] - [V,W] is written with mathlib's VectorField.lieBracket, and the conclusion is an OpenPartialHomeomorph onto an open subset of ℂⁿ, smooth in both directions, whose differential is complex linear (dφ ∘ J = i · dφ). N is tensorial, so quantifying over globally smooth vector fields is equivalent to quantifying over pairs of tangent vectors. Mathlib has no almost complex structures, no Nijenhuis tensor, and no Newlander-Nirenberg theorem; no formalization of it was found in any other proof assistant."
+source = "A. Newlander and L. Nirenberg, `Complex analytic coordinates in almost complex manifolds`, Annals of Math, 65 (3) 1957, 391-404."
+informal_solution = "Complexify: vanishing of the Nijenhuis tensor says exactly that the -i eigenbundle T^{0,1} of J in TU ⊗ ℂ is closed under the Lie bracket. The theorem is therefore the Frobenius theorem for this involutive complex distribution, which is false for general complex distributions and needs genuine analysis in the non-real-analytic case. Newlander and Nirenberg's original argument reduces, after a linear change of coordinates making J standard to first order at the point, to solving a nonlinear perturbation of the ∂̄ equation ∂̄u = A(u, ∂u), and runs a Nash-Moser-type iteration on Hölder spaces. Later proofs replace the iteration with Hörmander's L² estimates for ∂̄ on small polydiscs (Kohn, Hörmander), or with Webster's elementary iteration using only the Cauchy kernel and interior Schauder estimates. In the real-analytic case the complex Frobenius theorem applies directly and no hard analysis is needed."


### PR DESCRIPTION
This PR adds the Newlander-Nirenberg theorem: an almost complex structure whose Nijenhuis tensor vanishes is integrable.

The content is local, so the statement lives on an open set `U ⊆ ℝ^{2n}`, following `LeanEval/Geometry/Darboux.lean`. An almost complex structure on `U` is a smooth field `J : U → End(ℝ^{2n})` with `J² = -1`; its Nijenhuis tensor `N(V, W) = [JV, JW] - J[JV, W] - J[V, JW] - [V, W]` is written with mathlib's `VectorField.lieBracket`, and vanishing is asserted for all globally smooth vector fields, which under the other hypotheses is equivalent to the pointwise condition since the tensor is bilinear over functions. The conclusion produces a holomorphic coordinate chart: an `OpenPartialHomeomorph` from a neighbourhood of the point inside `U` onto an open subset of `ℂⁿ`, smooth in both directions, whose differential is complex linear. Transition maps between two such charts are then automatically biholomorphic, so the charts make `U` a complex manifold inducing `J`.

Mathlib has the Lie bracket of vector fields, `ContDiffOn`, `fderiv`, `EuclideanSpace` and `OpenPartialHomeomorph`, but no almost complex structures, no Nijenhuis tensor, no Frobenius theorem, and no Newlander-Nirenberg theorem. No formalization of the theorem was found in any other proof assistant.

🤖 Prepared with Claude Code