### PR TITLE
refactor: qualify results schema terminology

### DIFF
--- a/docs/catalog-metadata.md
+++ b/docs/catalog-metadata.md
@@ -55,7 +55,7 @@ through lifecycle metadata rather than deleting members.
 
 ## v1 evidence
 
-The audit tool reads either schema-v1 or schema-v2 result files and emits stable
+The audit tool reads either schema version 1 or schema version 2 result files and emits stable
 JSON and Markdown solve-count reports:
 
 ```bash

--- a/scripts/v1_audit.py
+++ b/scripts/v1_audit.py
@@ -53,11 +53,11 @@ def _v1_records(data: Mapping[str, Any], path: pathlib.Path) -> Iterable[dict[st
             }
 
 
-def _v2_records(data: Mapping[str, Any], path: pathlib.Path) -> Iterable[dict[str, Any]]:
+def _schema_v2_records(data: Mapping[str, Any], path: pathlib.Path) -> Iterable[dict[str, Any]]:
     file_user = data.get("user")
     records = data.get("results")
     if not isinstance(records, list):
-        raise AuditError(f"{path}: v2 file requires results array")
+        raise AuditError(f"{path}: schema version 2 file requires results array")
     for index, record in enumerate(records):
         if not isinstance(record, dict):
             raise AuditError(f"{path}: results[{index}] must be an object")
@@ -87,7 +87,7 @@ def load_records(results_dir: pathlib.Path) -> tuple[list[dict[str, Any]], int]:
         if version == 1:
             loaded = _v1_records(data, path)
         elif version == 2:
-            loaded = _v2_records(data, path)
+            loaded = _schema_v2_records(data, path)
         else:
             raise AuditError(f"{path}: unsupported schema_version {version!r}")
         for record in loaded:

--- a/tests/python/test_v1_audit.py
+++ b/tests/python/test_v1_audit.py
@@ -17,7 +17,7 @@ SPEC.loader.exec_module(AUDIT)
 
 
 class V1AuditTest(unittest.TestCase):
-    def test_v1_and_v2_records_produce_deterministic_evidence(self):
+    def test_schema_v1_and_schema_v2_records_produce_deterministic_evidence(self):
         with tempfile.TemporaryDirectory() as directory:
             results = pathlib.Path(directory)
             (results / "v1.json").write_text(json.dumps({


### PR DESCRIPTION
Follow-up to #552. Removes the remaining unqualified `v2` wording from the v1 audit implementation and documentation: the format is now consistently called **schema version 2**, while bare v1/v2 remain reserved for problem sets.

Verification:
- `python3 -m unittest tests.python.test_v1_audit`
- `python3 -m py_compile scripts/v1_audit.py`
- `git diff --check`