### PR TITLE
Refresh lifecycle overhaul execution status

### DIFF
--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -1,22 +1,23 @@
 # CI secrets and access control for `leanprover/lean-eval`
 
 This document is the source of truth for every CI credential and branch-
-protection setting the repository depends on. It is written so that, on a
-fresh clone or a brand-new repo, you can reconstruct the entire CI auth
-posture from this file alone — no UI screenshots, no tribal knowledge.
+protection setting the repository depends on. It records the reconstructable
+CI authentication posture and explicitly identifies facts that GitHub's APIs
+cannot expose, rather than relying on screenshots or guesses.
 
 ## Audit checklist
 
 | Item | Type | Stored as | Used by |
 | --- | --- | --- | --- |
 | `lean-eval-regenerator` | GitHub App (owner: `kim-em`) | `LEAN_EVAL_REGENERATOR_CLIENT_ID`, `LEAN_EVAL_REGENERATOR_PRIVATE_KEY` | `regenerate-main.yml` |
-| `LEADERBOARD_WRITE_TOKEN` | Fine-grained PAT | `LEADERBOARD_WRITE_TOKEN` (in both `leanprover/lean-eval` and `leanprover/lean-eval-leaderboard`) | `notify-leaderboard.yml` (this repo); `bump-benchmark-snapshot.yml` (leaderboard) |
+| `LEADERBOARD_WRITE_TOKEN` | Fine-grained PAT | `LEADERBOARD_WRITE_TOKEN` (in all three caller repositories) | `notify-leaderboard.yml` (this repo); `bump-benchmark-snapshot.yml` (leaderboard); `submission.yml` (submissions) |
 | Ruleset `main protection` | Repository Ruleset | (config in this repo, applied via API) | branch protection on `main` |
 
 The submission pipeline's credentials (`lean-eval-bot`,
-`lean-eval-recorder`, and that repo's copy of `LEADERBOARD_WRITE_TOKEN`)
-moved with the pipeline to `leanprover/lean-eval-submissions`; they are
-documented in [that repo's `docs/ci-secrets.md`](https://github.com/leanprover/lean-eval-submissions/blob/main/docs/ci-secrets.md).
+`lean-eval-recorder`, `lean-eval-archiver`, and that repo's copy of
+`LEADERBOARD_WRITE_TOKEN`) moved with the pipeline to
+`leanprover/lean-eval-submissions`; they are documented in
+[that repo's `docs/ci-secrets.md`](https://github.com/leanprover/lean-eval-submissions/blob/main/docs/ci-secrets.md).
 
 To check the live state at any time:
 
@@ -50,6 +51,14 @@ branch protection.
   but stored as a secret to keep the workflow's app inputs together.
 - `LEAN_EVAL_REGENERATOR_PRIVATE_KEY` — the full PEM contents of a private
   key generated for the app.
+
+Kim Morrison is the temporary credential custodian; no alternate custodian is
+recorded. Rotate the key by generating one replacement while the current key
+remains valid, replacing only `LEAN_EVAL_REGENERATOR_PRIVATE_KEY`, verifying a
+protected-main regeneration, and then deleting the old key in the App
+settings. Immediate revocation is deletion of the App key followed by removal
+or replacement of the repository secret. Do not change the App ID, installation
+scope, permissions, or ruleset bypass as part of a routine key rotation.
 
 ### Where used
 
@@ -128,7 +137,8 @@ for `repository_dispatch` (per
 
 ### Repository secrets
 
-The same token value is stored once per repo that needs it:
+One shared credential is intended to be stored once per repo that needs it;
+GitHub's secret APIs cannot prove equality between the encrypted copies:
 
 - `LEADERBOARD_WRITE_TOKEN` in `leanprover/lean-eval` (used by
   `notify-leaderboard.yml`).
@@ -141,6 +151,14 @@ When rotating the PAT, update **all three** secrets together. Forgetting
 one causes silent half-failures: e.g., dispatch fires but the bump's
 push step rejects, or vice versa.
 
+The recorded temporary custodian of the three stored copies is Kim Morrison.
+GitHub's repository APIs do not reveal the PAT issuer or expiry, and those
+current facts are not otherwise recorded, so do not guess them. At the next
+approved rotation, record the issuing account and expiry, replace all three
+copies, verify one dispatch from each caller, and only then revoke the old token
+in its issuing account. If its issuer is unavailable before then, disable the
+three calling workflows rather than broadening another credential.
+
 ### Reconstruction from scratch
 
 1. Open <https://github.com/settings/personal-access-tokens/new>.
@@ -151,13 +169,15 @@ push step rejects, or vice versa.
 3. Repository access: **Only select repositories** →
    `leanprover/lean-eval-leaderboard`.
 4. Repository permissions: **Contents: Read and write**.
-5. Save the token, then write it to both repos:
+5. Save the token, then write it to all three callers:
    ```bash
    # lean-eval is the side that fires the dispatch and pushes records.
    gh secret set LEADERBOARD_WRITE_TOKEN -R leanprover/lean-eval --body <TOKEN>
    # The leaderboard side checks itself out with this token so its
    # snapshot-bump push back to its own main bypasses branch protection.
    gh secret set LEADERBOARD_WRITE_TOKEN -R leanprover/lean-eval-leaderboard --body <TOKEN>
+   # The submissions workflow dispatches a leaderboard redeploy after recording results.
+   gh secret set LEADERBOARD_WRITE_TOKEN -R leanprover/lean-eval-submissions --body <TOKEN>
    ```
 
 ## Branch protection on `main` (Repository Ruleset)

--- a/docs/overhaul-execution-runbook.md
+++ b/docs/overhaul-execution-runbook.md
@@ -93,18 +93,18 @@ Goal: make the repositories describe only the approved remaining program.
 - [x] Preserve source-bound agent sessions, authorization boundaries,
       idempotency, CAS conflict handling, and other generally useful security
       hardening.
-- [ ] Remove superseded run narratives, diagnostic artifacts, and tests whose
+- [x] Remove superseded run narratives, diagnostic artifacts, and tests whose
       only purpose is preserving those narratives.
 - [x] Retain canonical replay inventories, final plans, exact toolchain/source
       maps, unavailable-candidate data, current rollback contracts, and current
       infrastructure identifiers.
-- [ ] Retain an older canonical input set only while a live execution profile
+- [x] Retain an older canonical input set only while a live execution profile
       references it; delete the whole linked set after replacement.
-- [ ] Rewrite the submissions tracker, rollout runbook, and infrastructure
+- [x] Rewrite the submissions tracker, rollout runbook, and infrastructure
       inventory to current state and remaining gates, without a chronology.
-- [ ] Run repository tests, typechecks, linters with zero warnings, workflow
+- [x] Run repository tests, typechecks, linters with zero warnings, workflow
       validation, action-pin audit, and all relevant dry-runs.
-- [ ] Merge the cleanup in coherent repository-local PRs.
+- [x] Merge the cleanup in coherent repository-local PRs.
 
 Exit condition: no tracked instruction tells a future agent to implement FC,
 disproofs, experimental kernels, or the persistent qualification harness.
@@ -126,14 +126,14 @@ Current `main` baseline:
 
 | Repository | Commit | Protection state |
 | --- | --- | --- |
-| `lean-eval` | `de48559590eb8cff2125e8e933b3e13bb8a3ff98` | Required `verify` |
-| `lean-eval-submissions` | `2bdeb2be1d1cd504a567dd01a3b040ae6e341827` | Required `verify` |
-| `lean-eval-leaderboard` | `aef3269c7dd4a98781d7f2d9b23db3c196e14766` | Required `build` |
-| `lean-eval-state` | `b0a30e3a64aa5c05660040405b32135dea4b7f1d` | Required `validate`; append-only |
-| `lean-eval-state-staging` | `8d8ef8d1e30ac617d848c705907a941209aeb23c` | Required `validate`; append-only |
-| `lean-eval-releases` | `90dadc872d624b8e6d171caf439313d185fc3e7f` | Required `validate` |
-| `lean-eval-generator` | `77373a539b31f8f304c852f288d7d8469cceebff` | Required `check` |
-| `lean-eval-audit` | `ad356e7bc5a2d650d9902ac3f6d352a0164360bc` | Protection approval required |
+| `lean-eval` | `16945dfb367f77eaffaf167bbf70d57796e1bf08` | Required `verify` |
+| `lean-eval-submissions` | `4a1d14eb433d938f8f923d340f80cad87cb2a8eb` | Required `verify` |
+| `lean-eval-leaderboard` | `d67705cf4bbd34635251adcc4aa4bcff7ee622da` | Required `build` |
+| `lean-eval-state` | `15a96673efd44d3b198890c1e94581b33c2a1a87` | Required `validate`; append-only |
+| `lean-eval-state-staging` | `bb12184a9fbdf5cb4fd11420a16e874d07ae1938` | Required `validate`; append-only |
+| `lean-eval-releases` | `65b836c15d7ddb1c82c9454be0533d238de35520` | Required `validate` |
+| `lean-eval-generator` | `abea76e047face988e9ee2ff2be3829fdd32b73c` | Required `check` |
+| `lean-eval-audit` | `34e33e339eaac47a10c463abaedef47361c5abab` | Protection approval required |
 
 ### 5.2 Deployed services
 
@@ -167,51 +167,51 @@ These lanes can proceed in parallel after Phase 1.
 
 ### 6.1 No-DNS submission entry
 
-- [ ] Add `https://lean-lang.org/eval/submit/` to the leaderboard site.
-- [ ] Explain that authentication continues on the LeanEval Worker origin.
-- [ ] Link to the production `workers.dev` application.
-- [ ] Verify navigation, accessibility, mobile layout, and return path to the
+- [x] Add `https://lean-lang.org/eval/submit/` to the leaderboard site.
+- [x] Explain that authentication continues on the LeanEval Worker origin.
+- [x] Link to the production `workers.dev` application.
+- [x] Verify navigation, accessibility, mobile layout, and return path to the
       leaderboard.
-- [ ] Keep OAuth callback and session handling on the Worker origin.
+- [x] Keep OAuth callback and session handling on the Worker origin.
 
 ### 6.2 Release and archive repository preparation
 
 - [x] Reconfirm the exact staging release OIDC trust mismatch.
 - [x] Prepare the smallest reviewed infrastructure patch or operator command;
       do not apply it yet.
-- [ ] Reconfirm the production archive Wrap-only role requirement and prove the
+- [x] Reconfirm the production archive Wrap-only role requirement and prove the
       desired policy excludes unwrap.
 - [x] Verify the release controller reconstructs deterministically with
       publication disabled using credential-free fixtures.
-- [ ] Verify submitter-facing license, release delay, and opt-out language.
+- [x] Verify submitter-facing license, release delay, and opt-out language.
 
 ### 6.3 Lifecycle API launch surface
 
-- [ ] Confirm feature flags exist independently for the route families being
+- [x] Confirm feature flags exist independently for the route families being
       launched.
-- [ ] Keep model consolidation disabled or remove it.
-- [ ] Run all existing repository tests.
-- [ ] Prepare one success and one authorization/validation denial fixture for
+- [x] Keep model consolidation disabled or remove it.
+- [x] Run all existing repository tests.
+- [x] Prepare one success and one authorization/validation denial fixture for
       each launch route family:
-  - [ ] metadata backfill;
-  - [ ] repair/retraction request;
-  - [ ] maintainer decision;
-  - [ ] model alias/rename; and
-  - [ ] release opt-out.
-- [ ] Verify every launch gate can be returned to disabled and health reports
+  - [x] metadata backfill;
+  - [x] repair/retraction request;
+  - [x] maintainer decision;
+  - [x] model alias/rename; and
+  - [x] release opt-out.
+- [x] Verify every launch gate can be returned to disabled and health reports
       the effective state.
-- [ ] Do not build a persistent staging harness.
+- [x] Do not build a persistent staging harness.
 
 ### 6.4 Exact-version lifecycle rehearsal
 
-- [ ] Select the exact candidate commits across the repository family.
-- [ ] Use synthetic private source repositories owned for staging.
-- [ ] Prepare one browser and one source-bound headless submission.
-- [ ] Include one deliberate invalid or unauthorized case.
+- [x] Select the exact candidate commits across the repository family.
+- [x] Use synthetic private source repositories owned for staging.
+- [x] Prepare one browser and one source-bound headless submission.
+- [x] Include one deliberate invalid or unauthorized case.
 - [ ] Confirm archive-before-evaluation and schema-version-3 binding.
 - [ ] Confirm acceptance/rejection, immutable Result, append-only State, release
       scheduling, and redacted leaderboard projection.
-- [ ] Prepare the rollback/disable steps for the same exact version.
+- [x] Prepare the rollback/disable steps for the same exact version.
 
 Exit condition: repository changes and staging fixtures are ready; all external
 mutations remain unapplied until the next gate.
@@ -374,18 +374,18 @@ No experimental checker or promotion work may be added to close this phase.
 
 ### 13.1 Open problems
 
-- [ ] Add or verify the neutral open-problems tab.
-- [ ] Confirm the empty state is clear and visually intentional.
-- [ ] Confirm it has no FC branding, importer, synchronization, or disproof
+- [x] Add or verify the neutral open-problems tab.
+- [x] Confirm the empty state is clear and visually intentional.
+- [x] Confirm it has no FC branding, importer, synchronization, or disproof
       dependency.
 
 ### 13.2 Software verification and editorial state
 
-- [ ] Verify both reviewed software-verification drafts render correctly.
-- [ ] Verify provisional/draft policy text.
-- [ ] Complete the maintainer-selected human statement/citation review.
-- [ ] Confirm no agent-authored hints were introduced.
-- [ ] Leave verified-calculation runner infrastructure unimplemented.
+- [x] Verify both reviewed software-verification drafts render correctly.
+- [x] Verify provisional/draft policy text.
+- [x] Complete the maintainer-selected human statement/citation review.
+- [x] Confirm no agent-authored hints were introduced.
+- [x] Leave verified-calculation runner infrastructure unimplemented.
 
 ### 13.3 Retire issue intake
 
@@ -423,14 +423,14 @@ Update this table in place; do not append a history beneath it.
 
 | Phase | State | Current blocker |
 | --- | --- | --- |
-| 0. Rebaseline cleanup | In progress | Stale-instruction cleanup PRs and final validation |
+| 0. Rebaseline cleanup | Complete | — |
 | 1. Disabled baseline | In progress | Audit-repository protection and credential inventory |
-| 2. Repository launch preparation | In progress | Entry page, lifecycle gates, and bounded fixtures |
+| 2. Repository launch preparation | In progress | Approval A and the exact-version staging rehearsal |
 | Approval A. Staging credentials | Blocked on explicit approval | Exact staging trust mutation prepared but unapplied |
 | 3. Final staging acceptance | Not started | Approval A |
 | Approval B. Production launch | Blocked on explicit approval | Go/no-go packet incomplete |
 | 4. Launch | Not started | Approval B |
 | 5. Four-week overlap | Not started | Production launch |
-| 6. Historical completion | Not started | May begin after Phase 1; infrastructure steps approval-gated |
-| 7. Remaining product completion | Not started | Independent lanes; issue closure waits for overlap and final delta |
+| 6. Historical completion | In progress | Four exact staging image probes, private migration, replay execution, and final cutoff remain; infrastructure steps are approval-gated |
+| 7. Remaining product completion | In progress | Open-problems and editorial work complete; issue closure waits for overlap and final delta |
 | Final audit | Not started | All phases |


### PR DESCRIPTION
Refresh the mutable execution checklist to the exact current disabled baseline and remaining approval gates.

- records all eight current protected/main heads
- marks only completed cleanup, entry-page, lifecycle-preparation, open-problems, and editorial work
- leaves audit protection, unverifiable credential facts, staging acceptance, production launch, overlap, and historical completion open
- corrects the CI credential inventory without guessing encrypted-secret identity or expiry

The runbook remains a current-state checklist; this adds no run history or rollout narrative.

Validation: `git diff --check`; exact submissions deployment 4a1d14e and staging State bb12184 are green with all production capabilities disabled.