### PR TITLE
Clarify prelaunch submission paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,17 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Submit a benchmark solution
+  - name: Submission information
+    url: https://lean-lang.org/eval/submit/
+    about: Stable submission instructions and current intake status.
+  - name: Open a submission issue
     url: https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml
-    about: Benchmark submissions are filed in leanprover/lean-eval-submissions, not here.
+    about: Issue intake remains the functioning submission path while production server intake is disabled.
   - name: Discussion on Zulip
     url: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/with/594108910
     about: General questions and discussion about lean-eval happen in the #Model-comparisons-for-Lean > LeanEval topic on the Lean Zulip.
   - name: Benchmark source code and documentation
     url: https://github.com/leanprover/lean-eval
-    about: Read the README for submission requirements before opening a submission issue.
+    about: Read the README for benchmark authoring and submission requirements.
   - name: Leaderboard (results store)
     url: https://github.com/leanprover/lean-eval-leaderboard
     about: Machine-written results per GitHub user. The schema lives in that repo's README.

--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -13,8 +13,9 @@ body:
         is unprovable as stated, imports are missing, or the intended
         interpretation is ambiguous.
 
-        For submitting a solution, use the "Submit benchmark solution"
-        template instead.
+        For submitting a solution, see the stable instructions at
+        https://lean-lang.org/eval/submit/. While production server intake is
+        disabled, open a submission issue in leanprover/lean-eval-submissions.
 
   - type: input
     id: problem_id

--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -12,6 +12,11 @@ body:
 
         **https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml**
 
+        Issue intake remains the functioning path while production server intake
+        is disabled. The stable submission information page is:
+
+        **https://lean-lang.org/eval/submit/**
+
         Please open your submission there. Nothing filed here will be evaluated or
         recorded on the leaderboard.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -328,9 +328,9 @@ under the old policy because that path does not collect the new acknowledgement.
 
 - **Evaluation-group submissions must come from private sources.** This
   applies to the formalization evaluation and software verification groups.
-  (We can't stop simultaneous publication elsewhere, but we ask.) Open
-  conjecture submissions instead must be public from the start; see the open
-  conjectures section.
+  (We can't stop simultaneous publication elsewhere, but we ask.) The neutral
+  open-problems catalog launches empty; its eventual source-visibility and
+  submission policy are deferred to a later LeanEval catalog decision.
 - **Solutions are released automatically two months after acceptance**,
   published by us from the accepted snapshot in the audit archive. Publication
   contains the exact evaluated `Submission.lean` and `Submission/` files, plus
@@ -477,9 +477,10 @@ The client-side tables support sorting and filtering.
 **Features:**
 
 - **Tabs are groups.** Top-level navigation is the three groups
-  (formalization evaluation, software verification, open problems), each
-  stating its submission policy on the tab. The open-problems tab has an
-  intentional empty state until LeanEval-owned content is added later.
+  (formalization evaluation, software verification, open problems). The two
+  evaluation tabs state their submission policy. The open-problems tab has an
+  intentional empty state and says that its content and submission policy have
+  not yet been adopted.
 - **A scope selector within each tab, defaulting to the flagship set.** On the
   formalization evaluation tab: `v1 | draft | archive`, defaulting to v1.
   Named sets and current-status views may overlap. Standings and problem tables
@@ -501,7 +502,7 @@ The client-side tables support sorting and filtering.
   the solve. Each model's card shows unique, first, and total solve counts (a
   first solve is the earliest accepted solve of a problem, by acceptance-event
   order), leading with whichever the current sort uses. There is no combined
-  cross-group leaderboard: the groups have different submission policies, so
+  cross-group leaderboard: the group scopes and policies are distinct, so
   their standings are not comparable. The front page shows headline numbers
   per tab instead.
 - **Recent solutions feed**: a chronological page of new solves (problem,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Lean Eval
 
-**[View the leaderboard →](https://lean-lang.org/eval/)**
+**[View the leaderboard →](https://lean-lang.org/eval/)** ·
+**[Submission information →](https://lean-lang.org/eval/submit/)**
 
 This repository is a comparator-based Lean benchmark for formal mathematics.
 Benchmark authors write trusted problem statements once in shared Lean modules, and the
@@ -290,8 +291,14 @@ The scorer prefers `workspaces/<problem-id>/` when present and falls back to
 
 ## Submission Rules
 
-To **submit a solution** to the public leaderboard, open a submission issue on
-the submissions repository:
+The stable submission page is:
+
+> **[lean-lang.org/eval/submit/](https://lean-lang.org/eval/submit/)**
+
+Production server intake is not enabled yet. During this prelaunch period, the
+functioning way to **submit a solution** to the public leaderboard remains a
+[submission issue](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+in the submissions repository:
 
 > **[github.com/leanprover/lean-eval-submissions](https://github.com/leanprover/lean-eval-submissions)**
 


### PR DESCRIPTION
## Summary

- link the stable `https://lean-lang.org/eval/submit/` page from the README and GitHub issue contacts
- state clearly that issue intake remains the functioning submission path while production server intake is disabled
- replace stale open-conjecture/public-source wording in `PLAN.md` with the neutral open-problems policy deferred to a later catalog decision

This is documentation and issue-template copy only. It does not alter runtime flags, enable intake, remove compatibility aliases, or change lifecycle rollout behavior.

## Verification

- `python3 -m unittest discover -s tests/python -v` (38 passed)
- parsed every `.github/ISSUE_TEMPLATE/*.yml` file with PyYAML
- `git diff --check`
- verified both documented HTTPS routes return HTTP 200