### PR TITLE
docs: prepare production submission launch copy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Submission information
+  - name: Submit a benchmark solution
     url: https://lean-lang.org/eval/submit/
-    about: Stable submission instructions and current intake status.
-  - name: Open a submission issue
+    about: Primary path for authenticated production submissions.
+  - name: Submission issue fallback
     url: https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml
-    about: Issue intake remains the functioning submission path while production server intake is disabled.
+    about: Available during the 28-day launch overlap if the server path cannot be used.
   - name: Discussion on Zulip
     url: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/with/594108910
     about: General questions and discussion about lean-eval happen in the #Model-comparisons-for-Lean > LeanEval topic on the Lean Zulip.

--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -13,9 +13,10 @@ body:
         is unprovable as stated, imports are missing, or the intended
         interpretation is ambiguous.
 
-        For submitting a solution, see the stable instructions at
-        https://lean-lang.org/eval/submit/. While production server intake is
-        disabled, open a submission issue in leanprover/lean-eval-submissions.
+        To submit a solution, use the stable submission page at
+        https://lean-lang.org/eval/submit/. During the 28-day launch overlap,
+        issue intake remains available as a fallback at
+        https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml.
 
   - type: input
     id: problem_id

--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -1,31 +1,30 @@
-name: "Moved: submit at lean-eval-submissions"
-description: Benchmark submissions live in leanprover/lean-eval-submissions. This template only exists to catch stale links and redirect you there.
-title: "[wrong repo] please file at leanprover/lean-eval-submissions"
+name: "Moved: use the LeanEval submission page"
+description: Benchmark submissions do not belong in this repository. This template only exists to catch stale links and redirect you.
+title: "[wrong repo] please use the LeanEval submission page"
 body:
   - type: markdown
     attributes:
       value: |
         ## Benchmark submissions have moved
 
-        The hosted submission pipeline (issue intake, fetch, evaluate, leaderboard
-        recording) is no longer in this repository. It now lives in:
-
-        **https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml**
-
-        Issue intake remains the functioning path while production server intake
-        is disabled. The stable submission information page is:
+        Benchmark submissions do not belong in this repository. The primary
+        production submission path is:
 
         **https://lean-lang.org/eval/submit/**
 
-        Please open your submission there. Nothing filed here will be evaluated or
-        recorded on the leaderboard.
+        During the 28-day launch overlap, issue intake remains available as a
+        fallback:
 
-        You can close this draft and follow the link above; there is nothing more
-        to do in this repository.
+        **https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml**
+
+        Nothing filed here will be evaluated or recorded on the leaderboard.
+
+        You can close this draft and follow one of the links above; there is
+        nothing more to do in this repository.
   - type: checkboxes
     id: ack
     attributes:
       label: Acknowledgement
       options:
-        - label: I understand this repository no longer accepts submissions and I should file at leanprover/lean-eval-submissions instead.
+        - label: I understand this repository does not accept submissions and I should use the LeanEval submission page or the temporary issue-intake fallback instead.
           required: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lean Eval
 
 **[View the leaderboard →](https://lean-lang.org/eval/)** ·
-**[Submission information →](https://lean-lang.org/eval/submit/)**
+**[Submit a solution →](https://lean-lang.org/eval/submit/)**
 
 This repository is a comparator-based Lean benchmark for formal mathematics.
 Benchmark authors write trusted problem statements once in shared Lean modules, and the
@@ -291,16 +291,14 @@ The scorer prefers `workspaces/<problem-id>/` when present and falls back to
 
 ## Submission Rules
 
-The stable submission page is:
+To **submit a solution** through the production server, start at the stable
+submission page:
 
 > **[lean-lang.org/eval/submit/](https://lean-lang.org/eval/submit/)**
 
-Production server intake is not enabled yet. During this prelaunch period, the
-functioning way to **submit a solution** to the public leaderboard remains a
-[submission issue](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-in the submissions repository:
-
-> **[github.com/leanprover/lean-eval-submissions](https://github.com/leanprover/lean-eval-submissions)**
+During the 28-day launch overlap, [submission issue
+intake](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+remains available as a fallback.
 
 That repository owns the hosted submission pipeline and the stored results.
 This repository (`leanprover/lean-eval`) holds only the problem set and the


### PR DESCRIPTION
## Summary

- make the stable LeanEval submission page the primary submission path
- retain issue intake as the explicit fallback during the 28-day launch overlap
- remove disabled/prelaunch wording from the README and submission-related issue templates

## Launch gate

Draft only: do not merge until the production lifecycle canary has passed and public server intake is ready to be announced. Merging this PR changes public-facing submission guidance.

## Validation

- exact head `00b91e4f0943f0212d9184a951d3a08a1ab4244e` passed required CI run `33323032862`
- branch is rebased directly on protected `main` `7e977ab32fa56be5b7f29933b3b8b02f9823d4b1`; its diff is limited to launch copy in the README and issue templates
- `git diff --check`
- parsed all issue-template YAML and checked the basic GitHub issue-template shape
- verified the stable submission page and issue-intake fallback URLs are reachable
- checked the edited files for stale disabled/prelaunch wording