### PR TITLE
docs: refresh exact overhaul runtime status

### DIFF
--- a/docs/overhaul-execution-runbook.md
+++ b/docs/overhaul-execution-runbook.md
@@ -145,11 +145,11 @@ effective flags; Section 5.2 and the current operational ledgers record those.
 
 | Repository | Commit | Protection state |
 | --- | --- | --- |
-| `lean-eval` | `52f42ed9dbf3f30723d2f1cfbd00b5213139ffe3` | Required `verify` |
-| `lean-eval-submissions` | `87c4b40afb7dbfa3f12ce4def607027765b7d22e` | Required `verify` |
+| `lean-eval` | `c2bd4432c7d8d077d17518fcce19b1660f6cced7` | Required `verify` |
+| `lean-eval-submissions` | `0a85d3a055600c3f60149d34f611c9e10767641b` | Required `verify` |
 | `lean-eval-leaderboard` | `bf534c149e204a286a5cd9bbaff449449567834b` | Required `build` |
 | `lean-eval-state` | `2812517256274fe681ea112eb4fc9599b7789277` | Required `validate`; append-only |
-| `lean-eval-state-staging` | `c4d996d6aa581882ba223a965e4ec4e7c6104270` | Required `validate`; append-only |
+| `lean-eval-state-staging` | `0a41ceaf78b7c42d4b4de6e4498542d437ee02af` | Required `validate`; append-only |
 | `lean-eval-releases` | `1c09d096687b7dd410b775c7022c9b3496245319` | Required `validate` |
 | `lean-eval-generator` | `010b01634cccda2db538cf9b09e6f26ddc453743` | Required `check` |
 | `lean-eval-audit` | `eadf24b2b4a99c56ef59a43811eab9d54ae013ac` | Reviewed changes; non-rewritable linear history |
@@ -157,7 +157,7 @@ effective flags; Section 5.2 and the current operational ledgers record those.
 ### 5.2 Deployed services
 
 The staging submission unit, broker, and replay executor are deployed from the
-exact submissions candidate `87c4b40afb7dbfa3f12ce4def607027765b7d22e`.
+exact submissions candidate `0a85d3a055600c3f60149d34f611c9e10767641b`.
 Its protected deployment and promotion canary passed. The production gate was
 deliberately not crossed, and the resulting all-false production recovery was
 a verified no-op; the production unit remains deployed from
@@ -171,7 +171,7 @@ and the promotion canary are enabled. The deployed contract pins are production 
 `c6a4bb67b55609ae7215bdd3cac2378b2db42a0a` and staging State
 `8ae11456f0a439f91ec5822ec36adb93b76b0d96`. Protected production State
 `2812517256274fe681ea112eb4fc9599b7789277` and protected staging State
-`c4d996d6aa581882ba223a965e4ec4e7c6104270` are validated append-only
+`0a41ceaf78b7c42d4b4de6e4498542d437ee02af` are validated append-only
 descendants of their respective contract pins.
 
 - [x] Read staging and production intake health.
@@ -243,7 +243,7 @@ These lanes can proceed in parallel after Phase 1.
 
 The operational-baseline table in section 5.1 records the current repository
 family. Protected submissions `main` and the exact currently deployed staging
-runtime are `87c4b40afb7dbfa3f12ce4def607027765b7d22e`; its immutable dispatch
+runtime are `0a85d3a055600c3f60149d34f611c9e10767641b`; its immutable dispatch
 tag, protected deployment, promotion canary, and zero-write staging preflight
 pass. The remaining lifecycle cases must stay bound to that exact candidate.
 Historical image preparation is an independent historical lane and is not a
@@ -481,9 +481,9 @@ against pinned audit commit
 `a8913f1c8b5073e5b7ab309ba10481b615ca4fc00e629e41a9e57962f3afebd4`, and
 exact count 439 without installing legacy or AWS authority.
 
-The exact private-image canary is running from submissions commit
-`87c4b40afb7dbfa3f12ce4def607027765b7d22e`; its bounded 63-image waves wait
-for that one-image result.
+The exact private-image canary passed from submissions commit
+`0a85d3a055600c3f60149d34f611c9e10767641b`; its bounded 63-image waves are
+running from the same immutable candidate.
 The inactive migration infrastructure remains pending the same reviewed
 operator CloudShell handoff as the production release-trust repair.
 
@@ -593,7 +593,7 @@ Update this table in place; do not append a history beneath it.
 | --- | --- | --- |
 | 0. Rebaseline cleanup | Complete | — |
 | 1. Disabled baseline | Complete | — |
-| 2. Repository launch preparation | In progress | Exact `87c4b40…` is deployed and its promotion canary and zero-write preflight pass; complete the two org App selections and bounded final lifecycle rehearsal |
+| 2. Repository launch preparation | In progress | Exact `0a85d3a…` is deployed and its promotion canary and zero-write preflight pass; complete the two org App selections and bounded final lifecycle rehearsal |
 | Credential boundary | Staging and production Wrap-only complete; release trust pending | Run the reviewed production release-trust and inactive migration-infrastructure CloudShell handoff, then the publication-disabled write-free preflight |
 | 3. Final staging acceptance | In progress | Select the staging fixture repository in both org Apps, then complete the bounded browser-led acceptance sequence, all-false recovery, and staging State validation |
 | Production launch readiness | Standing authorization recorded; packet incomplete | Complete production trust, final staging, and current launch readbacks; the prepared intake PR remains unmerged |


### PR DESCRIPTION
Updates the mutable overhaul runbook in place to the current protected repository heads, exact staging candidate, validated staging State head, and passed private-image canary. No scope or operating contract changes.