### PR TITLE
docs: make publication choice one-way

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -338,17 +338,23 @@ under the old policy because that path does not collect the new acknowledgement.
   challenge files, and unrelated files. Submitting includes an acknowledgement
   that the submitter has authority to license those files and grants a license
   (proposal: Apache 2.0) that takes effect at release.
-- **Submitters may opt out** at submission time or any time before release.
-  Opt-outs are recorded and displayed on the leaderboard entry ("solution
-  withheld"). The default is release; opting out is visible.
+- **Submitters choose scheduled release or private source at submission.**
+  Scheduled release is the default and is irreversible. A submitter who chose
+  private source may later authorize scheduled release; the reverse transition
+  is not supported. The current choice is recorded and displayed on the
+  leaderboard entry.
 - **Existing submissions are grandfathered.** Their declared tiers stand. The
-  backfill mechanism includes an invitation to opt in to release.
+  backfill mechanism includes an invitation to schedule release.
 
 The proposed two-month delay should outlast most evaluation runs while releasing
 proofs soon enough to remain useful. I'm open to argument about the duration.
-The append-only event order resolves an opt-out racing with release: an opt-out
-recorded before the release transition prevents publication. Release jobs are
-idempotent, record failures, and retry without changing the scheduled date.
+Before result recording, the recorded choice determines whether the result and
+release schedule are created together. After result recording, a
+private-to-scheduled transition atomically records the publication change and
+creates the missing release schedule. Its eligibility date remains exactly two
+UTC calendar months after acceptance, so a later authorization may make the
+release immediately due. Release jobs are idempotent, record failures, and
+retry without changing the scheduled date.
 
 **Audit-archive key management.** The archive is currently encrypted to a
 single key that only I hold, which is incompatible with automatic release.
@@ -514,7 +520,7 @@ The client-side tables support sorting and filtering.
   released solutions. These pages support fixed-problem comparisons of models
   and harnesses.
 - **Metadata display** with provenance: declared-at-submission vs backfilled,
-  self-reported throughout, opt-out status visible.
+  self-reported throughout, publication choice visible.
 - **Stable URLs**: existing problem URLs (`/eval/problems/<id>`) keep
   working. A problem's page is permanent and status-agnostic: it shows the
   problem's group, current status, status history, and all solutions, so
@@ -576,7 +582,7 @@ The active workstreams are:
 1. **Official-kernel and nanoda replay**: archive restore, exact-pin builds,
    terminal outcomes, statistics, and bounded queue mechanics.
 2. **Submission lifecycle**: server intake, append-only State, owner and
-   maintainer routes, release scheduling, opt-out, pause, and rollback.
+   maintainer routes, one-way release scheduling, pause, and rollback.
 3. **Archive and release**: per-submission envelopes, separated wrap/unwrap
    authority, deterministic reconstruction, and automatic publication.
 4. **Lifecycle-aware leaderboard**: group tabs, stable problem pages and

--- a/docs/overhaul-completion-plan.md
+++ b/docs/overhaul-completion-plan.md
@@ -92,7 +92,10 @@ The following remain part of the overhaul.
 - Append-only State transitions and immutable base Results records.
 - Metadata backfill, result repair and retraction requests, maintainer
   decisions, model aliases, and model renaming.
-- Visible release opt-out and the automatic two-calendar-month release policy.
+- A visible initial choice between scheduled publication and private source,
+  one-way later private-to-scheduled opt-in, and the automatic
+  two-calendar-month release policy. Scheduled publication cannot later be
+  changed to private.
 - An operator-controlled emergency pause and deterministic recovery path.
 
 ### 3.3 Archive and release
@@ -103,7 +106,8 @@ The following remain part of the overhaul.
 - Automatic reconstruction and publication from the accepted immutable
   snapshot, with source and credentials excluded from public logs and
   artifacts.
-- Existing grandfathering and opt-out policy for legacy submissions.
+- Existing grandfathering policy for legacy submissions, without inferring a
+  new publication choice for them.
 
 ### 3.4 Historical replay and statistics
 
@@ -203,7 +207,7 @@ Launch with most of the implemented lifecycle surface available.
 | Repair and retraction requests | Enable | One valid owner request and one invalid or non-owner denial |
 | Maintainer decisions | Enable | One configured-maintainer success and one non-maintainer denial |
 | Model alias and rename | Enable | One owner success and one collision or non-owner denial |
-| Release opt-out | Enable | One pre-release opt-out with scheduling consequence checked |
+| Publication opt-in | Enable | One post-result private-to-scheduled transition with its atomic release schedule checked |
 | Model consolidation | Keep disabled or remove | Not a launch test |
 
 This is intentionally a bounded smoke, not a qualification campaign. Existing
@@ -459,7 +463,8 @@ The lifecycle overhaul is finished when all of the following are true:
 - production server intake is the supported intake path;
 - new submissions archive before evaluation with per-submission envelopes;
 - accepted and rejected lifecycle transitions are coherent and recoverable;
-- automatic two-calendar-month releases are operating with opt-out support;
+- automatic two-calendar-month releases are operating with initial
+  scheduled/private choice and one-way private-to-scheduled opt-in;
 - the launch-approved backfill, repair/retraction, maintainer, alias, and rename
   functions are available;
 - the leaderboard correctly exposes lifecycle, statements, standings,

--- a/docs/overhaul-execution-runbook.md
+++ b/docs/overhaul-execution-runbook.md
@@ -223,7 +223,8 @@ These lanes can proceed in parallel after Phase 1.
       desired policy excludes unwrap.
 - [x] Verify the release controller reconstructs deterministically with
       publication disabled using credential-free fixtures.
-- [x] Verify submitter-facing license, release delay, and opt-out language.
+- [ ] Verify submitter-facing license, release delay, initial private choice,
+      and irreversible later opt-in language.
 
 ### 6.3 Lifecycle API launch surface
 
@@ -237,7 +238,7 @@ These lanes can proceed in parallel after Phase 1.
   - [x] repair/retraction request;
   - [x] maintainer decision;
   - [x] model alias/rename; and
-  - [x] release opt-out success.
+  - [ ] publication opt-in success, including post-result atomic scheduling.
 - [x] Verify every launch gate can be returned to disabled and health reports
       the effective state.
 - [x] Do not build a persistent staging harness.
@@ -396,7 +397,7 @@ section 11. The packet must still show these launch components separately:
 - [ ] enable automatic release controller;
 - [ ] enable the approved public lifecycle APIs;
 - [ ] enable production intake and create one named production canary, with
-      permanent archive, Result, State, release-schedule, and opt-out records;
+      permanent archive, Result, State, and release-schedule records;
       and
 - [ ] publish the overlap announcement.
 
@@ -422,7 +423,8 @@ After the launch packet is complete:
 ### 10.2 Lifecycle APIs
 
 - [ ] Enable only backfill, repair/retraction, maintainer decisions,
-      alias/rename, and release opt-out.
+      alias/rename, and one-way publication opt-in. The reverse publication
+      transition must remain unavailable.
 - [ ] Keep model consolidation disabled.
 - [ ] Verify effective public health and one non-mutating authorization denial.
 
@@ -437,10 +439,10 @@ After the launch packet is complete:
       leaderboard presentation, and release scheduling.
 - [ ] Use the packet-bound visible archived problem and exact previously
       accepted Kim-owned source with a distinct canary model identity.
-- [ ] Verify the initially scheduled Result on the live problem page, exercise
-      the visible pre-release opt-out, force an immediate leaderboard build,
-      and verify the withheld choice and exact source-State commit on the live
-      page.
+- [ ] Submit the canary as private, verify that choice on the live problem page,
+      exercise the visible irreversible publication opt-in, force an immediate
+      leaderboard build, and verify the scheduled choice, release schedule,
+      and exact source-State commit on the live page.
 - [x] Keep the periodic read-only leaderboard State-drift deployment path
       active so later State-only lifecycle events cannot leave the public site
       stale indefinitely.


### PR DESCRIPTION
## Summary

- retain the initial choice between scheduled publication and private source
- make scheduled publication irreversible while allowing later private-to-scheduled authorization
- require post-result authorization to create the missing release schedule atomically
- replace the obsolete launch canary and completion criteria that required later withdrawal

## Checks

- `python scripts/action_pin_audit.py`
- `python -m py_compile scripts/*.py scripts/security_probes/*.py`
- `python -m unittest tests.python.test_select_ci_problems`
- `git diff --check`