### PR TITLE
Refresh submission entry copy for server launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Submission information
+  - name: Submit a benchmark solution
     url: https://lean-lang.org/eval/submit/
-    about: Stable submission instructions and current intake status.
-  - name: Open a submission issue
+    about: Primary authenticated submission path from OVERLAP_START_UTC.
+  - name: Submission issue fallback
     url: https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml
-    about: Issue intake remains the functioning submission path while production server intake is disabled.
+    about: Available through at least EARLIEST_ISSUE_CLOSE_UTC and possibly longer.
   - name: Discussion on Zulip
     url: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/with/594108910
     about: General questions and discussion about lean-eval happen in the #Model-comparisons-for-Lean > LeanEval topic on the Lean Zulip.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,10 +2,10 @@ blank_issues_enabled: true
 contact_links:
   - name: Submit a benchmark solution
     url: https://lean-lang.org/eval/submit/
-    about: Primary authenticated submission path from OVERLAP_START_UTC.
+    about: Primary authenticated submission path from 2026-09-02T06:57:10Z.
   - name: Submission issue fallback
     url: https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml
-    about: Available through at least EARLIEST_ISSUE_CLOSE_UTC and possibly longer.
+    about: Available through at least 2026-09-30T06:57:10Z and possibly longer.
   - name: Discussion on Zulip
     url: https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/with/594108910
     about: General questions and discussion about lean-eval happen in the #Model-comparisons-for-Lean > LeanEval topic on the Lean Zulip.

--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -15,8 +15,8 @@ body:
 
         For submission instructions, use the primary authenticated path at
         https://lean-lang.org/eval/submit/. The launch overlap starts at
-        OVERLAP_START_UTC. Issue intake remains available as a fallback through
-        at least EARLIEST_ISSUE_CLOSE_UTC, no earlier than four weeks after the
+        2026-09-02T06:57:10Z. Issue intake remains available as a fallback through
+        at least 2026-09-30T06:57:10Z, no earlier than four weeks after the
         overlap begins, and may stay open longer. Any closure will be announced
         at least two weeks in advance.
 

--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -13,9 +13,19 @@ body:
         is unprovable as stated, imports are missing, or the intended
         interpretation is ambiguous.
 
-        For submitting a solution, see the stable instructions at
-        https://lean-lang.org/eval/submit/. While production server intake is
-        disabled, open a submission issue in leanprover/lean-eval-submissions.
+        For submission instructions, use the primary authenticated path at
+        https://lean-lang.org/eval/submit/. The launch overlap starts at
+        OVERLAP_START_UTC. Issue intake remains available as a fallback through
+        at least EARLIEST_ISSUE_CLOSE_UTC, no earlier than four weeks after the
+        overlap begins, and may stay open longer. Any closure will be announced
+        at least two weeks in advance.
+
+        Scheduled release is recommended for authenticated intake, while you
+        may keep accepted source private instead. Once selected, scheduled
+        release cannot be changed back to private and publishes accepted source
+        under the Apache License 2.0 exactly two UTC calendar months after
+        acceptance. A private choice may later be changed once to scheduled
+        release.
 
   - type: input
     id: problem_id

--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -1,31 +1,39 @@
-name: "Moved: submit at lean-eval-submissions"
-description: Benchmark submissions live in leanprover/lean-eval-submissions. This template only exists to catch stale links and redirect you there.
-title: "[wrong repo] please file at leanprover/lean-eval-submissions"
+name: "Moved: use the LeanEval submission page"
+description: Benchmark submissions do not belong in this repository. This template only exists to catch stale links and redirect you.
+title: "[wrong repo] please use the LeanEval submission page"
 body:
   - type: markdown
     attributes:
       value: |
         ## Benchmark submissions have moved
 
-        The hosted submission pipeline (issue intake, fetch, evaluate, leaderboard
-        recording) is no longer in this repository. It now lives in:
-
-        **https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml**
-
-        Issue intake remains the functioning path while production server intake
-        is disabled. The stable submission information page is:
+        Benchmark submissions do not belong in this repository. For current
+        submission instructions, use the stable page:
 
         **https://lean-lang.org/eval/submit/**
 
-        Please open your submission there. Nothing filed here will be evaluated or
-        recorded on the leaderboard.
+        That page is the primary authenticated submission path from
+        OVERLAP_START_UTC. Issue intake remains available as a fallback through
+        at least EARLIEST_ISSUE_CLOSE_UTC, no earlier than four weeks after the
+        overlap begins, and may stay open longer:
 
-        You can close this draft and follow the link above; there is nothing more
-        to do in this repository.
+        **https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml**
+
+        Scheduled release is recommended for authenticated intake, while you
+        may keep accepted source private instead. Once selected, scheduled
+        release cannot be changed back to private and publishes accepted source
+        under the Apache License 2.0 exactly two UTC calendar months after
+        acceptance. A private choice may later be changed once to scheduled
+        release.
+
+        Nothing filed here will be evaluated or recorded on the leaderboard.
+
+        You can close this draft and follow one of the links above; there is
+        nothing more to do in this repository.
   - type: checkboxes
     id: ack
     attributes:
       label: Acknowledgement
       options:
-        - label: I understand this repository no longer accepts submissions and I should file at leanprover/lean-eval-submissions instead.
+        - label: I understand this repository does not accept submissions and I should follow the stable LeanEval submission page or its documented issue-intake fallback instead.
           required: true

--- a/.github/ISSUE_TEMPLATE/submit.yml
+++ b/.github/ISSUE_TEMPLATE/submit.yml
@@ -13,8 +13,8 @@ body:
         **https://lean-lang.org/eval/submit/**
 
         That page is the primary authenticated submission path from
-        OVERLAP_START_UTC. Issue intake remains available as a fallback through
-        at least EARLIEST_ISSUE_CLOSE_UTC, no earlier than four weeks after the
+        2026-09-02T06:57:10Z. Issue intake remains available as a fallback through
+        at least 2026-09-30T06:57:10Z, no earlier than four weeks after the
         overlap begins, and may stay open longer:
 
         **https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml**

--- a/README.md
+++ b/README.md
@@ -296,14 +296,14 @@ For current instructions to **submit a solution**, start at the stable page:
 > **[lean-lang.org/eval/submit/](https://lean-lang.org/eval/submit/)**
 
 That page is the primary authenticated submission path from
-`OVERLAP_START_UTC`. The application itself is at
+`2026-09-02T06:57:10Z`. The application itself is at
 `https://lean-eval-submission-server.lean-eval.workers.dev/`; this change of
 origin is expected.
 
 [Submission issue
 intake](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
 remains available as a fallback through at least
-`EARLIEST_ISSUE_CLOSE_UTC`, no earlier than four weeks after the overlap begins,
+`2026-09-30T06:57:10Z`, no earlier than four weeks after the overlap begins,
 and may stay open longer if the launch is not yet stable. Any closure will be
 announced at least two weeks in advance.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lean Eval
 
 **[View the leaderboard →](https://lean-lang.org/eval/)** ·
-**[Submission information →](https://lean-lang.org/eval/submit/)**
+**[Submit a solution →](https://lean-lang.org/eval/submit/)**
 
 This repository is a comparator-based Lean benchmark for formal mathematics.
 Benchmark authors write trusted problem statements once in shared Lean modules, and the
@@ -291,18 +291,29 @@ The scorer prefers `workspaces/<problem-id>/` when present and falls back to
 
 ## Submission Rules
 
-The stable submission page is:
+For current instructions to **submit a solution**, start at the stable page:
 
 > **[lean-lang.org/eval/submit/](https://lean-lang.org/eval/submit/)**
 
-Production server intake is not enabled yet. During this prelaunch period, the
-functioning way to **submit a solution** to the public leaderboard remains a
-[submission issue](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-in the submissions repository:
+That page is the primary authenticated submission path from
+`OVERLAP_START_UTC`. The application itself is at
+`https://lean-eval-submission-server.lean-eval.workers.dev/`; this change of
+origin is expected.
 
-> **[github.com/leanprover/lean-eval-submissions](https://github.com/leanprover/lean-eval-submissions)**
+[Submission issue
+intake](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+remains available as a fallback through at least
+`EARLIEST_ISSUE_CLOSE_UTC`, no earlier than four weeks after the overlap begins,
+and may stay open longer if the launch is not yet stable. Any closure will be
+announced at least two weeks in advance.
 
-That repository owns the hosted submission pipeline and the stored results.
+Scheduled release is recommended for authenticated intake, while submitters
+may keep accepted source private instead. Once selected, scheduled release
+cannot be changed back to private. Accepted source is published under the
+Apache License 2.0 exactly two UTC calendar months after acceptance. A
+submitter who initially chooses private source may later change that choice
+once to scheduled release.
+
 This repository (`leanprover/lean-eval`) holds only the problem set and the
 comparator/sandbox integration.
 


### PR DESCRIPTION
## Summary

- point submission entry copy at the no-DNS server path
- state that server intake is primary while issue intake remains available during the four-week overlap
- retain issue templates for the overlap without changing problem, catalog, or open-problems content

This PR is launch-coupled: merge only when production server intake is genuinely public and the overlap begins. Exact overlap dates and closure notice remain a separate announcement requirement.

## Verification

- 33 Python tests
- issue-template YAML and structural checks
- action-pin audit
- referenced links return HTTP 200
- independent exact-commit review: GO on `4ac6205ea122278db1101d4f5cd91cb4d28a954d`
