### PR TITLE
docs: bind retirement notice to public merge time

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ remains available as a fallback through at least `2026-09-30T06:57:10Z`, four
 weeks after the overlap began. Conditional on stable operation, adequate
 adoption, no unresolved severity-high incident, and a reconciled final corpus,
 that is the planned retirement time. This notice was issued at
-`2026-09-02T23:03:18Z`, more than two weeks in advance. Retirement will be
+`2026-09-02T23:06:35Z`, more than two weeks in advance. Retirement will be
 postponed if any gate is not satisfied.
 
 Scheduled release is recommended for authenticated intake, while submitters

--- a/docs/overhaul-execution-runbook.md
+++ b/docs/overhaul-execution-runbook.md
@@ -507,8 +507,8 @@ the system can be paused through the documented path.
 
 The overlap began `2026-09-02T06:57:10Z` and cannot end before
 `2026-09-30T06:57:10Z`. The conditional issue-intake retirement target of that
-same timestamp was announced at `2026-09-02T23:03:18Z`; its two-week notice
-gate matures at `2026-09-16T23:03:18Z`. Retirement remains conditional on every
+same timestamp was announced at `2026-09-02T23:06:35Z`; its two-week notice
+gate matures at `2026-09-16T23:06:35Z`. Retirement remains conditional on every
 operational, adoption, final-corpus, and readiness gate below and must be
 postponed if any is not satisfied. The canary's first automatic-release
 checkpoint is `2026-11-02T03:50:01.002Z`. Full overhaul completion remains
@@ -772,7 +772,7 @@ Update this table in place; do not append a history beneath it.
 | 3. Final staging acceptance | Complete | — |
 | Production launch readiness | Complete | — |
 | 4. Launch | Complete | — |
-| 5. Four-week overlap | In progress; calendar-bound | Keep issue intake open through at least `2026-09-30T06:57:10Z`; the exact conditional closure notice matures `2026-09-16T23:03:18Z`, and the canary automatic-release checkpoint is `2026-11-02T03:50:01.002Z` |
+| 5. Four-week overlap | In progress; calendar-bound | Keep issue intake open through at least `2026-09-30T06:57:10Z`; the exact conditional closure notice matures `2026-09-16T23:06:35Z`, and the canary automatic-release checkpoint is `2026-11-02T03:50:01.002Z` |
 | 6. Historical completion | In progress; not a launch gate | The retained profiles, static pre-mutation packet, and exact-main dry binding are complete; the bounded custodian install is the next gate before migration/replay and the final post-cutoff delta |
 | 7. Remaining product completion | In progress | Open problems and editorial work are complete; final live release/replay presentation and issue closure retain their calendar, stability, adoption, final-delta, and readiness gates |
 | Final audit | Preparatory cleanup complete; final audit pending | Repeat the audit after all phases and confirm only explained launch and retirement work remains |


### PR DESCRIPTION
Correct the notice timestamp to the exact time PR #609 became durable on protected `main`, and derive the two-week maturity timestamp from that same instant. No policy or runtime behavior changes.