### PR TITLE
docs: refresh sustained replay and retirement status

### DIFF
--- a/docs/overhaul-execution-runbook.md
+++ b/docs/overhaul-execution-runbook.md
@@ -175,12 +175,13 @@ bound at protected submissions `main`
 `6e0aeb2b5c71fb857f09feff6172c4ee7bdfae08`. At activation State checkpoint
 `4fae55f7699e80d5b50314cf678bcf6caa020ad8`, the retained queues contained
 161 public and 630 private queued entries. Both bounded sustained chains are
-active with independent controller variables and concurrency groups. The
-private non-replenishing proof is terminal accepted at protected State
+active with independent controller variables and concurrency groups. Repeated
+exact-packet public and private tasks are reaching terminal accepted State,
+performing their required source/credential/resource cleanup, and starting
+exactly one successor per lane. The private non-replenishing proof is terminal
+accepted at protected State
 `24bcb65c8849b95f569c8ee037503049c7fe568f`; its source-free artifact,
 credential scrub, sandbox destruction, and temporary-executor deletion pass.
-Current sustained private run `33826897577` passed its exact protected-main
-entry gate.
 
 Leaderboard commit `939d69c88292358adf60b124f29605215a1e422a` is protected and
 deployed. The live submit entry directs users to the production service,
@@ -687,13 +688,15 @@ The post-launch replay packet is protected at submissions
 `6e0aeb2b5c71fb857f09feff6172c4ee7bdfae08`. Activation State checkpoint
 `4fae55f7699e80d5b50314cf678bcf6caa020ad8` materialized 161 public and 630
 private queued entries. The first public sustained task is terminal accepted
-and exactly one successor continues that chain. Private non-replenishing proof
+and exactly one successor continues that chain. Repeated monitored public and
+private terminals preserve that invariant and complete the required cleanup.
+Private non-replenishing proof
 run `33823645564` is terminal accepted at State
 `24bcb65c8849b95f569c8ee037503049c7fe568f`, with its redacted artifact and
-resource/credential cleanup reviewed. Sustained private run `33826897577` is
-active on the same exact baseline. Both controller variables are installed; a
-future safe stop deletes the relevant lane variable first, before any other
-recovery action.
+resource/credential cleanup reviewed. Both sustained lanes remain active on the
+same exact baseline. Both controller variables are installed; a future safe
+stop deletes the relevant lane variable first, before any other recovery
+action.
 
 - [x] Install the production replay credential without exposing its value.
 - [x] Merge and deploy the bounded public/private two-lane controller in the
@@ -837,6 +840,6 @@ Update this table in place; do not append a history beneath it.
 | Production launch readiness | Complete | — |
 | 4. Launch | Complete: backend `6e0aeb2b5c71fb857f09feff6172c4ee7bdfae08` live with durable intake; leaderboard `939d69c88292358adf60b124f29605215a1e422a` protected, deployed, and read back | — |
 | 5. Four-week overlap | In progress; automatic publication, durable server intake, and server-primary entry live; calendar-bound; future cutoff variable installed | Keep issue intake open through at least `2026-09-30T06:57:10Z`; merge and verify the reviewed cutoff guard after the retained drain and before that timestamp; the conditional closure notice matures `2026-09-16T23:06:35Z`, and the canary automatic-release checkpoint is `2026-11-02T03:50:01.002Z` |
-| 6. Historical completion | Packet bound; both bounded sustained drains active from a 161-public/630-private activation checkpoint after terminal private proof; final-delta closure drafts open; not ready; calendar-bound | Complete both retained drains; then merge the audit companion and rebind the submissions final-delta implementation before the cutoff; process the separately bound delta only after issue-intake cutoff |
+| 6. Historical completion | Packet bound; both bounded sustained drains active from a 161-public/630-private activation checkpoint after terminal private proof; repeated exact-packet terminals and single successors pass; final-delta and issue-retirement drafts are open, including the matching leaderboard-copy retirement; not ready; calendar-bound | Complete both retained drains; then merge the audit companion and rebind the submissions final-delta implementation before the cutoff; process the separately bound delta only after issue-intake cutoff |
 | 7. Remaining product completion | In progress | Open problems and editorial work are complete; final live release/replay presentation and issue closure retain their calendar, stability, adoption, final-delta, and readiness gates |
 | Final audit | Preparatory cleanup complete; final audit pending | Repeat the audit after all phases and confirm only explained launch and retirement work remains |


### PR DESCRIPTION
## Summary
- replace the stale single-run replay description with the current sustained two-lane state
- record that repeated exact-packet public/private terminals, cleanup, and one-successor invariants pass
- record that final-delta and Issue-retirement drafts now include the matching leaderboard copy change

This updates current status in place and does not add a run history or change product scope.

## Validation
- git diff --check: clean
- public: three consecutive monitored terminal continuations verified; latest queue 157 queued / 16 accepted / 1 safely failed, with one successor
- private: three sustained terminal runs verified accepted with complete source/credential/artifact/executor cleanup; latest queue 626 with one successor
- protected submissions main and both controllers remain exact d26a3090a338358915cc94651ec7efddde71d241
